### PR TITLE
Reuse coerce in engines.utils 

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -31,6 +31,14 @@ class DataType(ABC):
         """Coerce data container to the data type."""
         raise NotImplementedError()
 
+    def try_coerce(self, data_container: Any):
+        """Coerce data container to the data type,
+        raises a `~pandera.errors.ParserError` if the coercion fails
+
+        :raises: :class:`~pandera.errors.ParserError`: if coercion fails
+        """
+        raise NotImplementedError()
+
     def __call__(self, data_container: Any):
         """Coerce data container to the data type."""
         return self.coerce(data_container)

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -43,15 +43,15 @@ class DataType(dtypes.DataType):
             self, "type", np.dtype(self.type)
         )  # pragma: no cover
 
-    def _coerce(self, data_container: PandasObject) -> PandasObject:
+    def coerce(self, data_container: PandasObject) -> PandasObject:
         """Pure coerce without catching exceptions."""
         return data_container.astype(self.type)
 
-    def coerce(
+    def try_coerce(
         self, data_container: Union[PandasObject, np.ndarray]
     ) -> Union[PandasObject, np.ndarray]:
         try:
-            return self._coerce(data_container)
+            return self.coerce(data_container)
         except Exception as exc:  # pylint:disable=broad-except
             raise errors.ParserError(
                 f"Could not coerce {type(data_container)} data_container "
@@ -338,7 +338,7 @@ class Bytes(DataType):
 class String(DataType, dtypes.String):
     type = np.dtype("str")
 
-    def _coerce(self, data_container: np.ndarray) -> np.ndarray:
+    def coerce(self, data_container: np.ndarray) -> np.ndarray:
         data_container = data_container.astype(object)
         try:
             notna = ~np.isnan(data_container)

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -71,13 +71,13 @@ class DataType(dtypes.DataType):
             self, "type", pd.api.types.pandas_dtype(self.type)
         )  # pragma: no cover
 
-    def _coerce(self, data_container: PandasObject) -> PandasObject:
+    def coerce(self, data_container: PandasObject) -> PandasObject:
         """Pure coerce without catching exceptions."""
         return data_container.astype(self.type)
 
-    def coerce(self, data_container: PandasObject) -> PandasObject:
+    def try_coerce(self, data_container: PandasObject) -> PandasObject:
         try:
-            return self._coerce(data_container)
+            return self.coerce(data_container)
         except Exception as exc:  # pylint:disable=broad-except
             raise errors.ParserError(
                 f"Could not coerce {type(data_container)} data_container "
@@ -443,7 +443,7 @@ else:
 class NpString(numpy_engine.String):
     """Specializes numpy_engine.String.coerce to handle pd.NA values."""
 
-    def _coerce(self, data_container: PandasObject) -> np.ndarray:
+    def coerce(self, data_container: PandasObject) -> np.ndarray:
         # Convert to object first to avoid
         # TypeError: object cannot be converted to an IntegerDtype
         data_container = data_container.astype(object)
@@ -515,7 +515,7 @@ class DateTime(DataType, dtypes.Timestamp):
 
         object.__setattr__(self, "type", type_)
 
-    def _coerce(self, data_container: PandasObject) -> PandasObject:
+    def coerce(self, data_container: PandasObject) -> PandasObject:
         def _to_datetime(col: pd.Series) -> pd.Series:
             col = pd.to_datetime(col, **self.to_datetime_kwargs)
             return col.astype(self.type)

--- a/pandera/engines/utils.py
+++ b/pandera/engines/utils.py
@@ -29,7 +29,7 @@ def numpy_pandas_coercible(series: pd.Series, type_: Any) -> pd.Series:
 
     def _coercible(series):
         try:
-            data_type._coerce(series)
+            data_type.coerce(series)
             return True
         except Exception:  # pylint:disable=broad-except
             return False

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -376,7 +376,7 @@ class Index(SeriesSchemaBase):
             check_obj.index = self.coerce_dtype(check_obj.index)
             # handles case where pandas native string type is not supported
             # by index.
-            obj_to_validate = self.dtype.coerce(
+            obj_to_validate = self.dtype.try_coerce(
                 pd.Series(check_obj.index, name=check_obj.index.name)
             )
         else:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -326,7 +326,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
             )
 
         try:
-            return self.dtype.coerce(obj)
+            return self.dtype.try_coerce(obj)
         except errors.ParserError as exc:
             raise errors.SchemaError(
                 self,
@@ -1689,7 +1689,7 @@ class SeriesSchemaBase:
             return obj
 
         try:
-            return self.dtype.coerce(obj)
+            return self.dtype.try_coerce(obj)
         except errors.ParserError as exc:
             msg = (
                 f"Error while coercing '{self.name}' to type "

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -379,16 +379,16 @@ def test_coerce_cast(dtypes, examples, data):
         ),
     ],
 )
-def test_coerce_error(examples, type_, failure_indices):
-    """Test that coerce errors are transformed to ParseError."""
+def test_try_coerce(examples, type_, failure_indices):
+    """Test that try_coerce raises a ParseError."""
     data_type = pandas_engine.Engine.dtype(type_)
     data = pd.Series(examples)
 
     with pytest.raises(pa.errors.ParserError):
-        data_type.coerce(data)
+        data_type.try_coerce(data)
 
     try:
-        data_type.coerce(data)
+        data_type.try_coerce(data)
     except pa.errors.ParserError as exc:
         assert exc.failure_cases["index"].to_list() == failure_indices
 

--- a/tests/core/test_pandas_engine.py
+++ b/tests/core/test_pandas_engine.py
@@ -39,6 +39,6 @@ def test_pandas_data_type_coerce(data_type):
         # don't test data types that require parameters e.g. Category
         return
     try:
-        data_type().coerce(pd.Series(["1", "2", "a"]))
+        data_type().try_coerce(pd.Series(["1", "2", "a"]))
     except ParserError as exc:
         assert exc.failure_cases.shape[0] > 0


### PR DESCRIPTION
As discussed in #642, this PR let `numpy_pandas_coercible` call the `coerce` method to replicate closely the error that was raised in the first place when coercing the whole series. 

It's achieved by introducing a `_coerce()`  proxy that does not attempt to catch errors, the public `coerce` takes care of catching any errors and transform them into ParserError. 

It fixes #639 and should prevent future related issues with other data types.