### PR TITLE
improve lazy validation performance for nullable cases

### DIFF
--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -182,5 +182,10 @@ class SchemaErrors(Exception):
                 )
                 check_failure_cases.append(failure_cases[column_order])
 
-        failure_cases = pd.concat(check_failure_cases).reset_index(drop=True)
+        failure_cases = (
+            pd.concat(check_failure_cases)
+            .reset_index(drop=True)
+            .sort_values("schema_context", ascending=False)
+            .drop_duplicates()
+        )
         return error_counts, failure_cases


### PR DESCRIPTION
fixes #652

This PR fixes an issue where setting `lazy=True` with a schema
where `nullable=False` and there are lot of null values causes
severe performance issues in the ~500,000 row dataframe case.

The fix is to drop duplicates when aggregating failure cases
and removing unnecessary data processing of lazily collected
failure cases.