### PR TITLE
support koalas

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -145,6 +145,13 @@ jobs:
           --non-interactive
           --session "tests-${{ matrix.python-version }}(extra='strategies', pandas='${{ matrix.pandas-version }}')"
 
+      - name: Unit Tests - Koalas
+        run: >
+          nox
+          -db virtualenv -r -v
+          --non-interactive
+          --session "tests-${{ matrix.python-version }}(extra='koalas', pandas='${{ matrix.pandas-version }}')"
+
       - name: Upload coverage to Codecov
         uses: "codecov/codecov-action@v1"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,10 +64,18 @@ except ImportError:
 else:
     SKIP_STRATEGY = False
 
+try:
+    import koalas
+except ImportError:
+    KOALAS_INSTALLED = True
+else:
+    KOALAS_INSTALLED = False
+
 SKIP = sys.version_info < (3, 6)
 PY36 = sys.version_info < (3, 7)
 SKIP_PANDAS_LT_V1 = version.parse(pd.__version__).release < (1, 0) or PY36
 SKIP_SCALING = True
+SKIP_SCHEMA_MODEL = SKIP_PANDAS_LT_V1 or KOALAS_INSTALLED
 """
 
 doctest_default_flags = (

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -194,13 +194,13 @@ You must give a **type**, not an **instance**.
 :red:`✘` Bad:
 
 .. testcode:: dataframe_schema_model
-    :skipif: SKIP_PANDAS_LT_V1
+    :skipif: SKIP_SCHEMA_MODEL
 
     class Schema(pa.SchemaModel):
         a: Series[pd.StringDtype()]
 
 .. testoutput:: dataframe_schema_model
-    :skipif: SKIP_PANDAS_LT_V1
+    :skipif: SKIP_SCHEMA_MODEL
 
     Traceback (most recent call last):
     ...

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,10 @@ dependencies:
   - frictionless
   - pyarrow
 
+  # koalas extra
+  - koalas
+  - pyspark
+
   # testing and dependencies
   - black >= 20.8b1
 
@@ -26,7 +30,7 @@ dependencies:
   - isort >= 5.7.0
   - codecov
   - mypy >= 0.902 # mypy no longer bundle stubs for third-party libraries
-  - pylint = v2.11.1
+  - pylint = 2.11.1
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/noxfile.py
+++ b/noxfile.py
@@ -184,7 +184,7 @@ def install_extras(
             specs.append(
                 spec if spec != "pandas" else f"pandas{pandas_version}"
             )
-    if extra == "core":
+    if extra in {"core", "koalas"}:
         specs.append(REQUIRES["all"]["hypothesis"])
 
     # this is a temporary measure to install setuptools due to this issue:

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,6 +1,7 @@
 """A flexible and expressive pandas validation library."""
 import platform
 
+from pandera import external_config
 from pandera.dtypes import (
     Bool,
     Category,
@@ -56,4 +57,5 @@ from .schemas import DataFrameSchema, SeriesSchema
 from .version import __version__
 
 if platform.system() != "Windows":
+    # pylint: disable=ungrouped-imports
     from pandera.dtypes import Complex256, Float128

--- a/pandera/check_utils.py
+++ b/pandera/check_utils.py
@@ -1,8 +1,87 @@
 """Utility functions for validation."""
 
-from typing import Optional, Tuple, Union
+from functools import lru_cache
+from typing import NamedTuple, Optional, Tuple, Union
 
 import pandas as pd
+
+SupportedTypes = NamedTuple(
+    "SupportedTypes",
+    (
+        ("table_types", Tuple[type]),
+        ("field_types", Tuple[type]),
+        ("index_types", Tuple[type]),
+        ("multiindex_types", Tuple[type]),
+    ),
+)
+
+
+@lru_cache(maxsize=None)
+def _supported_types():
+    # pylint: disable=import-outside-toplevel
+    table_types = [pd.DataFrame]
+    field_types = [pd.Series]
+    index_types = [pd.Index]
+    multiindex_types = [pd.MultiIndex]
+
+    try:
+        import databricks.koalas as ks
+
+        table_types.append(ks.DataFrame)
+        field_types.append(ks.Series)
+        index_types.append(ks.Index)
+        multiindex_types.append(ks.MultiIndex)
+    except ImportError:
+        pass
+    try:  # pragma: no cover
+        import modin.pandas as mpd
+
+        table_types.append(mpd.DataFrame)
+        field_types.append(mpd.Series)
+        index_types.append(mpd.Index)
+        multiindex_types.append(mpd.MultiIndex)
+    except ImportError:
+        pass
+
+    return SupportedTypes(
+        tuple(table_types),
+        tuple(field_types),
+        tuple(index_types),
+        tuple(multiindex_types),
+    )
+
+
+def is_table(obj):
+    """Verifies whether an object is table-like.
+
+    Where a table is a 2-dimensional data matrix of rows and columns, which
+    can be indexed in multiple different ways.
+    """
+    return isinstance(obj, _supported_types().table_types)
+
+
+def is_field(obj):
+    """Verifies whether an object is field-like.
+
+    Where a field is a columnar representation of data in a table-like
+    data structure.
+    """
+    return isinstance(obj, _supported_types().field_types)
+
+
+def is_index(obj):
+    """Verifies whether an object is a table index."""
+    return isinstance(obj, _supported_types().index_types)
+
+
+def is_multiindex(obj):
+    """Verifies whether an object is a multi-level table index."""
+    return isinstance(obj, _supported_types().multiindex_types)
+
+
+def is_supported_check_obj(obj):
+    """Verifies whether an object is table- or field-like."""
+    return is_table(obj) or is_field(obj)
 
 
 def prepare_series_check_output(
@@ -25,9 +104,20 @@ def prepare_series_check_output(
         check_output = check_output | isna
     failure_cases = check_obj[~check_output]
     if not failure_cases.empty and n_failure_cases is not None:
-        failure_cases = failure_cases.groupby(check_output).head(
-            n_failure_cases
-        )
+        # NOTE: this is a hack to support koalas, since you can't use groupby
+        # on a dataframe with another dataframe
+        if type(failure_cases).__module__.startswith("databricks.koalas"):
+            failure_cases = (
+                failure_cases.rename("failure_cases")
+                .to_frame()
+                .assign(check_output=check_output)
+                .groupby("check_output")
+                .head(n_failure_cases)["failure_cases"]
+            )
+        else:
+            failure_cases = failure_cases.groupby(check_output).head(
+                n_failure_cases
+            )
     return check_output, failure_cases
 
 

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -104,20 +104,22 @@ class SchemaErrors(Exception):
         for k, v in error_counts.items():
             msg += f"- {k}: {v}\n"
 
-        def failure_cases(x: pd.Series):
-            return list(set(x.drop_duplicates()))
-
         agg_schema_errors = (
             schema_errors.fillna({"column": "<NA>"})
             .groupby(["schema_context", "column", "check"])
-            .failure_case.agg([failure_cases])
+            .failure_case.unique()
+            .rename("failure_cases")
+            .to_frame()
             .assign(n_failure_cases=lambda df: df.failure_cases.map(len))
-            .sort_index(
-                level=["schema_context", "column"],
-                ascending=[False, True],
-            )
         )
-
+        index_labels = [
+            agg_schema_errors.index.names.index(name)
+            for name in ["schema_context", "column"]
+        ]
+        agg_schema_errors = agg_schema_errors.sort_index(
+            level=index_labels,
+            ascending=[False, True],
+        )
         msg += "\nSchema Error Summary"
         msg += "\n--------------------\n"
         with pd.option_context("display.max_colwidth", 100):
@@ -182,8 +184,23 @@ class SchemaErrors(Exception):
                 )
                 check_failure_cases.append(failure_cases[column_order])
 
+        # NOTE: this is a hack to support koalas
+        concat_fn = pd.concat
+        if any(
+            type(x).__module__.startswith("databricks.koalas")
+            for x in check_failure_cases
+        ):
+            # pylint: disable=import-outside-toplevel
+            import databricks.koalas as ks
+
+            concat_fn = ks.concat
+            check_failure_cases = [
+                x if isinstance(x, ks.DataFrame) else ks.DataFrame(x)
+                for x in check_failure_cases
+            ]
+
         failure_cases = (
-            pd.concat(check_failure_cases)
+            concat_fn(check_failure_cases)
             .reset_index(drop=True)
             .sort_values("schema_context", ascending=False)
             .drop_duplicates()

--- a/pandera/external_config.py
+++ b/pandera/external_config.py
@@ -1,0 +1,17 @@
+"""Configuration for external packages."""
+
+import os
+
+try:
+    # try importing koalas to see if it exists. This is important because the
+    # pandera.typing module defines a Series type that inherits from
+    # pandas.Series, and koalas v1+ injects a __getitem__ method to pandas
+    # Series and DataFrames to support type hinting:
+    # https://koalas.readthedocs.io/en/latest/user_guide/typehints.html#type-hinting-with-names
+    # pylint: disable=unused-import
+    import databricks.koalas as ks
+
+    if os.getenv("SPARK_LOCAL_IP") is None:
+        os.environ["SPARK_LOCAL_IP"] = "127.0.0.1"
+except ImportError:
+    pass

--- a/pandera/model.py
+++ b/pandera/model.py
@@ -336,7 +336,8 @@ class SchemaModel:
                 indices.append(index)
             else:
                 raise SchemaInitError(
-                    f"Invalid annotation '{field_name}: {annotation.raw_annotation}'"
+                    f"Invalid annotation '{field_name}: "
+                    f"{annotation.raw_annotation}'"
                 )
 
         return columns, _build_schema_index(indices, **multiindex_kwargs)

--- a/pandera/typing.py
+++ b/pandera/typing.py
@@ -8,6 +8,12 @@ import typing_inspect
 from . import dtypes
 from .engines import numpy_engine, pandas_engine
 
+try:
+    from typing import _GenericAlias  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    _GenericAlias = None
+
+
 Bool = dtypes.Bool  #: ``"bool"`` numpy dtype
 DateTime = dtypes.DateTime  #: ``"datetime64[ns]"`` numpy dtype
 Timedelta = dtypes.Timedelta  #: ``"timedelta64[ns]"`` numpy dtype
@@ -94,6 +100,15 @@ class Series(pd.Series, Generic[GenericDtype]):  # type: ignore
     *new in 0.5.0*
     """
 
+    if hasattr(pd.Series, "__class_getitem__") and _GenericAlias:
+
+        def __class_getitem__(cls, item):
+            """Define this to override the patch that koalas performs on pandas.
+
+            https://github.com/databricks/koalas/blob/master/databricks/koalas/__init__.py#L207-L223
+            """
+            return _GenericAlias(cls, item)
+
     def __get__(
         self, instance: object, owner: Type
     ) -> str:  # pragma: no cover
@@ -114,6 +129,15 @@ class DataFrame(pd.DataFrame, Generic[T]):
 
     *new in 0.5.0*
     """
+
+    if hasattr(pd.Series, "__class_getitem__") and _GenericAlias:
+
+        def __class_getitem__(cls, item):
+            """Define this to override the patch that koalas performs on pandas.
+
+            https://github.com/databricks/koalas/blob/master/databricks/koalas/__init__.py#L207-L223
+            """
+            return _GenericAlias(cls, item)
 
 
 class AnnotationInfo:  # pylint:disable=too-few-public-methods

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,11 +13,13 @@ typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
 frictionless
 pyarrow
+koalas
+pyspark
 black >= 20.8b1
 isort >= 5.7.0
 codecov
 mypy >= 0.902
-pylint == v2.11.1
+pylint == 2.11.1
 pytest
 pytest-cov
 pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ _extras_require = {
     "strategies": ["hypothesis >= 5.41.1"],
     "hypotheses": ["scipy"],
     "io": ["pyyaml >= 5.1", "black", "frictionless"],
+    "koalas": ["koalas", "pyspark"],
 }
 extras_require = {
     **_extras_require,

--- a/tests/core/test_deprecations.py
+++ b/tests/core/test_deprecations.py
@@ -18,7 +18,8 @@ from pandera.system import FLOAT_128_AVAILABLE
 def test_deprecate_pandas_dtype(schema_cls, as_pos_arg):
     """Test that pandas_dtype deprecation warnings/errors are raised."""
     assert schema_cls(dtype=int).dtype.check(pa.Int())
-    assert schema_cls(pandas_dtype=int).dtype.check(pa.Int())
+    with pytest.warns(DeprecationWarning):
+        assert schema_cls(pandas_dtype=int).dtype.check(pa.Int())
 
     with pytest.warns(DeprecationWarning):
         schema_cls(pandas_dtype=int)

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -357,7 +357,6 @@ def test_coerce_cast(dtypes, examples, data):
     series = pd.Series(examples, dtype=from_pd_dtype)
     coerced_dtype = expected_dtype.coerce(series).dtype
     assert expected_dtype.check(pandas_engine.Engine.dtype(coerced_dtype))
-
     df = pd.DataFrame({"col": examples}, dtype=from_pd_dtype)
     coerced_dtype = expected_dtype.coerce(df)["col"].dtype
     assert expected_dtype.check(pandas_engine.Engine.dtype(coerced_dtype))

--- a/tests/koalas/test_schemas.py
+++ b/tests/koalas/test_schemas.py
@@ -1,0 +1,554 @@
+"""Test pandera on koalas data structures."""
+
+import typing
+from unittest.mock import MagicMock
+
+import databricks.koalas as ks
+import pandas as pd
+import pytest
+
+import pandera as pa
+from pandera import dtypes, extensions, system
+from pandera.engines import numpy_engine, pandas_engine
+from tests.strategies.test_strategies import NULLABLE_DTYPES
+from tests.strategies.test_strategies import (
+    UNSUPPORTED_DTYPES as UNSUPPORTED_STRATEGY_DTYPES,
+)
+
+try:
+    import hypothesis
+    import hypothesis.strategies as st
+except ImportError:
+    HAS_HYPOTHESIS = False
+    hypothesis = MagicMock()
+    st = MagicMock()
+else:
+    HAS_HYPOTHESIS = True
+
+
+UNSUPPORTED_STRATEGY_DTYPES = set(UNSUPPORTED_STRATEGY_DTYPES)
+UNSUPPORTED_STRATEGY_DTYPES.add(numpy_engine.Object)
+
+
+KOALAS_UNSUPPORTED = {
+    numpy_engine.Complex128,
+    numpy_engine.Complex64,
+    numpy_engine.Float16,
+    numpy_engine.Object,
+    numpy_engine.Timedelta64,
+    numpy_engine.UInt64,
+    numpy_engine.UInt32,
+    numpy_engine.UInt16,
+    numpy_engine.UInt8,
+    pandas_engine.Category,
+    pandas_engine.Interval,
+    pandas_engine.Period,
+    pandas_engine.Sparse,
+    pandas_engine.UINT64,
+    pandas_engine.UINT32,
+    pandas_engine.UINT16,
+    pandas_engine.UINT8,
+}
+
+if system.FLOAT_128_AVAILABLE:
+    KOALAS_UNSUPPORTED.update({numpy_engine.Float128, numpy_engine.Complex256})
+
+try:
+    ks.Series(pd.to_datetime(["1900-01-01 00:03:59.999999999"]))
+    MIN_TIMESTAMP = None
+except OverflowError:
+    MIN_TIMESTAMP = pd.Timestamp("1900-01-01 00:04:00")
+
+
+@pytest.mark.parametrize("coerce", [True, False])
+def test_dataframe_schema_case(coerce):
+    """Test a simple schema case."""
+    schema = pa.DataFrameSchema(
+        {
+            "int_column": pa.Column(int, pa.Check.ge(0)),
+            "float_column": pa.Column(float, pa.Check.le(0)),
+            "str_column": pa.Column(str, pa.Check.isin(list("abcde"))),
+        },
+        coerce=coerce,
+    )
+    kdf = ks.DataFrame(
+        {
+            "int_column": range(10),
+            "float_column": [float(-x) for x in range(10)],
+            "str_column": list("aabbcceedd"),
+        }
+    )
+    assert isinstance(schema.validate(kdf), ks.DataFrame)
+
+
+def _test_datatype_with_schema(
+    dtype: pandas_engine.DataType,
+    schema: typing.Union[pa.DataFrameSchema, pa.SeriesSchema],
+    data: st.DataObject,
+):
+    """Test pandera datatypes against koalas data containers.
+
+    Handle case where koalas can't handle datetimes before 1900-01-01 00:04:00,
+    raising an overflow
+    """
+    data_container_cls = {
+        pa.DataFrameSchema: ks.DataFrame,
+        pa.SeriesSchema: ks.Series,
+        pa.Column: ks.DataFrame,
+    }[type(schema)]
+
+    # pandas automatically upcasts numeric datatypes when defining Indexes,
+    # so we want to skip this pytest.raises expectation for types that are
+    # technically unsupported by koalas
+    if dtype in KOALAS_UNSUPPORTED:
+        with pytest.raises(TypeError):
+            sample = data.draw(schema.strategy(size=3))
+            data_container_cls(sample)
+        return
+
+    sample = data.draw(schema.strategy(size=3))
+
+    if dtype is pandas_engine.DateTime or isinstance(
+        dtype, pandas_engine.DateTime
+    ):
+        if MIN_TIMESTAMP is not None and (sample < MIN_TIMESTAMP).any(
+            axis=None
+        ):
+            with pytest.raises(
+                OverflowError, match="mktime argument out of range"
+            ):
+                data_container_cls(sample)
+            return
+    else:
+        assert isinstance(data_container_cls(sample), data_container_cls)
+
+
+@pytest.mark.parametrize("dtype", pandas_engine.Engine.get_registered_dtypes())
+@pytest.mark.parametrize("coerce", [True, False])
+@hypothesis.given(st.data())
+def test_dataframe_schema_dtypes(
+    dtype: pandas_engine.DataType,
+    coerce: bool,
+    data: st.DataObject,
+):
+    """
+    Test that all supported koalas data types work as expected for dataframes.
+    """
+    if dtype in UNSUPPORTED_STRATEGY_DTYPES:
+        pytest.skip(
+            f"type {dtype} currently not supported by the strategies module"
+        )
+
+    schema = pa.DataFrameSchema({"column": pa.Column(dtype)})
+    schema.coerce = coerce
+    _test_datatype_with_schema(dtype, schema, data)
+
+
+@pytest.mark.parametrize("dtype", pandas_engine.Engine.get_registered_dtypes())
+@pytest.mark.parametrize("coerce", [True, False])
+@pytest.mark.parametrize("schema_cls", [pa.SeriesSchema, pa.Column])
+@hypothesis.given(st.data())
+def test_field_schema_dtypes(
+    dtype: pandas_engine.DataType,
+    coerce: bool,
+    schema_cls,
+    data: st.DataObject,
+):
+    """
+    Test that all supported koalas data types work as expected for series.
+    """
+    if dtype in UNSUPPORTED_STRATEGY_DTYPES:
+        pytest.skip(
+            f"type {dtype} currently not supported by the strategies module"
+        )
+    schema = schema_cls(dtype, name="field")
+    schema.coerce = coerce
+    _test_datatype_with_schema(dtype, schema, data)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        int,
+        float,
+        bool,
+        str,
+        pandas_engine.DateTime,
+    ],
+)
+@pytest.mark.parametrize("coerce", [True, False])
+@pytest.mark.parametrize("schema_cls", [pa.Index, pa.MultiIndex])
+@hypothesis.given(st.data())
+def test_index_dtypes(
+    dtype: pandas_engine.DataType,
+    coerce: bool,
+    schema_cls,
+    data: st.DataObject,
+):
+    """Test koalas Index and MultiIndex on subset of datatypes.
+
+    Only test basic datatypes since index handling in pandas is already a
+    little finicky.
+    """
+    if coerce and dtype is pandas_engine.DateTime:
+        pytest.skip(
+            "koalas cannot coerce a koalas DateTime index to datetime."
+        )
+
+    if schema_cls is pa.Index:
+        schema = schema_cls(dtype, name="field")
+        schema.coerce = coerce
+    else:
+        schema = schema_cls(
+            indexes=[pa.Index(dtype, name="field")], coerce=True
+        )
+    sample = data.draw(schema.strategy(size=3))
+
+    if dtype is pandas_engine.DateTime or isinstance(
+        dtype, pandas_engine.DateTime
+    ):
+        # handle datetimes
+        if MIN_TIMESTAMP is not None and (
+            sample.to_frame() < MIN_TIMESTAMP
+        ).any(axis=None):
+            with pytest.raises(
+                OverflowError, match="mktime argument out of range"
+            ):
+                ks.DataFrame(pd.DataFrame(index=sample))
+            return
+    else:
+        assert isinstance(
+            schema(ks.DataFrame(pd.DataFrame(index=sample))), ks.DataFrame
+        )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        dt
+        for dt in NULLABLE_DTYPES
+        if type(dt) not in KOALAS_UNSUPPORTED
+        # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
+        and dt
+        not in {
+            pandas_engine.Engine.dtype(pandas_engine.BOOL),
+            pandas_engine.DateTime(tz="UTC"),  # type: ignore[call-arg]
+        }
+    ],
+)
+@hypothesis.given(st.data())
+@hypothesis.settings(
+    suppress_health_check=[hypothesis.HealthCheck.too_slow],
+)
+def test_nullable(
+    dtype: pandas_engine.DataType,
+    data: st.DataObject,
+):
+    """Test nullable checks on koalas dataframes."""
+    checks = None
+    if dtypes.is_datetime(type(dtype)) and MIN_TIMESTAMP is not None:
+        checks = [pa.Check.gt(MIN_TIMESTAMP)]
+    nullable_schema = pa.DataFrameSchema(
+        {"field": pa.Column(dtype, checks=checks, nullable=True)}
+    )
+    nonnullable_schema = pa.DataFrameSchema(
+        {"field": pa.Column(dtype, checks=checks, nullable=False)}
+    )
+    null_sample = data.draw(nullable_schema.strategy(size=5))
+    nonnull_sample = data.draw(nonnullable_schema.strategy(size=5))
+
+    # for some reason values less than MIN_TIMESTAMP are still sampled.
+    if dtype is pandas_engine.DateTime or isinstance(
+        dtype, pandas_engine.DateTime
+    ):
+        if MIN_TIMESTAMP is not None and (null_sample < MIN_TIMESTAMP).any(
+            axis=None
+        ):
+            with pytest.raises(
+                OverflowError, match="mktime argument out of range"
+            ):
+                ks.DataFrame(null_sample)
+            return
+        if MIN_TIMESTAMP is not None and (nonnull_sample < MIN_TIMESTAMP).any(
+            axis=None
+        ):
+            with pytest.raises(
+                OverflowError, match="mktime argument out of range"
+            ):
+                ks.DataFrame(nonnull_sample)
+            return
+    else:
+        ks_null_sample = ks.DataFrame(null_sample)
+        ks_nonnull_sample = ks.DataFrame(nonnull_sample)
+        n_nulls = ks_null_sample.isna().sum().item()
+        assert ks_nonnull_sample.notna().all().item()
+        assert n_nulls >= 0
+        if n_nulls > 0:
+            with pytest.raises(pa.errors.SchemaError):
+                nonnullable_schema(ks_null_sample)
+
+
+def test_unique():
+    """Test uniqueness checks on koalas dataframes."""
+    schema = pa.DataFrameSchema({"field": pa.Column(int)}, unique=["field"])
+    column_schema = pa.Column(int, unique=True, name="field")
+    series_schema = pa.SeriesSchema(int, unique=True, name="field")
+
+    data_unique = ks.DataFrame({"field": [1, 2, 3]})
+    data_non_unique = ks.DataFrame({"field": [1, 1, 1]})
+
+    assert isinstance(schema(data_unique), ks.DataFrame)
+    assert isinstance(column_schema(data_unique), ks.DataFrame)
+    assert isinstance(series_schema(data_unique["field"]), ks.Series)
+
+    with pytest.raises(pa.errors.SchemaError, match="columns .+ not unique"):
+        schema(data_non_unique)
+    with pytest.raises(
+        pa.errors.SchemaError, match="series .+ contains duplicate values"
+    ):
+        column_schema(data_non_unique)
+    with pytest.raises(
+        pa.errors.SchemaError, match="series .+ contains duplicate values"
+    ):
+        series_schema(data_non_unique["field"])
+
+    schema.unique = None
+    column_schema.unique = False
+    series_schema.unique = False
+
+    assert isinstance(schema(data_non_unique), ks.DataFrame)
+    assert isinstance(column_schema(data_non_unique), ks.DataFrame)
+    assert isinstance(series_schema(data_non_unique["field"]), ks.Series)
+
+
+def test_regex_columns():
+    """Test regex column selection works on on koalas dataframes."""
+    schema = pa.DataFrameSchema({r"field_\d+": pa.Column(int, regex=True)})
+    n_fields = 3
+    data = ks.DataFrame({f"field_{i}": [1, 2, 3] for i in range(n_fields)})
+    schema(data)
+
+    for i in range(n_fields):
+        invalid_data = data.copy()
+        invalid_data[f"field_{i}"] = ["a", "b", "c"]
+        with pytest.raises(pa.errors.SchemaError):
+            schema(invalid_data)
+
+
+def test_required_column():
+    """Test the required column raises error."""
+    required_schema = pa.DataFrameSchema(
+        {"field": pa.Column(int, required=True)}
+    )
+    schema = pa.DataFrameSchema({"field_": pa.Column(int, required=False)})
+
+    data = ks.DataFrame({"field": [1, 2, 3]})
+
+    assert isinstance(required_schema(data), ks.DataFrame)
+    assert isinstance(schema(data), ks.DataFrame)
+
+    with pytest.raises(pa.errors.SchemaError):
+        required_schema(ks.DataFrame({"another_field": [1, 2, 3]}))
+    schema(ks.DataFrame({"another_field": [1, 2, 3]}))
+
+
+@pytest.mark.parametrize("from_dtype", [str])
+@pytest.mark.parametrize("to_dtype", [float, int, str, bool])
+@hypothesis.given(st.data())
+def test_dtype_coercion(from_dtype, to_dtype, data):
+    """Test the datatype coercion provides informative errors."""
+    from_schema = pa.DataFrameSchema({"field": pa.Column(from_dtype)})
+    to_schema = pa.DataFrameSchema({"field": pa.Column(to_dtype, coerce=True)})
+
+    pd_sample = data.draw(from_schema.strategy(size=3))
+    sample = ks.DataFrame(pd_sample)
+    if from_dtype is to_dtype:
+        assert isinstance(to_schema(sample), ks.DataFrame)
+        return
+
+    # strings that can't be intepreted as numbers are converted to NA
+    if from_dtype is str and to_dtype in {int, float}:
+        with pytest.raises(pa.errors.SchemaError, match="non-nullable series"):
+            to_schema(sample)
+        return
+
+    assert isinstance(to_schema(sample), ks.DataFrame)
+
+
+def test_strict_schema():
+    """Test schema strictness."""
+    strict_schema = pa.DataFrameSchema({"field": pa.Column()}, strict=True)
+    non_strict_schema = pa.DataFrameSchema({"field": pa.Column()})
+
+    strict_df = ks.DataFrame({"field": [1]})
+    non_strict_df = ks.DataFrame({"field": [1], "foo": [2]})
+
+    strict_schema(strict_df)
+    non_strict_schema(strict_df)
+
+    with pytest.raises(
+        pa.errors.SchemaError, match="column 'foo' not in DataFrameSchema"
+    ):
+        strict_schema(non_strict_df)
+
+    non_strict_schema(non_strict_df)
+
+
+def test_custom_checks():
+    """Test that custom checks can be executed."""
+
+    @extensions.register_check_method(statistics=["value"])
+    def koalas_eq(koalas_obj, *, value):
+        return koalas_obj == value
+
+    custom_schema = pa.DataFrameSchema(
+        {"field": pa.Column(checks=pa.Check(lambda s: s == 0, name="custom"))}
+    )
+
+    custom_registered_schema = pa.DataFrameSchema(
+        {"field": pa.Column(checks=pa.Check.koalas_eq(0))}
+    )
+
+    for schema in (custom_schema, custom_registered_schema):
+        schema(ks.DataFrame({"field": [0] * 100}))
+
+        try:
+            schema(ks.DataFrame({"field": [-1] * 100}))
+        except pa.errors.SchemaError as err:
+            assert (err.failure_cases["failure_case"] == -1).all()
+
+
+def test_schema_model():
+    # pylint: disable=missing-class-docstring
+    """Test that SchemaModel subclasses work on koalas dataframes."""
+
+    # pylint: disable=too-few-public-methods
+    class Schema(pa.SchemaModel):
+        int_field: pa.typing.Series[int] = pa.Field(gt=0)
+        float_field: pa.typing.Series[float] = pa.Field(lt=0)
+        str_field: pa.typing.Series[str] = pa.Field(isin=["a", "b", "c"])
+
+    valid_df = ks.DataFrame(
+        {
+            "int_field": [1, 2, 3],
+            "float_field": [-1.1, -2.1, -3.1],
+            "str_field": ["a", "b", "c"],
+        }
+    )
+    invalid_df = ks.DataFrame(
+        {
+            "int_field": [-1],
+            "field_field": [1],
+            "str_field": ["d"],
+        }
+    )
+
+    Schema.validate(valid_df)
+    try:
+        Schema.validate(invalid_df, lazy=True)
+    except pa.errors.SchemaErrors as err:
+        expected_failures = {"-1", "d", "float_field"}
+        assert (
+            set(err.failure_cases["failure_case"].tolist())
+            == expected_failures
+        )
+
+
+@pytest.mark.parametrize(
+    "check,valid,invalid",
+    [
+        [pa.Check.eq(0), 0, -1],
+        [pa.Check.ne(0), 1, 0],
+        [pa.Check.gt(0), 1, -1],
+        [pa.Check.ge(0), 0, -1],
+        [pa.Check.lt(0), -1, 0],
+        [pa.Check.le(0), 0, 1],
+        [pa.Check.in_range(0, 10), 5, -1],
+        [pa.Check.isin(["a"]), "a", "b"],
+        [pa.Check.notin(["a"]), "b", "a"],
+        [pa.Check.str_matches("^a$"), "a", "b"],
+        [pa.Check.str_contains("a"), "faa", "foo"],
+        [pa.Check.str_startswith("a"), "ab", "ba"],
+        [pa.Check.str_endswith("a"), "ba", "ab"],
+        [pa.Check.str_length(1, 2), "a", ""],
+    ],
+)
+def test_check_comparison_operators(check, valid, invalid):
+    """Test simple comparison operators."""
+    valid_check_result = check(ks.Series([valid] * 3))
+    invalid_check_result = check(ks.Series([invalid] * 3))
+    assert valid_check_result.check_passed
+    assert not invalid_check_result.check_passed
+
+
+def test_check_decorators():
+    # pylint: disable=missing-class-docstring
+    """Test that pandera decorators work with koalas."""
+    in_schema = pa.DataFrameSchema({"a": pa.Column(int)})
+    out_schema = in_schema.add_columns({"b": pa.Column(int)})
+
+    # pylint: disable=too-few-public-methods
+    class InSchema(pa.SchemaModel):
+        a: pa.typing.Series[int]
+
+    class OutSchema(InSchema):
+        b: pa.typing.Series[int]
+
+    @pa.check_input(in_schema)
+    @pa.check_output(out_schema)
+    def function_check_input_output(df: ks.DataFrame) -> ks.DataFrame:
+        df["b"] = df["a"] + 1
+        return df
+
+    @pa.check_input(in_schema)
+    @pa.check_output(out_schema)
+    def function_check_input_output_invalid(df: ks.DataFrame) -> ks.DataFrame:
+        return df
+
+    @pa.check_io(df=in_schema, out=out_schema)
+    def function_check_io(df: ks.DataFrame) -> ks.DataFrame:
+        df["b"] = df["a"] + 1
+        return df
+
+    @pa.check_io(df=in_schema, out=out_schema)
+    def function_check_io_invalid(df: ks.DataFrame) -> ks.DataFrame:
+        return df
+
+    @pa.check_types
+    def function_check_types(
+        df: pa.typing.DataFrame[InSchema],
+    ) -> pa.typing.DataFrame[OutSchema]:
+        df["b"] = df["a"] + 1
+        return df
+
+    @pa.check_types
+    def function_check_types_invalid(
+        df: pa.typing.DataFrame[InSchema],
+    ) -> pa.typing.DataFrame[OutSchema]:
+        return df
+
+    valid_df = ks.DataFrame({"a": [1, 2, 3]})
+    invalid_df = ks.DataFrame({"b": [1, 2, 3]})
+
+    function_check_input_output(valid_df)
+    function_check_io(valid_df)
+    function_check_types(valid_df)
+
+    for fn in (
+        function_check_input_output,
+        function_check_input_output_invalid,
+        function_check_io,
+        function_check_io_invalid,
+        function_check_types,
+        function_check_types_invalid,
+    ):
+        with pytest.raises(pa.errors.SchemaError):
+            fn(invalid_df)
+
+    for fn in (
+        function_check_input_output_invalid,
+        function_check_io_invalid,
+        function_check_types_invalid,
+    ):
+        with pytest.raises(pa.errors.SchemaError):
+            fn(valid_df)

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -3,7 +3,7 @@
 import datetime
 import operator
 import re
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Set
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -28,14 +28,20 @@ else:
     HAS_HYPOTHESIS = True
 
 
+UNSUPPORTED_DTYPES: Set[Any] = set(
+    [
+        pandas_engine.Interval,
+        pandas_engine.Period,
+        pandas_engine.Sparse,
+    ]
+)
 SUPPORTED_DTYPES = set()
 for data_type in pandas_engine.Engine.get_registered_dtypes():
     if (
         # valid hypothesis.strategies.floats <=64
         getattr(data_type, "bit_width", -1) > 64
         or is_category(data_type)
-        or data_type
-        in (pandas_engine.Interval, pandas_engine.Period, pandas_engine.Sparse)
+        or data_type in UNSUPPORTED_DTYPES
     ):
         continue
     SUPPORTED_DTYPES.add(pandas_engine.Engine.dtype(data_type))


### PR DESCRIPTION
Addresses one part of #601 

This PR introduces support for `koalas` object validation (`DataFrame`, `Series`, and `Index`), so pandera can be used like so:

Install

```
pip install pandera[koalas]
```

Then validate away!

```python
schema = pa.DataFrameSchema(
    {
        "int_column": pa.Column(int, pa.Check.ge(0)),
        "float_column": pa.Column(float, pa.Check.le(0)),
        "str_column": pa.Column(str, pa.Check.isin(list("abcde"))),
    },
    coerce=True,
)
kdf = ks.DataFrame(
    {
        "int_column": range(10),
        "float_column": [float(-x) for x in range(10)],
        "str_column": list("aabbcceedd"),
    }
)
```

### Notes:

- `check_utils` module adds a bunch of methods for checking the type of a object-to-validate. This should probably be moved somewhere else.
- littered about in the core schema validation logic are checks for koalas objects, e.g. [here](https://github.com/pandera-dev/pandera/pull/651/files#diff-623c80b5083860f6496940a67c1329a55ac5ff732a533ceffbb40776ca2ce631R375-R383) and [here](https://github.com/pandera-dev/pandera/pull/651/files#diff-623c80b5083860f6496940a67c1329a55ac5ff732a533ceffbb40776ca2ce631R596-R603). Will clean up this tech debt as part of #381
- there are a few places that use a footgun, i.e. enable koalas features that negatively impacts performance, e.g. [here](https://github.com/pandera-dev/pandera/pull/651/files#diff-0cc44eebd93e52d9b34752fe6c1cd0ef2a978069e417b2e1269689c4e4209c90R1832) which enables the koalas `compute.ops_on_diff_frames` config, which allows for computations across dataframes (which can involve expensive join operations). Clearing this tech debt would require someone more familiar with the koalas project.
- [This conditional](https://github.com/pandera-dev/pandera/pull/651/files#diff-0cc44eebd93e52d9b34752fe6c1cd0ef2a978069e417b2e1269689c4e4209c90R2104-R2106) checks for presence of a `pandera` accessor class. Need to find a way around this for modin, which doesn't currently support the accessor extension  utility.  Koalas does, though, so will need to implement that extension in a future PR.

This feature is in beta, so many bugs are expected.