### PR TITLE
Handle cases of reset_index level being None or an empty list

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1577,6 +1577,10 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         # pylint: disable=import-outside-toplevel,cyclic-import
         from pandera.schema_components import Column, Index, MultiIndex
 
+        # explcit check for an empty list
+        if level == []:
+            return self
+
         new_schema = copy.deepcopy(self)
 
         if new_schema.index is None:
@@ -1586,7 +1590,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         # ensure no duplicates
         level_temp: Union[List[Any], List[str]] = (
-            list(set(level)) if level is not None else []
+            new_schema.index.names if level is None else list(set(level))
         )
 
         # ensure all specified keys are present in the index

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1644,20 +1644,33 @@ def test_reset_index_drop(drop: bool, schema_simple: DataFrameSchema) -> None:
         assert test_schema.index is None
 
 
-def test_reset_index_level(schema_multiindex: DataFrameSchema):
+@pytest.mark.parametrize(
+    "level, columns, index",
+    [
+        [
+            None,{"col1", "col2", "ind0", "ind1"},None
+        ],
+        [   
+            [],{"col1", "col2"},["ind0", "ind1"]
+        ],
+        [
+            ["ind0"],{"col1", "col2", "ind0"},["ind1"]
+        ],
+        [
+            ["ind0","ind1"],{"col1", "col2", "ind0", "ind1"},None
+        ]
+    ],
+)
+def test_reset_index_level(schema_multiindex: DataFrameSchema, level, columns, index):
     """Test that resetting index correctly handles specifying level."""
-    test_schema = schema_multiindex.reset_index(level=["ind0"])
-    assert test_schema.index.name == "ind1"
-    assert isinstance(test_schema.index, Index)
-
-    test_schema = schema_multiindex.reset_index(level=["ind0", "ind1"])
-    assert test_schema.index is None
-    assert set(list(test_schema.columns.keys())) == {
-        "col1",
-        "col2",
-        "ind0",
-        "ind1",
-    }
+    test_schema = schema_multiindex.reset_index(level=level)
+    if index:
+        assert isinstance(test_schema.index, (Index, MultiIndex))
+        assert test_schema.index.names == index
+    else:
+        assert test_schema.index is None
+        
+    assert set(test_schema.columns.keys()) == columns
 
 
 def test_invalid_keys(schema_simple: DataFrameSchema) -> None:

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1647,21 +1647,15 @@ def test_reset_index_drop(drop: bool, schema_simple: DataFrameSchema) -> None:
 @pytest.mark.parametrize(
     "level, columns, index",
     [
-        [
-            None,{"col1", "col2", "ind0", "ind1"},None
-        ],
-        [   
-            [],{"col1", "col2"},["ind0", "ind1"]
-        ],
-        [
-            ["ind0"],{"col1", "col2", "ind0"},["ind1"]
-        ],
-        [
-            ["ind0","ind1"],{"col1", "col2", "ind0", "ind1"},None
-        ]
+        [None, {"col1", "col2", "ind0", "ind1"}, None],
+        [[], {"col1", "col2"}, ["ind0", "ind1"]],
+        [["ind0"], {"col1", "col2", "ind0"}, ["ind1"]],
+        [["ind0", "ind1"], {"col1", "col2", "ind0", "ind1"}, None],
     ],
 )
-def test_reset_index_level(schema_multiindex: DataFrameSchema, level, columns, index):
+def test_reset_index_level(
+    schema_multiindex: DataFrameSchema, level, columns, index
+):
     """Test that resetting index correctly handles specifying level."""
     test_schema = schema_multiindex.reset_index(level=level)
     if index:
@@ -1669,7 +1663,7 @@ def test_reset_index_level(schema_multiindex: DataFrameSchema, level, columns, i
         assert test_schema.index.names == index
     else:
         assert test_schema.index is None
-        
+
     assert set(test_schema.columns.keys()) == columns
 
 


### PR DESCRIPTION
Closes #863

As I was writing the test for None, I thought about the case of an empty list.

I wasn't sure how it should be handled, but thankfully I don't have to break my head over it. I simply asked: wwpd? (what would pandas do?)

![image](https://user-images.githubusercontent.com/10162554/170505617-041a3272-1327-4422-81b9-485683691a51.png)