### PR TITLE
Fix modin and pyspark CI 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
 
   # modin extra
   - modin
+  - protobuf <= 3.20
 
   # dask extra
   - dask

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - pyspark-stubs
 
   # pyspark extra
-  - pyspark
+  - pyspark >= 3.2.0
 
   # modin extra
   - modin
@@ -79,9 +79,9 @@ dependencies:
   - pre_commit
 
   - pip:
-    - furo
-    - ray <= 1.7.0; python_version < '3.10'
-    - types-click
-    - types-pyyaml
-    - types-pkg_resources
-    - types-requests
+      - furo
+      - ray <= 1.7.0; python_version < '3.10'
+      - types-click
+      - types-pyyaml
+      - types-pkg_resources
+      - types-requests

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
 
   # mypy extra
   - pandas-stubs
+  - pyspark-stubs
 
   # pyspark extra
   - pyspark

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -1077,7 +1077,8 @@ def dataframe_strategy(
             for col_name, col in expanded_columns.items()
         }
         nullable_columns = {
-            col_name: col.nullable for col_name, col in expanded_columns.items()
+            col_name: col.nullable
+            for col_name, col in expanded_columns.items()
         }
 
         row_strategy = None
@@ -1102,7 +1103,9 @@ def dataframe_strategy(
 
         # this is a hack to convert np.str_ data values into native python str.
         for col_name, col_dtype in col_dtypes.items():
-            if col_dtype in {"object", "str"} or col_dtype.startswith("string"):
+            if col_dtype in {"object", "str"} or col_dtype.startswith(
+                "string"
+            ):
                 # pylint: disable=cell-var-from-loop,undefined-loop-variable
                 strategy = strategy.map(
                     lambda df: df.assign(**{col_name: df[col_name].map(str)})

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -54,7 +54,7 @@ except ImportError:  # pragma: no cover
     class SearchStrategy:  # type: ignore
         """placeholder type."""
 
-    def composite(fn):
+    def composite(fn):  # type: ignore
         """placeholder composite strategy."""
         return fn
 
@@ -1077,8 +1077,7 @@ def dataframe_strategy(
             for col_name, col in expanded_columns.items()
         }
         nullable_columns = {
-            col_name: col.nullable
-            for col_name, col in expanded_columns.items()
+            col_name: col.nullable for col_name, col in expanded_columns.items()
         }
 
         row_strategy = None
@@ -1103,9 +1102,7 @@ def dataframe_strategy(
 
         # this is a hack to convert np.str_ data values into native python str.
         for col_name, col_dtype in col_dtypes.items():
-            if col_dtype in {"object", "str"} or col_dtype.startswith(
-                "string"
-            ):
+            if col_dtype in {"object", "str"} or col_dtype.startswith("string"):
                 # pylint: disable=cell-var-from-loop,undefined-loop-variable
                 strategy = strategy.map(
                     lambda df: df.assign(**{col_name: df[col_name].map(str)})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ pandas-stubs
 pyspark-stubs
 pyspark
 modin
+protobuf <= 3.20
 dask
 distributed
 geopandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ frictionless
 pyarrow
 pydantic
 pandas-stubs
+pyspark-stubs
 pyspark
 modin
 dask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pyarrow
 pydantic
 pandas-stubs
 pyspark-stubs
-pyspark
+pyspark >= 3.2.0
 modin
 protobuf <= 3.20
 dask

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ _extras_require = {
     "strategies": ["hypothesis >= 5.41.1"],
     "hypotheses": ["scipy"],
     "io": ["pyyaml >= 5.1", "black", "frictionless"],
-    "pyspark": ["pyspark"],
+    "pyspark": ["pyspark >= 3.2.0"],
     "modin": ["modin", "ray <= 1.7.0", "dask"],
     "modin-ray": ["modin", "ray <= 1.7.0"],
     "modin-dask": ["modin", "dask"],

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -55,10 +55,10 @@ def test_mypy_pandas_dataframe(capfd) -> None:
     # assert error messages on particular lines of code
     assert errors[35] == {
         "msg": (
-            'Argument 1 to "pipe" of "NDFrame" has incompatible type '
-            '"Type[DataFrame[Any]]"; expected '
-            '"Union[Callable[..., DataFrame[SchemaOut]], '
-            'Tuple[Callable[..., DataFrame[SchemaOut]], str]]"'
+            'Argument 1 to "pipe" of "DataFrame" has incompatible type '
+            '"Type[pandera.typing.pandas.DataFrame[Any]]"; expected '
+            '"Union[Callable[..., pandera.typing.pandas.DataFrame[SchemaOut]], '
+            'Tuple[Callable[..., pandera.typing.pandas.DataFrame[SchemaOut]], str]]"'
         ),
         "errcode": "arg-type",
     }

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pyspark.pandas as ps
 import pytest
+from pyspark import SparkContext
 
 import pandera as pa
 from pandera import dtypes, extensions, system
@@ -44,7 +45,6 @@ PYSPARK_PANDAS_UNSUPPORTED = {
     numpy_engine.Complex64,
     numpy_engine.Float16,
     numpy_engine.Object,
-    numpy_engine.Timedelta64,
     numpy_engine.UInt64,
     numpy_engine.UInt32,
     numpy_engine.UInt16,
@@ -58,6 +58,11 @@ PYSPARK_PANDAS_UNSUPPORTED = {
     pandas_engine.UINT16,
     pandas_engine.UINT8,
 }
+
+SPARK_VERSION = SparkContext().version
+
+if SPARK_VERSION < "3.3.0":
+    PYSPARK_PANDAS_UNSUPPORTED.add(numpy_engine.Timedelta64)
 
 if system.FLOAT_128_AVAILABLE:
     PYSPARK_PANDAS_UNSUPPORTED.update(
@@ -117,7 +122,7 @@ def _test_datatype_with_schema(
             data_container_cls(sample)
         return
 
-    sample = data.draw(schema.strategy(size=3))
+    sample = data.draw(schema.strategy(size=50))
 
     if dtype is pandas_engine.DateTime or isinstance(
         dtype, pandas_engine.DateTime

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -122,7 +122,7 @@ def _test_datatype_with_schema(
             data_container_cls(sample)
         return
 
-    sample = data.draw(schema.strategy(size=50))
+    sample = data.draw(schema.strategy(size=3))
 
     if dtype is pandas_engine.DateTime or isinstance(
         dtype, pandas_engine.DateTime

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -302,7 +302,7 @@ def test_nullable(
             return
     else:
         try:
-            ks_null_sample = ps.DataFrame(null_sample)
+            ks_null_sample: ps.DataFrame = ps.DataFrame(null_sample)
         except TypeError as exc:
             match = re.search(
                 r"can not accept object (<NA>|NaT) in type", exc.args[0]
@@ -313,8 +313,8 @@ def test_nullable(
                 f"pyspark.pandas cannot handle native {match.groups()[0]} type "
                 f"with dtype {dtype.type}"
             )
-        ks_nonnull_sample = ps.DataFrame(nonnull_sample)
-        n_nulls = ks_null_sample.isna().sum().item()
+        ks_nonnull_sample: ps.DataFrame = ps.DataFrame(nonnull_sample)
+        n_nulls: int = ks_null_sample.isna().sum().item()  # type: ignore [union-attr,assignment]
         assert ks_nonnull_sample.notna().all().item()
         assert n_nulls >= 0
         if n_nulls > 0:

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -1,5 +1,5 @@
 """Test pandera on pyspark data structures."""
-
+import re
 import typing
 from unittest.mock import MagicMock
 
@@ -304,11 +304,14 @@ def test_nullable(
         try:
             ks_null_sample = ps.DataFrame(null_sample)
         except TypeError as exc:
-            if "can not accept object <NA> in type" not in exc.args[0]:
+            match = re.search(
+                r"can not accept object (<NA>|NaT) in type", exc.args[0]
+            )
+            if match is None:
                 raise
             pytest.skip(
-                "pyspark.pandas cannot handle native pd.NA type with dtype "
-                f"{dtype.type}"
+                f"pyspark.pandas cannot handle native {match.groups()[0]} type "
+                f"with dtype {dtype.type}"
             )
         ks_nonnull_sample = ps.DataFrame(nonnull_sample)
         n_nulls = ks_null_sample.isna().sum().item()


### PR DESCRIPTION
Currently tests for modin-ray don't pass and the pyspark code raises mypy errors, both seemingly due to new releases.

Pyspark:
* added pyspark stubs to solve mypy errors
* timedelta64 is [now supported with pyspark 3.3.0](https://issues.apache.org/jira/browse/SPARK-37525). However, the strategy always draws `0 days`. It can be addressed in a separate ticket I think.

Newest ray release requires:
* requires protobuf <= 3.20