### PR TITLE
Add pandas_engine.Date

### DIFF
--- a/docs/source/reference/dtypes.rst
+++ b/docs/source/reference/dtypes.rst
@@ -63,6 +63,7 @@ Passing native pandas dtypes to pandera components is preferred.
    pandera.engines.pandas_engine.STRING
    pandera.engines.numpy_engine.Object
    pandera.engines.pandas_engine.DateTime
+   pandera.engines.pandas_engine.Date
    pandera.engines.pandas_engine.Decimal
 
 GeoPandas Dtypes

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -16,7 +16,7 @@ much the same way you'd define ``pydantic`` models.
 
 `Schema Models` are annotated with the :mod:`pandera.typing` module using the standard
 `typing <https://docs.python.org/3/library/typing.html>`_ syntax. Models can be
-explictly converted to a :class:`~pandera.schemas.DataFrameSchema` or used to validate a
+explicitly converted to a :class:`~pandera.schemas.DataFrameSchema` or used to validate a
 :class:`~pandas.DataFrame` directly.
 
 .. note::

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -9,6 +9,7 @@ from pandera.dtypes import (
     Complex64,
     Complex128,
     DataType,
+    Date,
     DateTime,
     Decimal,
     Float,

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -380,6 +380,8 @@ class Complex64(Complex128):
 # decimal
 ###############################################################################
 
+DEFAULT_PYTHON_PREC = 28
+
 
 @immutable(init=True)
 class Decimal(_Number):
@@ -388,22 +390,21 @@ class Decimal(_Number):
     exact: bool = dataclasses.field(init=False, default=True)
     continuous: bool = dataclasses.field(init=False, default=True)
 
-    precision: Optional[int] = None
-    scale: Optional[int] = None
+    precision: int = DEFAULT_PYTHON_PREC
+    """The number of significant digits that the decimal type can represent."""
+    scale: int = 0  # default 0 is aligned with pyarrow and various databases.
+    """The number of digits after the decimal point."""
 
-    def __init__(
-        self, precision: Optional[int] = None, scale: Optional[int] = None
-    ):
+    def __init__(self, precision: int = DEFAULT_PYTHON_PREC, scale: int = 0):
         super().__init__()
-        if precision is not None:
-            if precision <= 0:
-                raise ValueError(
-                    f"Decimal precision {precision} must be positive."
-                )
-            if scale is not None and scale > precision:
-                raise ValueError(
-                    f"Decimal scale {scale} must be between 0 and {precision}."
-                )
+        if precision <= 0:
+            raise ValueError(
+                f"Decimal precision {precision} must be positive."
+            )
+        if scale is not None and scale > precision:
+            raise ValueError(
+                f"Decimal scale {scale} must be between 0 and {precision}."
+            )
         object.__setattr__(self, "precision", precision)
         object.__setattr__(self, "scale", scale)
 

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -701,11 +701,6 @@ class _BaseDateTime(DataType):
         default_factory=dict, compare=False, repr=False
     )
 
-    def __init__(  # pylint:disable=super-init-not-called
-        self, to_datetime_kwargs: Optional[Dict[str, Any]] = None
-    ) -> None:
-        object.__setattr__(self, "to_datetime_kwargs", to_datetime_kwargs)
-
     @staticmethod
     def _get_to_datetime_fn(obj: Any) -> Callable:
 
@@ -844,6 +839,14 @@ class Date(_BaseDateTime, dtypes.Date):
         default_factory=dict, compare=False, repr=False
     )
     "Any additional kwargs passed to :func:`pandas.to_datetime` for coercion."
+
+    # define __init__ to please mypy
+    def __init__(  # pylint:disable=super-init-not-called
+        self, to_datetime_kwargs: Optional[Dict[str, Any]] = None
+    ) -> None:
+        object.__setattr__(
+            self, "to_datetime_kwargs", to_datetime_kwargs or {}
+        )
 
     def coerce(self, data_container: PandasObject) -> PandasObject:
         return self._coerce(data_container, pandas_dtype=np.datetime64).dt.date

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -46,8 +46,7 @@ def is_extension_dtype(
 ) -> Union[bool, Iterable[bool]]:
     """Check if a value is a pandas extension type or instance of one."""
     return isinstance(pd_dtype, PandasExtensionType) or (
-        isinstance(pd_dtype, type)
-        and issubclass(pd_dtype, PandasExtensionType)
+        isinstance(pd_dtype, type) and issubclass(pd_dtype, PandasExtensionType)
     )
 
 
@@ -181,9 +180,7 @@ class Engine(  # pylint:disable=too-few-public-methods
     def numpy_dtype(cls, pandera_dtype: dtypes.DataType) -> np.dtype:
         """Convert a Pandera :class:`~pandera.dtypes.DataType
         to a :class:`numpy.dtype`."""
-        pandera_dtype: dtypes.DataType = engine.Engine.dtype(
-            cls, pandera_dtype
-        )
+        pandera_dtype: dtypes.DataType = engine.Engine.dtype(cls, pandera_dtype)
 
         alias = str(pandera_dtype).lower()
         if alias == "boolean":
@@ -749,9 +746,7 @@ class _BaseDateTime(DataType):
 
     def coerce_value(self, value: Any) -> Any:
         """Coerce an value to specified datatime type."""
-        return self._get_to_datetime_fn(value)(
-            value, **self.to_datetime_kwargs
-        )
+        return self._get_to_datetime_fn(value)(value, **self.to_datetime_kwargs)
 
 
 @Engine.register_dtype(
@@ -845,7 +840,8 @@ class Date(_BaseDateTime, dtypes.Date):
         return self._coerce(data_container, pandas_dtype=np.datetime64).dt.date
 
     def coerce_value(self, value: Any) -> Any:
-        return _BaseDateTime.coerce_value(self, value).date()
+        coerced = _BaseDateTime.coerce_value(self, value)
+        return coerced.date() if coerced is not None else pd.NaT
 
     def check(  # type: ignore
         self,
@@ -939,9 +935,7 @@ class Interval(DataType):
     subtype: Union[str, np.dtype]
 
     def __post_init__(self):
-        object.__setattr__(
-            self, "type", pd.IntervalDtype(subtype=self.subtype)
-        )
+        object.__setattr__(self, "type", pd.IntervalDtype(subtype=self.subtype))
 
     @classmethod
     def from_parametrized_dtype(cls, pd_dtype: pd.IntervalDtype):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -774,6 +774,10 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
     """The precision of the datetime data. Currently limited to "ns"."""
     tz: Optional[datetime.tzinfo] = None
     """The timezone."""
+    to_datetime_kwargs: Dict[str, Any] = dataclasses.field(
+        default_factory=dict, compare=False, repr=False
+    )
+    "Any additional kwargs passed to :func:`pandas.to_datetime` for coercion."
 
     def __post_init__(self):
         if self.tz is None:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -525,7 +525,10 @@ class Decimal(DataType, dtypes.Decimal):
                 "Decimal is not yet supported for pyspark."
             )
         if not super().check(pandera_dtype, data_container):
-            return np.full_like(data_container, False)
+            if data_container is None:
+                return False
+            else:
+                return np.full_like(data_container, False)
         if data_container is None:
             return True
         return _check_decimal(
@@ -855,7 +858,10 @@ class Date(_BaseDateTime, dtypes.Date):
         data_container: Optional[pd.Series] = None,
     ) -> Union[bool, Iterable[bool]]:
         if not DataType.check(self, pandera_dtype, data_container):
-            return np.full_like(data_container, False)
+            if data_container is None:
+                return False
+            else:
+                return np.full_like(data_container, False)
         if data_container is None:
             return True
 

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -464,9 +464,6 @@ def _check_decimal(
     return is_valid.to_numpy()
 
 
-DEFAULT_PYTHON_PREC = 28
-
-
 @Engine.register_dtype(equivalents=["decimal", decimal.Decimal])
 @immutable(init=True)
 class Decimal(DataType, dtypes.Decimal):
@@ -489,8 +486,8 @@ class Decimal(DataType, dtypes.Decimal):
 
     def __init__(  # pylint:disable=super-init-not-called
         self,
-        precision: Optional[int] = DEFAULT_PYTHON_PREC,
-        scale: Optional[int] = None,
+        precision: int = dtypes.DEFAULT_PYTHON_PREC,
+        scale: int = 0,
         rounding: Optional[str] = None,
     ) -> None:
         dtypes.Decimal.__init__(self, precision, scale)

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -46,7 +46,8 @@ def is_extension_dtype(
 ) -> Union[bool, Iterable[bool]]:
     """Check if a value is a pandas extension type or instance of one."""
     return isinstance(pd_dtype, PandasExtensionType) or (
-        isinstance(pd_dtype, type) and issubclass(pd_dtype, PandasExtensionType)
+        isinstance(pd_dtype, type)
+        and issubclass(pd_dtype, PandasExtensionType)
     )
 
 
@@ -180,7 +181,9 @@ class Engine(  # pylint:disable=too-few-public-methods
     def numpy_dtype(cls, pandera_dtype: dtypes.DataType) -> np.dtype:
         """Convert a Pandera :class:`~pandera.dtypes.DataType
         to a :class:`numpy.dtype`."""
-        pandera_dtype: dtypes.DataType = engine.Engine.dtype(cls, pandera_dtype)
+        pandera_dtype: dtypes.DataType = engine.Engine.dtype(
+            cls, pandera_dtype
+        )
 
         alias = str(pandera_dtype).lower()
         if alias == "boolean":
@@ -746,7 +749,9 @@ class _BaseDateTime(DataType):
 
     def coerce_value(self, value: Any) -> Any:
         """Coerce an value to specified datatime type."""
-        return self._get_to_datetime_fn(value)(value, **self.to_datetime_kwargs)
+        return self._get_to_datetime_fn(value)(
+            value, **self.to_datetime_kwargs
+        )
 
 
 @Engine.register_dtype(
@@ -935,7 +940,9 @@ class Interval(DataType):
     subtype: Union[str, np.dtype]
 
     def __post_init__(self):
-        object.__setattr__(self, "type", pd.IntervalDtype(subtype=self.subtype))
+        object.__setattr__(
+            self, "type", pd.IntervalDtype(subtype=self.subtype)
+        )
 
     @classmethod
     def from_parametrized_dtype(cls, pd_dtype: pd.IntervalDtype):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -513,7 +513,6 @@ class Decimal(DataType, dtypes.Decimal):
         dec = decimal.Decimal(str(value))
         if self._exp:
             return dec.quantize(self._exp, context=self._ctx)
-        print(dec)
         return dec
 
     def coerce(self, data_container: pd.Series) -> pd.Series:

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -364,27 +364,16 @@ class Index(SeriesSchemaBase):
                 self, check_obj, "Attempting to validate mismatch index"
             )
 
-        series_cls = pd.Series
-        # NOTE: this is a hack to get pyspark.pandas working, this needs a more
-        # principled implementation
-        if type(check_obj).__module__ == "pyspark.pandas.frame":
-            # pylint: disable=import-outside-toplevel
-            import pyspark.pandas as ps
-
-            series_cls = ps.Series
-
         if self.coerce:
             check_obj.index = self.coerce_dtype(check_obj.index)
             # handles case where pandas native string type is not supported
             # by index.
             obj_to_validate = self.dtype.coerce(
-                series_cls(
-                    check_obj.index.to_numpy(), name=check_obj.index.name
-                )
+                check_obj.index.to_series().reset_index(drop=True)
             )
         else:
-            obj_to_validate = series_cls(
-                check_obj.index.to_numpy(), name=check_obj.index.name
+            obj_to_validate = check_obj.index.to_series().reset_index(
+                drop=True
             )
 
         assert check_utils.is_field(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1986,7 +1986,10 @@ class SeriesSchemaBase:
                 )
             elif not isinstance(check_output, bool):
                 _, failure_cases = check_utils.prepare_series_check_output(
-                    series, pd.Series(check_output)
+                    series,
+                    pd.Series(list(check_output))
+                    if not isinstance(check_output, pd.Series)
+                    else check_output,
                 )
                 failure_cases = reshape_failure_cases(failure_cases)
                 msg = (

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1577,6 +1577,10 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         # pylint: disable=import-outside-toplevel,cyclic-import
         from pandera.schema_components import Column, Index, MultiIndex
 
+        # explcit check for an empty list
+        if level == []:
+            return self
+
         new_schema = copy.deepcopy(self)
 
         if new_schema.index is None:
@@ -1586,7 +1590,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         # ensure no duplicates
         level_temp: Union[List[Any], List[str]] = (
-            list(set(level)) if level is not None else []
+            new_schema.index.names if level is None else list(set(level))
         )
 
         # ensure all specified keys are present in the index

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -491,21 +491,25 @@ def test_numpy_dtypes(alias, np_dtype):
             [datetime.date(2013, 1, 1)],  # date
             [datetime.timedelta(0, 1, 1)],  # timedelta
             pd.Series(list("aabc")).astype("category"),  # categorical
-            [datetime.date(2022, 1, 1)],  # datre,
+            [datetime.date(2022, 1, 1)],  # date,
         ]
     ],
 )
 def test_inferred_dtype(examples: pd.Series):
     """Test compatibility with pd.api.types.infer_dtype's outputs."""
     alias = pd.api.types.infer_dtype(examples)
-    if "mixed" in alias or alias in ("date", "string"):
-        # infer_dtype returns "string", "date"
+    if "mixed" in alias or alias == "string":
+        # infer_dtype returns "string"
         # whereas a Series will default to a "np.object_" dtype
         inferred_datatype = pandas_engine.Engine.dtype(object)
     else:
         inferred_datatype = pandas_engine.Engine.dtype(alias)
-    actual_dtype = pandas_engine.Engine.dtype(pd.Series(examples).dtype)
-    assert actual_dtype.check(inferred_datatype)
+
+    if alias.startswith(("decimal", "date")):
+        assert str(inferred_datatype).lower().startswith(alias)
+    else:
+        actual_dtype = pandas_engine.Engine.dtype(pd.Series(examples).dtype)
+        assert actual_dtype.check(inferred_datatype)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -491,7 +491,7 @@ def test_numpy_dtypes(alias, np_dtype):
             [datetime.date(2013, 1, 1)],  # date
             [datetime.timedelta(0, 1, 1)],  # timedelta
             pd.Series(list("aabc")).astype("category"),  # categorical
-            [Decimal(1), Decimal(2.0)],  # decimal
+            [datetime.date(2022, 1, 1)],  # datre,
         ]
     ],
 )

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -3,7 +3,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from types import ModuleType
-from typing import Any, Generator, Iterable, List, Optional, cast
+from typing import Any, Generator, Iterable, List, cast
 
 import numpy as np
 import pandas as pd
@@ -202,9 +202,7 @@ def test_logical_datatype_coerce_value(
 
 
 @pytest.mark.parametrize("precision,scale", [(-1, None), (0, 0), (1, 2)])
-def test_invalid_decimal_params(
-    precision: Optional[int], scale: Optional[int]
-):
+def test_invalid_decimal_params(precision: int, scale: int):
     """Test invalid decimal params."""
     with pytest.raises(ValueError):
         pa.Decimal(precision, scale)

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -1,6 +1,6 @@
 """Tests logical dtypes."""
 
-import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from types import ModuleType
 from typing import Any, Generator, Iterable, List, Optional, cast
@@ -63,8 +63,8 @@ def datacontainer_lib(request) -> Generator[ModuleType, None, None]:
         ),
         (
             [
-                datetime.date(2022, 1, 1),
-                datetime.datetime(2022, 1, 1),
+                date(2022, 1, 1),
+                datetime(2022, 1, 1),
                 pd.Timestamp("20130101"),
                 "foo.bar",
                 None,
@@ -106,8 +106,8 @@ def test_logical_datatype_check(
         ),
         (
             [
-                datetime.date(2022, 1, 1),
-                datetime.datetime(2022, 1, 2, 1, 1, 1),
+                date(2022, 1, 1),
+                datetime(2022, 1, 2, 1, 1, 1),
                 None,
                 pd.NA,
                 np.nan,
@@ -176,6 +176,16 @@ def test_logical_datatype_coerce(
         (pd.NA, pandas_engine.Decimal(2, 1), pd.NA),
         (None, pandas_engine.Decimal(2, 1), pd.NA),
         (np.nan, pandas_engine.Decimal(2, 1), pd.NA),
+        (date(2022, 1, 1), pandas_engine.Date(), date(2022, 1, 1)),
+        (
+            "2022-01-01",
+            pandas_engine.Date(to_datetime_kwargs={"format": "%Y-%m-%d"}),
+            date(2022, 1, 1),
+        ),
+        (pd.NA, pandas_engine.Date(), pd.NaT),
+        (None, pandas_engine.Date(), pd.NaT),
+        (np.nan, pandas_engine.Date(), pd.NaT),
+        (pd.NaT, pandas_engine.Date(), pd.NaT),
     ],
 )
 def test_logical_datatype_coerce_value(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1644,20 +1644,27 @@ def test_reset_index_drop(drop: bool, schema_simple: DataFrameSchema) -> None:
         assert test_schema.index is None
 
 
-def test_reset_index_level(schema_multiindex: DataFrameSchema):
+@pytest.mark.parametrize(
+    "level, columns, index",
+    [
+        [None, {"col1", "col2", "ind0", "ind1"}, None],
+        [[], {"col1", "col2"}, ["ind0", "ind1"]],
+        [["ind0"], {"col1", "col2", "ind0"}, ["ind1"]],
+        [["ind0", "ind1"], {"col1", "col2", "ind0", "ind1"}, None],
+    ],
+)
+def test_reset_index_level(
+    schema_multiindex: DataFrameSchema, level, columns, index
+):
     """Test that resetting index correctly handles specifying level."""
-    test_schema = schema_multiindex.reset_index(level=["ind0"])
-    assert test_schema.index.name == "ind1"
-    assert isinstance(test_schema.index, Index)
+    test_schema = schema_multiindex.reset_index(level=level)
+    if index:
+        assert isinstance(test_schema.index, (Index, MultiIndex))
+        assert test_schema.index.names == index
+    else:
+        assert test_schema.index is None
 
-    test_schema = schema_multiindex.reset_index(level=["ind0", "ind1"])
-    assert test_schema.index is None
-    assert set(list(test_schema.columns.keys())) == {
-        "col1",
-        "col2",
-        "ind0",
-        "ind1",
-    }
+    assert set(test_schema.columns.keys()) == columns
 
 
 def test_invalid_keys(schema_simple: DataFrameSchema) -> None:

--- a/tests/modin/conftest.py
+++ b/tests/modin/conftest.py
@@ -21,6 +21,7 @@ def setup_modin_engine(request):
     engine = request.param
     os.environ["MODIN_ENGINE"] = engine
     os.environ["MODIN_MEMORY"] = "100000000"
+    os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
 
     if engine == "ray":
         # pylint: disable=import-outside-toplevel

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -57,6 +57,7 @@ PYSPARK_PANDAS_UNSUPPORTED = {
     pandas_engine.UINT32,
     pandas_engine.UINT16,
     pandas_engine.UINT8,
+    pandas_engine.Date,
 }
 
 SPARK_VERSION = SparkContext().version

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -121,11 +121,15 @@ def test_check_strategy_continuous(data_type, data):
 
     assert data.draw(strategies.ne_strategy(data_type, value=value)) != value
     assert data.draw(strategies.eq_strategy(data_type, value=value)) == value
-    assert data.draw(strategies.gt_strategy(data_type, min_value=value)) > value
+    assert (
+        data.draw(strategies.gt_strategy(data_type, min_value=value)) > value
+    )
     assert (
         data.draw(strategies.ge_strategy(data_type, min_value=value)) >= value
     )
-    assert data.draw(strategies.lt_strategy(data_type, max_value=value)) < value
+    assert (
+        data.draw(strategies.lt_strategy(data_type, max_value=value)) < value
+    )
     assert (
         data.draw(strategies.le_strategy(data_type, max_value=value)) <= value
     )

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -35,6 +35,7 @@ UNSUPPORTED_DTYPE_CLS: Set[Any] = set(
         pandas_engine.Sparse,
         pandas_engine.PydanticModel,
         pandas_engine.Decimal,
+        pandas_engine.Date,
     ]
 )
 SUPPORTED_DTYPES = set()
@@ -120,15 +121,11 @@ def test_check_strategy_continuous(data_type, data):
 
     assert data.draw(strategies.ne_strategy(data_type, value=value)) != value
     assert data.draw(strategies.eq_strategy(data_type, value=value)) == value
-    assert (
-        data.draw(strategies.gt_strategy(data_type, min_value=value)) > value
-    )
+    assert data.draw(strategies.gt_strategy(data_type, min_value=value)) > value
     assert (
         data.draw(strategies.ge_strategy(data_type, min_value=value)) >= value
     )
-    assert (
-        data.draw(strategies.lt_strategy(data_type, max_value=value)) < value
-    )
+    assert data.draw(strategies.lt_strategy(data_type, max_value=value)) < value
     assert (
         data.draw(strategies.le_strategy(data_type, max_value=value)) <= value
     )


### PR DESCRIPTION
This PR adds  the logical type `panderas.engines.pandas_engine.Date` and fixes #881. 

The `strategies` module does not support date because it relies on [hypothesis.extra.pandas.series](https://hypothesis.readthedocs.io/en/latest/numpy.html?highlight=pandas#hypothesis.extra.pandas.series), which requires a numpy dtype. Generally speaking, `strategies` does not support logical data types. We'll have to address this shortcoming in the future if we want user-defined logical types to be a viable alternatives to custom checks.

A consequence of the above is that I had to disable pyspark tests for Date, since they rely on drawing examples.

The primary goal was to support pyarrow date types (+ parquet), and it works great :tada:

```python
import pandas as pd
import pandera as pa
from pandera.engines import pandas_engine
from datetime import date
import pyarrow

df = pd.DataFrame({"col_date": ["2022-01-01"]})
schema = pa.DataFrameSchema({"col_date": pa.Column(date)}, coerce=True)
df = schema.validate(df)
df.info()
#> <class 'pandas.core.frame.DataFrame'>
#> RangeIndex: 1 entries, 0 to 0
#> Data columns (total 1 columns):
#>  #   Column    Non-Null Count  Dtype 
#> ---  ------    --------------  ----- 
#>  0   col_date  1 non-null      object
#> dtypes: object(1)
#> memory usage: 136.0+ bytes
print(f"{type(df.iloc[0, 0])=}")
#> type(df.iloc[0, 0])=<class 'datetime.date'>

# Enables translation to pyarrow date types
pyarrow.Table.from_pandas(df)
#> pyarrow.Table
col_date: date32[day]
----
col_date: [[2022-01-01]]
```