### PR TITLE
Update strict type-hints

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -198,7 +198,7 @@ jobs:
           CI_MODIN_ENGINES: ray
 
       - name: Upload coverage to Codecov
-        uses: "codecov/codecov-action@v1"
+        uses: codecov/codecov-action@v3
 
       - name: Check Docstrings
         if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}

--- a/pandera/schema_components.py
+++ b/pandera/schema_components.py
@@ -15,6 +15,7 @@ from .schemas import (
     DataFrameSchema,
     PandasDtypeInputTypes,
     SeriesSchemaBase,
+    StrictType,
 )
 
 
@@ -456,8 +457,8 @@ class MultiIndex(DataFrameSchema):
         self,
         indexes: List[Index],
         coerce: bool = False,
-        strict: bool = False,
-        name: str = None,
+        strict: StrictType = False,
+        name: Optional[str] = None,
         ordered: bool = True,
         unique: Optional[Union[str, List[str]]] = None,
     ) -> None:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -15,6 +15,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -62,6 +63,8 @@ PandasDtypeInputTypes = Union[
     None,
 ]
 
+StrictType = Union[bool, Literal["filter"]]
+
 TSeriesSchemaBase = TypeVar("TSeriesSchemaBase", bound="SeriesSchemaBase")
 
 
@@ -94,7 +97,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         index=None,
         dtype: PandasDtypeInputTypes = None,
         coerce: bool = False,
-        strict: Union[bool, str] = False,
+        strict: StrictType = False,
         name: Optional[str] = None,
         ordered: bool = False,
         unique: Optional[Union[str, List[str]]] = None,
@@ -181,7 +184,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         self.checks: CheckListProperty = checks
         self.index = index
-        self.strict: Union[bool, str] = strict
+        self.strict: StrictType = strict
         self.name: Optional[str] = name
         self.dtype: PandasDtypeInputTypes = dtype  # type: ignore
         self._coerce = coerce

--- a/pandera/typing/config.py
+++ b/pandera/typing/config.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from ..schemas import PandasDtypeInputTypes
+from ..schemas import PandasDtypeInputTypes, StrictType
 from .formats import Format
 
 
@@ -26,7 +26,7 @@ class BaseConfig:  # pylint:disable=R0903
 
     #: make sure all specified columns are in the validated dataframe -
     #: if ``"filter"``, removes columns not specified in the schema
-    strict: Union[bool, str] = False
+    strict: StrictType = False
 
     ordered: bool = False  #: validate columns order
     multiindex_name: Optional[str] = None  #: name of multiindex
@@ -36,7 +36,7 @@ class BaseConfig:  # pylint:disable=R0903
 
     #: make sure all specified columns are in validated MultiIndex -
     #: if ``"filter"``, removes indexes not specified in the schema
-    multiindex_strict: bool = False
+    multiindex_strict: StrictType = False
 
     #: validate MultiIndex in order
     multiindex_ordered: bool = True

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -145,7 +145,7 @@ def test_dataframe_schema_strict() -> None:
                 "a": Column(int, nullable=True),
                 "b": Column(int, nullable=True),
             },
-            strict="foobar",
+            strict="foobar",  # type: ignore[arg-type]
         )
 
     with pytest.raises(errors.SchemaError):


### PR DESCRIPTION
This PR closes #897 

* `StrictType = Union[bool, typing.Literal["filter"]]` added and used as type-hint for `strict` and `multiindex_strict` arguments.
* Although `strict="foobar"` it is being passed into a test that is supposed to fail, I [had to use type: ignore statement](https://github.com/the-matt-morris/pandera/blob/6f514fcfd3b75ee1728adafeefdb3e684e541c30/tests/core/test_schemas.py#L148) to ensure mypy can pass, given that `Literal["filter"]` is being used instead of `str`.  Might consider [using pydantic.validate_arguments](https://github.com/unionai-oss/pandera/issues/897#issuecomment-1197098473) in future, which could remove the necessity for this test and other places where validation is performed on the value of `strict`.