### PR TITLE
fix strategies ci

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -93,6 +93,11 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10"]
         pandas-version: ["1.2.0", "1.3.0", "latest"]
+        exclude:
+        - python-version: "3.10"
+          pandas-version: "1.2.0"
+        - python-version: "3.10"
+          pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest
           pip-cache: ~/.cache/pip
@@ -133,9 +138,16 @@ jobs:
           channel-priority: flexible
           use-only-tar-bz2: true
 
-      - name: Install deps
+      - name: Install Conda Deps [Latest]
+        if: ${{ matrix.pandas-version == 'latest' }}
+        run: mamba install -c conda-forge pandas geopandas
+
+      - name: Install Conda Deps
+        if: ${{ matrix.pandas-version != 'latest' }}
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
+
+      - name: Install Pip Deps
         run: |
-          mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
           python -m pip install -U pip
           python -m pip install -r requirements-dev.txt
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,9 +135,8 @@ jobs:
 
       - name: Install deps
         run: |
-          mamba install -c conda-forge geopandas
+          mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
           python -m pip install -U pip
-          python -m pip install pandas==${{ matrix.pandas-version }}
           python -m pip install -r requirements-dev.txt
 
       - run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ correctness.*
 [![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/12)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Documentation Status](https://readthedocs.org/projects/pandera/badge/?version=latest)](https://pandera.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/pandera-dev/pandera/branch/master/graph/badge.svg)](https://codecov.io/gh/pandera-dev/pandera)
+[![codecov](https://codecov.io/gh/unionai-oss/pandera/branch/master/graph/badge.svg)](https://codecov.io/gh/pandera-dev/pandera)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/pandera.svg)](https://pypi.python.org/pypi/pandera/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3385265.svg)](https://doi.org/10.5281/zenodo.3385265)
 [![asv](http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat)](https://pandera-dev.github.io/pandera-asv-logs/)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,8 +35,8 @@ correctness.*
     :target: https://pandera.readthedocs.io/en/stable/?badge=latest
     :alt: Documentation Latest Status
 
-.. image:: https://codecov.io/gh/pandera-dev/pandera/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/pandera-dev/pandera
+.. image:: https://codecov.io/gh/unionai-oss/pandera/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/unionai-oss/pandera
     :alt: Code Coverage
 
 .. image:: https://img.shields.io/pypi/pyversions/pandera.svg

--- a/pandera/strategies.py
+++ b/pandera/strategies.py
@@ -213,8 +213,10 @@ def register_check_strategy(strategy_fn: StrategyFn):
 # pylint: disable=line-too-long
 # Values taken from
 # https://hypothesis.readthedocs.io/en/latest/_modules/hypothesis/extra/numpy.html#from_dtype  # noqa
-MIN_DT_VALUE = -(2**63)
-MAX_DT_VALUE = 2**63 - 1
+# NOTE: We're reducing the range here by an order of magnitude to avoid overflows
+# when synthesizing timezone-aware timestamps.
+MIN_DT_VALUE = -(2**62) + 1
+MAX_DT_VALUE = 2**62 - 1
 
 
 def _is_datetime_tz(pandera_dtype: DataType) -> bool:
@@ -225,7 +227,6 @@ def _is_datetime_tz(pandera_dtype: DataType) -> bool:
 def _datetime_strategy(
     dtype: Union[np.dtype, pd.DatetimeTZDtype], strategy
 ) -> SearchStrategy:
-
     if isinstance(dtype, pd.DatetimeTZDtype):
 
         def _to_datetime(value) -> pd.DatetimeTZDtype:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,23 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=40, deadline=None)
-    settings.register_profile("dev", max_examples=20, deadline=None)
+
+    suppressed_health_checks = [
+        hypothesis.HealthCheck.data_too_large,
+        hypothesis.HealthCheck.too_slow,
+        hypothesis.HealthCheck.filter_too_much,
+    ]
+
+    settings.register_profile(
+        "ci",
+        max_examples=40,
+        deadline=None,
+        suppress_health_check=suppressed_health_checks,
+    )
+    settings.register_profile(
+        "dev",
+        max_examples=20,
+        deadline=None,
+        suppress_health_check=suppressed_health_checks,
+    )
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,6 @@ collect_ignore = []
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:
-    settings.register_profile("ci", max_examples=20, deadline=None)
-    settings.register_profile("dev", max_examples=10, deadline=None)
+    settings.register_profile("ci", max_examples=40, deadline=None)
+    settings.register_profile("dev", max_examples=20, deadline=None)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -157,7 +157,14 @@ def test_dataframe_schema_dtypes(
             "module"
         )
 
-    schema = pa.DataFrameSchema({"column": pa.Column(dtype_cls)})
+    checks = None
+    if dtypes.is_string(dtype_cls):
+        # there's an issue generating data in pyspark with string dtypes having
+        # to do with encoding utf-8 characters... therefore this test restricts
+        # the generated strings to alphanumaric characters
+        checks = [pa.Check.str_matches("[0-9a-z]")]
+
+    schema = pa.DataFrameSchema({"column": pa.Column(dtype_cls, checks)})
     schema.coerce = coerce
     _test_datatype_with_schema(dtype_cls, schema, data)
 

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -214,12 +214,19 @@ def test_index_dtypes(
             "pyspark.pandas cannot coerce a DateTime index to datetime."
         )
 
+    # there's an issue generating index strategies with string dtypes having to
+    # do with encoding utf-8 characters... therefore this test restricts the
+    # generated strings to alphanumaric characters
+    check = None
+    if dtype is str:
+        check = pa.Check.str_matches("[0-9a-z]")
+
     if schema_cls is pa.Index:
-        schema = schema_cls(dtype, name="field")
+        schema = schema_cls(dtype, name="field", checks=check)
         schema.coerce = coerce
     else:
         schema = schema_cls(
-            indexes=[pa.Index(dtype, name="field")], coerce=True
+            indexes=[pa.Index(dtype, name="field", checks=check)], coerce=True
         )
     sample = data.draw(schema.strategy(size=3))
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -979,7 +979,8 @@ def test_datetime_tz_example(dtype, check_arg, data) -> None:
             checks=checks,
             name="test_datetime_tz",
         )
-        column_schema(data.draw(column_schema.strategy()))
+        synth_data = data.draw(column_schema.strategy())
+        column_schema(synth_data)
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -85,13 +85,6 @@ def test_unsupported_pandas_dtype_strategy(data_type):
 
 @pytest.mark.parametrize("data_type", SUPPORTED_DTYPES)
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[
-        hypothesis.HealthCheck.too_slow,
-        hypothesis.HealthCheck.data_too_large,
-    ],
-    max_examples=20,
-)
 def test_pandas_dtype_strategy(data_type, data):
     """Test that series can be constructed from pandas dtype."""
 
@@ -112,9 +105,6 @@ def test_pandas_dtype_strategy(data_type, data):
 
 @pytest.mark.parametrize("data_type", NUMERIC_DTYPES)
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_check_strategy_continuous(data_type, data):
     """Test built-in check strategies can generate continuous data."""
     np_dtype = strategies.to_numpy_dtype(data_type)
@@ -179,9 +169,6 @@ def value_ranges(data_type: pa.DataType):
     ],
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_check_strategy_chained_continuous(
     data_type, strat_fn, arg_name, base_st_type, compare_op, data
 ):
@@ -225,9 +212,6 @@ def test_check_strategy_chained_continuous(
 @pytest.mark.parametrize("data_type", NUMERIC_DTYPES)
 @pytest.mark.parametrize("chained", [True, False])
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_in_range_strategy(data_type, chained, data):
     """Test the built-in in-range strategy can correctly generate data."""
     min_value, max_value = data.draw(value_ranges(data_type))
@@ -266,9 +250,6 @@ def test_in_range_strategy(data_type, chained, data):
 )
 @pytest.mark.parametrize("chained", [True, False])
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_isin_notin_strategies(data_type, chained, data):
     """Test built-in check strategies that rely on discrete values."""
     value_st = strategies.pandas_dtype_strategy(
@@ -360,7 +341,6 @@ def test_str_pattern_checks(
         .filter(lambda x: x[0] < x[1])  # type: ignore
     ),
 )
-@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
 def test_str_length_checks(chained, data, value_range):
     """Test built-in check strategies for string length."""
     min_value, max_value = value_range
@@ -450,9 +430,6 @@ def test_register_check_strategy_exception() -> None:
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_series_strategy(data) -> None:
     """Test SeriesSchema strategy."""
     series_schema = pa.SeriesSchema(pa.Int(), pa.Check.gt(0))
@@ -467,9 +444,6 @@ def test_series_example() -> None:
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_column_strategy(data) -> None:
     """Test Column schema strategy."""
     column_schema = pa.Column(pa.Int(), pa.Check.gt(0), name="column")
@@ -486,7 +460,6 @@ def test_column_example():
 @pytest.mark.parametrize("data_type", SUPPORTED_DTYPES)
 @pytest.mark.parametrize("size", [None, 0, 1, 3, 5])
 @hypothesis.given(st.data())
-@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
 def test_dataframe_strategy(data_type, size, data):
     """Test DataFrameSchema strategy."""
     dataframe_schema = pa.DataFrameSchema(
@@ -509,7 +482,6 @@ def test_dataframe_strategy(data_type, size, data):
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
 def test_dataframe_example(data) -> None:
     """Test DataFrameSchema example method generate examples that pass."""
     schema = pa.DataFrameSchema({"column": pa.Column(int, pa.Check.gt(0))})
@@ -519,7 +491,6 @@ def test_dataframe_example(data) -> None:
 
 @pytest.mark.parametrize("size", [3, 5, 10])
 @hypothesis.given(st.data())
-@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
 def test_dataframe_unique(size, data) -> None:
     """Test that DataFrameSchemas with unique columns are actually unique."""
     schema = pa.DataFrameSchema(
@@ -544,9 +515,6 @@ def test_dataframe_unique(size, data) -> None:
     ],
 )
 @hypothesis.given(st.data(), st.integers(min_value=-5, max_value=5))
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_dataframe_with_regex(regex: str, data, n_regex_columns: int) -> None:
     """Test DataFrameSchema strategy with regex columns"""
     dataframe_schema = pa.DataFrameSchema({regex: pa.Column(int, regex=True)})
@@ -565,9 +533,6 @@ def test_dataframe_with_regex(regex: str, data, n_regex_columns: int) -> None:
 
 
 @pytest.mark.parametrize("data_type", NUMERIC_DTYPES)
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 @hypothesis.given(st.data())
 def test_dataframe_checks(data_type, data):
     """Test dataframe strategy with checks defined at the dataframe level."""
@@ -585,9 +550,6 @@ def test_dataframe_checks(data_type, data):
     "data_type", [pa.Int(), pa.Float, pa.String, pa.DateTime]
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_dataframe_strategy_with_indexes(data_type, data):
     """Test dataframe strategy with index and multiindex components."""
     dataframe_schema_index = pa.DataFrameSchema(index=pa.Index(data_type))
@@ -604,9 +566,6 @@ def test_dataframe_strategy_with_indexes(data_type, data):
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_index_strategy(data) -> None:
     """Test Index schema component strategy."""
     data_type = pa.Int()
@@ -631,9 +590,6 @@ def test_index_example() -> None:
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_multiindex_strategy(data) -> None:
     """Test MultiIndex schema component strategy."""
     data_type = pa.Float()
@@ -699,9 +655,6 @@ def test_field_element_strategy(data_type, data):
 )
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_check_nullable_field_strategy(
     data_type, field_strategy, nullable, data
 ):
@@ -719,9 +672,6 @@ def test_check_nullable_field_strategy(
 @pytest.mark.parametrize("data_type", NULLABLE_DTYPES)
 @pytest.mark.parametrize("nullable", [True, False])
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_check_nullable_dataframe_strategy(data_type, nullable, data):
     """Test strategies for generating nullable DataFrame data."""
     size = 5
@@ -760,12 +710,6 @@ def test_check_nullable_dataframe_strategy(data_type, nullable, data):
             ),
             "Vectorized",
         ],
-    ],
-)
-@hypothesis.settings(
-    suppress_health_check=[
-        hypothesis.HealthCheck.filter_too_much,
-        hypothesis.HealthCheck.too_slow,
     ],
 )
 @hypothesis.given(st.data())
@@ -833,12 +777,6 @@ def test_series_strategy_undefined_check_strategy(
         ],
     ],
 )
-@hypothesis.settings(
-    suppress_health_check=[
-        hypothesis.HealthCheck.filter_too_much,
-        hypothesis.HealthCheck.too_slow,
-    ],
-)
 @hypothesis.given(st.data())
 def test_dataframe_strategy_undefined_check_strategy(
     schema: pa.DataFrameSchema, warning: str, data
@@ -873,9 +811,6 @@ class Schema(pa.SchemaModel):
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_schema_model_strategy(data) -> None:
     """Test that strategy can be created from a SchemaModel."""
     strat = Schema.strategy(size=10)
@@ -884,9 +819,6 @@ def test_schema_model_strategy(data) -> None:
 
 
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_schema_model_strategy_df_check(data) -> None:
     """Test that schema with custom checks produce valid data."""
 
@@ -928,9 +860,6 @@ def test_schema_component_with_no_pdtype() -> None:
     "check_arg", [pd.Timestamp("2006-01-01"), np.datetime64("2006-01-01")]
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_datetime_example(check_arg, data) -> None:
     """Test Column schema example method generate examples of
     timezone-naive datetimes that pass."""
@@ -962,9 +891,6 @@ def test_datetime_example(check_arg, data) -> None:
     ],
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_datetime_tz_example(dtype, check_arg, data) -> None:
     """Test Column schema example method generate examples of
     timezone-aware datetimes that pass."""
@@ -1023,9 +949,6 @@ def test_datetime_tz_example(dtype, check_arg, data) -> None:
     ],
 )
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_timedelta(dtype, check_arg, data):
     """
     Test Column schema example method generate examples of timedeltas
@@ -1048,9 +971,6 @@ def test_timedelta(dtype, check_arg, data):
 
 @pytest.mark.parametrize("dtype", [int, float, str])
 @hypothesis.given(st.data())
-@hypothesis.settings(
-    suppress_health_check=[hypothesis.HealthCheck.too_slow],
-)
 def test_empty_nullable_schema(dtype, data):
     """Test that empty nullable schema strategy draws empty examples."""
     schema = pa.DataFrameSchema({"myval": pa.Column(dtype, nullable=True)})


### PR DESCRIPTION
This PR addresses an issue in the `synthesis` module having to do with timestamp overflows. This was due to the fact that we're building timestamps based on nanosecond-scale integer values, which works fine for timezone-unaware timestamps, but for timezone-aware timestamps this causes overflow and underflow issues.

This fix in this PR is to reduce the min and max range of timestamps in the data synthesis module.

unblocks all the PRs currently waiting to be merged, e.g. #898 #877 #887