### PR TITLE
`ExtensionDtype` path should follow documentation

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -58,7 +58,7 @@ PandasDtypeInputTypes = Union[
     type,
     DataType,
     Type,
-    pd.core.dtypes.base.ExtensionDtype,
+    pd.api.extensions.ExtensionDtype,
     np.dtype,
     None,
 ]


### PR DESCRIPTION
Since at least `pandas==1.2.0`, one can access `ExtensionDtype` via `pandas.api.extensions`. See [here](https://github.com/pandas-dev/pandas/blob/3e89b4c4b1580aa890023fc550774e63d499da25/pandas/api/extensions/__init__.py#L19). This is what `pandas` has on their [documentation](https://pandas.pydata.org/docs/reference/api/pandas.api.extensions.ExtensionDtype.html#pandas.api.extensions.ExtensionDtype). Moreover, as of at least `pandas==1.4.3`, [importing from `pandas.core` will no long satisfy static type checkers](https://github.com/pandas-dev/pandas/blob/96fe05979c13ef4575faaf65c673016e3432c175/pandas/__init__.py).
