### PR TITLE
pin pandas-stubs version, bump mypy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pydantic
 
   # mypy extra
-  - pandas-stubs
+  - pandas-stubs <= 1.4.3.220807
   - pyspark-stubs
 
   # pyspark extra
@@ -48,7 +48,7 @@ dependencies:
   # testing
   - isort >= 5.7.0
   - codecov
-  - mypy <= 0.921
+  - mypy <= 0.971
   - pylint = 2.12.2
   - pytest
   - pytest-cov

--- a/pandera/checks.py
+++ b/pandera/checks.py
@@ -70,7 +70,7 @@ class _CheckMeta(type):  # pragma: no cover
 
     def __getattr__(cls, name: str) -> Any:
         """Prevent attribute errors for registered checks."""
-        attr = ChainMap(cls.__dict__, cls.REGISTERED_CUSTOM_CHECKS).get(name)
+        attr = ChainMap(cls.__dict__, cls.REGISTERED_CUSTOM_CHECKS).get(name)  # type: ignore
         if attr is None:
             raise AttributeError(
                 f"'{cls}' object has no attribute '{name}'. "

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ typing_extensions >= 3.7.4.3
 frictionless
 pyarrow
 pydantic
-pandas-stubs
+pandas-stubs <= 1.4.3.220807
 pyspark-stubs
 pyspark >= 3.2.0
 modin
@@ -27,7 +27,7 @@ fastapi
 black >= 22.1.0
 isort >= 5.7.0
 codecov
-mypy <= 0.921
+mypy <= 0.971
 pylint == 2.12.2
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _extras_require = {
     "modin-ray": ["modin", "ray <= 1.7.0"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
-    "mypy": ["pandas-stubs"],
+    "mypy": ["pandas-stubs <= 1.4.3.220807"],
     "fastapi": ["fastapi"],
     "geopandas": ["geopandas", "shapely"],
 }

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -153,7 +153,7 @@ def value_ranges(data_type: pa.DataType):
             ),
         )
         .map(sorted)
-        .filter(lambda x: x[0] < x[1])
+        .filter(lambda x: x[0] < x[1])  # type: ignore
     )
 
 


### PR DESCRIPTION
as of this commit, the latest version of `pandas-stubs == 1.4.3.220915`
causes a breaking change when using `pandera.typing.DataFrame[Schema]`
to initialize validated dataframes. The issue is tracked in the
pandas-stubs repo: https://github.com/pandas-dev/pandas-stubs/issues/197

In the mean time, we pin the pandas-stubs to the previous available
version, where this doesn't show up.

Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>