### PR TITLE
De/serializate data frame schema to/from JSON

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -148,6 +148,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -r requirements-dev.txt
+          python -m pip install bokeh
 
       - run: |
           conda info

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -239,11 +239,101 @@ is a convenience method for this functionality.
     unique: null
     ordered: false
 
-You can edit this yaml file by specifying column names under the ``column``
-key. The respective values map onto key-word arguments in the
-:class:`~pandera.schema_components.Column` class.
+You can edit this yaml file to modify the schema. For example, you can specify
+new column names under the ``column`` key, and the respective values map onto
+key-word arguments in the :class:`~pandera.schema_components.Column` class.
 
 .. note::
 
    Currently, only built-in :class:`~pandera.checks.Check` methods are supported under the
    ``checks`` key.
+
+
+Write to JSON
+~~~~~~~~~~~~~
+
+Finally, you can also write the schema object to a json file with :func:`~pandera.io.to_json`,
+and you can then read it into memory with :func:`~pandera.io.from_json`. The
+:func:`~pandera.schemas.DataFrameSchema.to_json` and :func:`~pandera.schemas.DataFrameSchema.from_json`
+is a convenience method for this functionality.
+
+.. testcode:: infer_dataframe_schema
+   :skipif: SKIP
+
+   # supply a file-like object, Path, or str to write to a file. If not
+   # specified, to_yaml will output a yaml string.
+   json_schema = schema.to_json(indent=4)
+   print(json_schema.replace(f"{pa.__version__}", "{PANDERA_VERSION}"))
+
+.. testoutput:: infer_dataframe_schema
+   :skipif: SKIP
+
+    {
+        "schema_type": "dataframe",
+        "version": "{PANDERA_VERSION}",
+        "columns": {
+            "column1": {
+                "title": null,
+                "description": null,
+                "dtype": "int64",
+                "nullable": false,
+                "checks": {
+                    "greater_than_or_equal_to": 5.0,
+                    "less_than_or_equal_to": 20.0
+                },
+                "unique": false,
+                "coerce": false,
+                "required": true,
+                "regex": false
+            },
+            "column2": {
+                "title": null,
+                "description": null,
+                "dtype": "object",
+                "nullable": false,
+                "checks": null,
+                "unique": false,
+                "coerce": false,
+                "required": true,
+                "regex": false
+            },
+            "column3": {
+                "title": null,
+                "description": null,
+                "dtype": "datetime64[ns]",
+                "nullable": false,
+                "checks": {
+                    "greater_than_or_equal_to": "2010-01-01 00:00:00",
+                    "less_than_or_equal_to": "2012-01-01 00:00:00"
+                },
+                "unique": false,
+                "coerce": false,
+                "required": true,
+                "regex": false
+            }
+        },
+        "checks": null,
+        "index": [
+            {
+                "title": null,
+                "description": null,
+                "dtype": "int64",
+                "nullable": false,
+                "checks": {
+                    "greater_than_or_equal_to": 0.0,
+                    "less_than_or_equal_to": 2.0
+                },
+                "name": null,
+                "unique": false,
+                "coerce": false
+            }
+        ],
+        "coerce": true,
+        "strict": false,
+        "unique": null,
+        "ordered": false
+    }
+
+You can edit this json file to update the schema as needed, and then load
+it back into a pandera schema object with :func:`~pandera.io.from_json` or
+:func:`~pandera.schemas.DataFrameSchema.from_json`.

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -279,37 +279,37 @@ def deserialize_schema(serialized_schema):
     )
 
 
-def from_yaml(source):
+def from_yaml(yaml_schema):
     """Create :class:`~pandera.schemas.DataFrameSchema` from yaml file.
 
-    :param source: str or Path to yaml schema, or serialized yaml string.
+    :param yaml_schema: str or Path to yaml schema, or serialized yaml string.
     :returns: dataframe schema.
     """
     try:
-        with Path(source).open("r", encoding="utf-8") as f:
+        with Path(yaml_schema).open("r", encoding="utf-8") as f:
             serialized_schema = yaml.safe_load(f)
     except (TypeError, OSError):
-        serialized_schema = yaml.safe_load(source)
+        serialized_schema = yaml.safe_load(yaml_schema)
     return deserialize_schema(serialized_schema)
 
 
-def to_yaml(dataframe_schema, target=None):
+def to_yaml(dataframe_schema, stream=None):
     """Write :class:`~pandera.schemas.DataFrameSchema` to yaml file.
 
     :param dataframe_schema: schema to write to file or dump to string.
-    :param target: file stream to write to. If None, dumps to string.
+    :param stream: file stream to write to. If None, dumps to string.
     :returns: yaml string if stream is None, otherwise returns None.
     """
     statistics = serialize_schema(dataframe_schema)
 
-    def _write_yaml(obj, target):
-        return yaml.safe_dump(obj, stream=target, sort_keys=False)
+    def _write_yaml(obj, stream):
+        return yaml.safe_dump(obj, stream=stream, sort_keys=False)
 
     try:
-        with Path(target).open("w", encoding="utf-8") as f:
+        with Path(stream).open("w", encoding="utf-8") as f:
             _write_yaml(statistics, f)
     except (TypeError, OSError):
-        return _write_yaml(statistics, target)
+        return _write_yaml(statistics, stream)
 
 
 def from_json(source):

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -312,12 +312,12 @@ def to_yaml(dataframe_schema, stream=None):
         return _write_yaml(statistics, stream)
 
 
-def from_json(source):
+def from_json(json_schema):
     """
     Create :class:`~pandera.schemas.DataFrameSchema` from json file.
 
-    :param source:
-        Depending on the type, the source is assumed to be:
+    :param json_schema:
+        Depending on the type, json_schema is assumed to be:
 
         1) str or Path to a file containing json schema (if the file exists),
         2) str as a JSON-encoded schema, or
@@ -326,41 +326,41 @@ def from_json(source):
 
     :returns: dataframe schema.
     """
-    if isinstance(source, str):
-        pth = Path(source)
-        if pth.exists() and pth.is_file():
-            with pth.open(encoding="utf-8") as f:
+    if isinstance(json_schema, str):
+        try:
+            serialized_schema = json.loads(json_schema)
+        except json.decoder.JSONDecodeError:
+            with Path(json_schema).open(encoding="utf-8") as f:
                 serialized_schema = json.load(fp=f)
-        else:
-            serialized_schema = json.loads(source)
-    elif isinstance(source, Path):
-        with source.open(encoding="utf-8") as f:
+    elif isinstance(json_schema, Path):
+        with json_schema.open(encoding="utf-8") as f:
             serialized_schema = json.load(fp=f)
     else:
-        serialized_schema = json.load(fp=source)
+        serialized_schema = json.load(fp=json_schema)
 
     return deserialize_schema(serialized_schema)
 
 
-def to_json(dataframe_schema, target=None):
+def to_json(dataframe_schema, stream=None, **kwargs):
     """
     Write :class:`~pandera.schemas.DataFrameSchema` to json file.
 
     :param dataframe_schema: schema to write to file or dump to string.
-    :param target:
+    :param stream:
         file path or stream to write to. If None, returns a dump to string.
+    :param kwargs: keyword arguments to pass into :func:`json.dump`
     :returns: json string if stream is None, otherwise returns None.
     """
     serialized_schema = serialize_schema(dataframe_schema)
 
-    if target is None:
-        return json.dumps(serialized_schema, sort_keys=False)
+    if stream is None:
+        return json.dumps(serialized_schema, sort_keys=False, **kwargs)
 
-    if isinstance(target, (str, Path)):
-        with Path(target).open("w", encoding="utf-8") as f:
-            json.dump(serialized_schema, fp=f, sort_keys=False)
+    if isinstance(stream, (str, Path)):
+        with Path(stream).open("w", encoding="utf-8") as f:
+            json.dump(serialized_schema, fp=f, sort_keys=False, **kwargs)
     else:
-        json.dump(serialized_schema, fp=target, sort_keys=False)
+        json.dump(serialized_schema, fp=stream, sort_keys=False, **kwargs)
 
 
 SCRIPT_TEMPLATE = """

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -279,45 +279,45 @@ def deserialize_schema(serialized_schema):
     )
 
 
-def from_yaml(yaml_schema):
+def from_yaml(source):
     """Create :class:`~pandera.schemas.DataFrameSchema` from yaml file.
 
-    :param yaml_schema: str or Path to yaml schema, or serialized yaml string.
+    :param source: str or Path to yaml schema, or serialized yaml string.
     :returns: dataframe schema.
     """
     try:
-        with Path(yaml_schema).open("r", encoding="utf-8") as f:
+        with Path(source).open("r", encoding="utf-8") as f:
             serialized_schema = yaml.safe_load(f)
     except (TypeError, OSError):
-        serialized_schema = yaml.safe_load(yaml_schema)
+        serialized_schema = yaml.safe_load(source)
     return deserialize_schema(serialized_schema)
 
 
-def to_yaml(dataframe_schema, stream=None):
+def to_yaml(dataframe_schema, target=None):
     """Write :class:`~pandera.schemas.DataFrameSchema` to yaml file.
 
     :param dataframe_schema: schema to write to file or dump to string.
-    :param stream: file stream to write to. If None, dumps to string.
+    :param target: file stream to write to. If None, dumps to string.
     :returns: yaml string if stream is None, otherwise returns None.
     """
     statistics = serialize_schema(dataframe_schema)
 
-    def _write_yaml(obj, stream):
-        return yaml.safe_dump(obj, stream=stream, sort_keys=False)
+    def _write_yaml(obj, target):
+        return yaml.safe_dump(obj, stream=target, sort_keys=False)
 
     try:
-        with Path(stream).open("w", encoding="utf-8") as f:
+        with Path(target).open("w", encoding="utf-8") as f:
             _write_yaml(statistics, f)
     except (TypeError, OSError):
-        return _write_yaml(statistics, stream)
+        return _write_yaml(statistics, target)
 
 
-def from_json(json_schema):
+def from_json(source):
     """
     Create :class:`~pandera.schemas.DataFrameSchema` from json file.
 
-    :param json_schema:
-        Depending on the type, json_schema is assumed to be:
+    :param source:
+        Depending on the type, source is assumed to be:
 
         1) str or Path to a file containing json schema (if the file exists),
         2) str as a JSON-encoded schema, or
@@ -326,41 +326,41 @@ def from_json(json_schema):
 
     :returns: dataframe schema.
     """
-    if isinstance(json_schema, str):
+    if isinstance(source, str):
         try:
-            serialized_schema = json.loads(json_schema)
+            serialized_schema = json.loads(source)
         except json.decoder.JSONDecodeError:
-            with Path(json_schema).open(encoding="utf-8") as f:
+            with Path(source).open(encoding="utf-8") as f:
                 serialized_schema = json.load(fp=f)
-    elif isinstance(json_schema, Path):
-        with json_schema.open(encoding="utf-8") as f:
+    elif isinstance(source, Path):
+        with source.open(encoding="utf-8") as f:
             serialized_schema = json.load(fp=f)
     else:
-        serialized_schema = json.load(fp=json_schema)
+        serialized_schema = json.load(fp=source)
 
     return deserialize_schema(serialized_schema)
 
 
-def to_json(dataframe_schema, stream=None, **kwargs):
+def to_json(dataframe_schema, target=None, **kwargs):
     """
     Write :class:`~pandera.schemas.DataFrameSchema` to json file.
 
     :param dataframe_schema: schema to write to file or dump to string.
-    :param stream:
-        file path or stream to write to. If None, returns a dump to string.
+    :param target: file path or stream to write to. If None, returns a
+        dump to string.
     :param kwargs: keyword arguments to pass into :func:`json.dump`
     :returns: json string if stream is None, otherwise returns None.
     """
     serialized_schema = serialize_schema(dataframe_schema)
 
-    if stream is None:
+    if target is None:
         return json.dumps(serialized_schema, sort_keys=False, **kwargs)
 
-    if isinstance(stream, (str, Path)):
-        with Path(stream).open("w", encoding="utf-8") as f:
+    if isinstance(target, (str, Path)):
+        with Path(target).open("w", encoding="utf-8") as f:
             json.dump(serialized_schema, fp=f, sort_keys=False, **kwargs)
     else:
-        json.dump(serialized_schema, fp=stream, sort_keys=False, **kwargs)
+        json.dump(serialized_schema, fp=target, sort_keys=False, **kwargs)
 
 
 SCRIPT_TEMPLATE = """

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1399,14 +1399,20 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         return pandera.io.from_json(json_schema)
 
     @overload
-    def to_json(self, stream: None = None) -> str:  # pragma: no cover
+    def to_json(
+        self, stream: None = None, **kwargs
+    ) -> str:  # pragma: no cover
         ...
 
     @overload
-    def to_json(self, stream: os.PathLike) -> None:  # pragma: no cover
+    def to_json(
+        self, stream: os.PathLike, **kwargs
+    ) -> None:  # pragma: no cover
         ...
 
-    def to_json(self, stream: Optional[os.PathLike] = None) -> Optional[str]:
+    def to_json(
+        self, stream: Optional[os.PathLike] = None, **kwargs
+    ) -> Optional[str]:
         """Write DataFrameSchema to json file.
 
         :param stream: file stream to write to. If None, dumps to string.
@@ -1415,7 +1421,7 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.to_json(self, target=stream)
+        return pandera.io.to_json(self, stream=stream, **kwargs)
 
     def set_index(
         self, keys: List[str], drop: bool = True, append: bool = False

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1385,6 +1385,38 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
 
         return pandera.io.to_yaml(self, stream=stream)
 
+    @classmethod
+    def from_json(cls, json_schema) -> "DataFrameSchema":
+        """Create DataFrameSchema from json file.
+
+        :param json_schema: str, Path to json schema, or serialized yaml
+            string.
+        :returns: dataframe schema.
+        """
+        # pylint: disable=import-outside-toplevel,cyclic-import
+        import pandera.io
+
+        return pandera.io.from_json(json_schema)
+
+    @overload
+    def to_json(self, stream: None = None) -> str:  # pragma: no cover
+        ...
+
+    @overload
+    def to_json(self, stream: os.PathLike) -> None:  # pragma: no cover
+        ...
+
+    def to_json(self, stream: Optional[os.PathLike] = None) -> Optional[str]:
+        """Write DataFrameSchema to json file.
+
+        :param stream: file stream to write to. If None, dumps to string.
+        :returns: json string if stream is None, otherwise returns None.
+        """
+        # pylint: disable=import-outside-toplevel,cyclic-import
+        import pandera.io
+
+        return pandera.io.to_json(self, target=stream)
+
     def set_index(
         self, keys: List[str], drop: bool = True, append: bool = False
     ) -> Self:

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1354,37 +1354,37 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         return pandera.io.to_script(self, fp)
 
     @classmethod
-    def from_yaml(cls, source) -> "DataFrameSchema":
+    def from_yaml(cls, yaml_schema) -> "DataFrameSchema":
         """Create DataFrameSchema from yaml file.
 
-        :param source: str, Path to yaml schema, or serialized yaml
+        :param yaml_schema: str, Path to yaml schema, or serialized yaml
             string.
         :returns: dataframe schema.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.from_yaml(source)
+        return pandera.io.from_yaml(yaml_schema)
 
     @overload
-    def to_yaml(self, target: None = None) -> str:  # pragma: no cover
+    def to_yaml(self, stream: None = None) -> str:  # pragma: no cover
         ...
 
     @overload
-    def to_yaml(self, target: os.PathLike) -> None:  # pragma: no cover
+    def to_yaml(self, stream: os.PathLike) -> None:  # pragma: no cover
         ...
 
-    def to_yaml(self, target: Optional[os.PathLike] = None) -> Optional[str]:
+    def to_yaml(self, stream: Optional[os.PathLike] = None) -> Optional[str]:
         """Write DataFrameSchema to yaml file.
 
-        :param target: file path or stream to write to. If None, dumps
+        :param stream: file path or stream to write to. If None, dumps
             to string.
         :returns: yaml string if stream is None, otherwise returns None.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.to_yaml(self, target)
+        return pandera.io.to_yaml(self, stream)
 
     @classmethod
     def from_json(cls, source) -> "DataFrameSchema":

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1354,74 +1354,75 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
         return pandera.io.to_script(self, fp)
 
     @classmethod
-    def from_yaml(cls, yaml_schema) -> "DataFrameSchema":
+    def from_yaml(cls, source) -> "DataFrameSchema":
         """Create DataFrameSchema from yaml file.
 
-        :param yaml_schema: str, Path to yaml schema, or serialized yaml
+        :param source: str, Path to yaml schema, or serialized yaml
             string.
         :returns: dataframe schema.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.from_yaml(yaml_schema)
+        return pandera.io.from_yaml(source)
 
     @overload
-    def to_yaml(self, stream: None = None) -> str:  # pragma: no cover
+    def to_yaml(self, target: None = None) -> str:  # pragma: no cover
         ...
 
     @overload
-    def to_yaml(self, stream: os.PathLike) -> None:  # pragma: no cover
+    def to_yaml(self, target: os.PathLike) -> None:  # pragma: no cover
         ...
 
-    def to_yaml(self, stream: Optional[os.PathLike] = None) -> Optional[str]:
+    def to_yaml(self, target: Optional[os.PathLike] = None) -> Optional[str]:
         """Write DataFrameSchema to yaml file.
 
-        :param stream: file stream to write to. If None, dumps to string.
+        :param target: file path or stream to write to. If None, dumps
+            to string.
         :returns: yaml string if stream is None, otherwise returns None.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.to_yaml(self, stream=stream)
+        return pandera.io.to_yaml(self, target)
 
     @classmethod
-    def from_json(cls, json_schema) -> "DataFrameSchema":
+    def from_json(cls, source) -> "DataFrameSchema":
         """Create DataFrameSchema from json file.
 
-        :param json_schema: str, Path to json schema, or serialized yaml
+        :param source: str, Path to json schema, or serialized yaml
             string.
         :returns: dataframe schema.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.from_json(json_schema)
+        return pandera.io.from_json(source)
 
     @overload
     def to_json(
-        self, stream: None = None, **kwargs
+        self, target: None = None, **kwargs
     ) -> str:  # pragma: no cover
         ...
 
     @overload
     def to_json(
-        self, stream: os.PathLike, **kwargs
+        self, target: os.PathLike, **kwargs
     ) -> None:  # pragma: no cover
         ...
 
     def to_json(
-        self, stream: Optional[os.PathLike] = None, **kwargs
+        self, target: Optional[os.PathLike] = None, **kwargs
     ) -> Optional[str]:
         """Write DataFrameSchema to json file.
 
-        :param stream: file stream to write to. If None, dumps to string.
-        :returns: json string if stream is None, otherwise returns None.
+        :param target: file target to write to. If None, dumps to string.
+        :returns: json string if target is None, otherwise returns None.
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         import pandera.io
 
-        return pandera.io.to_json(self, stream=stream, **kwargs)
+        return pandera.io.to_json(self, target, **kwargs)
 
     def set_index(
         self, keys: List[str], drop: bool = True, append: bool = False

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -728,45 +728,45 @@ def test_io_json(index):
     with tempfile.TemporaryDirectory() as tmpdir:
         # Check Path
         pth = Path(tmpdir) / "something.json"
-        output = io.to_json(schema, stream=pth)
+        output = io.to_json(schema, pth)
         assert output is None
         schema_from_json = io.from_json(pth)
         assert schema_from_json == schema
 
         # DataFrameSchema method
-        output = schema.to_json(stream=pth)
+        output = schema.to_json(pth)
         assert output is None
         schema_from_json = schema.from_json(pth)
         assert schema_from_json == schema
 
         # Check path as string
-        output = io.to_json(schema, stream=str(pth))
+        output = io.to_json(schema, str(pth))
         assert output is None
         schema_from_json = io.from_json(str(pth))
         assert schema_from_json == schema
 
         # DataFrameSchema method
-        output = schema.to_json(stream=str(pth))
+        output = schema.to_json(str(pth))
         assert output is None
         schema_from_json = schema.from_json(pth)
         assert schema_from_json == schema
 
         # Check schema encoded as a string
-        text = io.to_json(schema, stream=None)
+        text = io.to_json(schema)
         assert text is not None
         assert isinstance(text, str)
         schema_from_json = io.from_json(text)
         assert schema_from_json == schema
 
         # DataFrameSchema method
-        text = schema.to_json(stream=None)
+        text = schema.to_json()
         assert text is not None
         schema_from_json = schema.from_json(text)
         assert schema_from_json == schema
 
         # Check schema encoded in a stream
         stream = StringIO()
-        output = io.to_json(schema, stream=stream)
+        output = io.to_json(schema, stream)
         assert output is None
         stream.seek(0)
         schema_from_json = io.from_json(stream)
@@ -774,7 +774,7 @@ def test_io_json(index):
 
         # DataFrameSchema method
         stream = StringIO()
-        output = schema.to_json(stream=stream)
+        output = schema.to_json(stream)
         assert output is None
         stream.seek(0)
         schema_from_json = schema.from_json(stream)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -728,19 +728,19 @@ def test_io_json(index):
     with tempfile.TemporaryDirectory() as tmpdir:
         # Check Path
         pth = Path(tmpdir) / "something.json"
-        output = io.to_json(schema, target=pth)
+        output = io.to_json(schema, stream=pth)
         assert output is None
         schema_from_json = io.from_json(pth)
         assert schema_from_json == schema
 
         # Check path as string
-        output = io.to_json(schema, target=str(pth))
+        output = io.to_json(schema, stream=str(pth))
         assert output is None
         schema_from_json = io.from_json(str(pth))
         assert schema_from_json == schema
 
         # Check schema encoded as a string
-        text = io.to_json(schema, target=None)
+        text = io.to_json(schema, stream=None)
         assert text is not None
         assert isinstance(text, str)
         schema_from_json = io.from_json(text)
@@ -748,7 +748,7 @@ def test_io_json(index):
 
         # Check schema encoded in a stream
         stream = StringIO()
-        output = io.to_json(schema, target=stream)
+        output = io.to_json(schema, stream=stream)
         assert output is None
         stream.seek(0)
         schema_from_json = io.from_json(stream)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -733,10 +733,22 @@ def test_io_json(index):
         schema_from_json = io.from_json(pth)
         assert schema_from_json == schema
 
+        # DataFrameSchema method
+        output = schema.to_json(stream=pth)
+        assert output is None
+        schema_from_json = schema.from_json(pth)
+        assert schema_from_json == schema
+
         # Check path as string
         output = io.to_json(schema, stream=str(pth))
         assert output is None
         schema_from_json = io.from_json(str(pth))
+        assert schema_from_json == schema
+
+        # DataFrameSchema method
+        output = schema.to_json(stream=str(pth))
+        assert output is None
+        schema_from_json = schema.from_json(pth)
         assert schema_from_json == schema
 
         # Check schema encoded as a string
@@ -746,12 +758,26 @@ def test_io_json(index):
         schema_from_json = io.from_json(text)
         assert schema_from_json == schema
 
+        # DataFrameSchema method
+        text = schema.to_json(stream=None)
+        assert text is not None
+        schema_from_json = schema.from_json(text)
+        assert schema_from_json == schema
+
         # Check schema encoded in a stream
         stream = StringIO()
         output = io.to_json(schema, stream=stream)
         assert output is None
         stream.seek(0)
         schema_from_json = io.from_json(stream)
+        assert schema_from_json == schema
+
+        # DataFrameSchema method
+        stream = StringIO()
+        output = schema.to_json(stream=stream)
+        assert output is None
+        stream.seek(0)
+        schema_from_json = schema.from_json(stream)
         assert schema_from_json == schema
 
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -2,6 +2,7 @@
 
 import platform
 import tempfile
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -701,7 +702,7 @@ def test_io_yaml_file_obj():
 )
 @pytest.mark.parametrize("index", ["single", "multi", None])
 def test_io_yaml(index):
-    """Test read and write operation on file names."""
+    """Test read and write operation on yaml strings, files and streams."""
     schema = _create_schema(index)
 
     # pass in a file name
@@ -717,6 +718,41 @@ def test_io_yaml(index):
         assert output is None
         schema_from_yaml = pandera.DataFrameSchema.from_yaml(Path(f.name))
         assert schema_from_yaml == schema
+
+
+@pytest.mark.parametrize("index", ["single", "multi", None])
+def test_io_json(index):
+    """Test read and write operation on json strings, files and streams."""
+    schema = _create_schema(index)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Check Path
+        pth = Path(tmpdir) / "something.json"
+        output = io.to_json(schema, target=pth)
+        assert output is None
+        schema_from_json = io.from_json(pth)
+        assert schema_from_json == schema
+
+        # Check path as string
+        output = io.to_json(schema, target=str(pth))
+        assert output is None
+        schema_from_json = io.from_json(str(pth))
+        assert schema_from_json == schema
+
+        # Check schema encoded as a string
+        text = io.to_json(schema, target=None)
+        assert text is not None
+        assert isinstance(text, str)
+        schema_from_json = io.from_json(text)
+        assert schema_from_json == schema
+
+        # Check schema encoded in a stream
+        stream = StringIO()
+        output = io.to_json(schema, target=stream)
+        assert output is None
+        stream.seek(0)
+        schema_from_json = io.from_json(stream)
+        assert schema_from_json == schema
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
* Make the de/serialization from/to JSON-able mappings public so that
  we allow for other JSON-like de/serializations in the future.
* Add functions for de/serializing the data frame schema to/from JSON
  files, streams and strings.

Note to future developers: it would make sense to refactor the tests so
that the de/serialization of JSON-able mappings is tested in isolation
to target format (at the moment: JSON and YAML). Currently, the tests
are coupled with the YAML format. The authors of this patch did not have
time cycles to refactor the tests, but there is no reason not to do it
(except for the lack of time).

Fixes #918.

Co-authored-by: Marko Ristin-Kaufmann <marko@ristin.ch>