### PR TITLE
update `rename_columns` not to error on `{key: key, ...}` `rename_dict`

### DIFF
--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1238,9 +1238,12 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 f"Keys {not_in_cols} not found in schema columns!"
             )
 
-        # ensure all new keys are not present in the current column names unless being mapped to the same key
+        # remove any mapping to itself as this is a no-op
+        rename_dict = {k: v for k, v in rename_dict.items() if k != v}
+
+        # ensure all new keys are not present in the current column names
         already_in_columns: List[str] = [
-            new for old, new in rename_dict.items() if new in new_schema.columns.keys() and old != new
+            x for x in rename_dict.values() if x in new_schema.columns.keys()
         ]
         if already_in_columns:
             raise errors.SchemaInitError(

--- a/pandera/schemas.py
+++ b/pandera/schemas.py
@@ -1238,9 +1238,9 @@ class DataFrameSchema:  # pylint: disable=too-many-public-methods
                 f"Keys {not_in_cols} not found in schema columns!"
             )
 
-        # ensure all new keys are not present in the current column names
+        # ensure all new keys are not present in the current column names unless being mapped to the same key
         already_in_columns: List[str] = [
-            x for x in rename_dict.values() if x in new_schema.columns.keys()
+            new for old, new in rename_dict.items() if new in new_schema.columns.keys() and old != new
         ]
         if already_in_columns:
             raise errors.SchemaInitError(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -993,6 +993,10 @@ def test_rename_columns() -> None:
         with pytest.raises(errors.SchemaInitError):
             schema_original.rename_columns(rename_dict)
 
+    # Test doesn't raise error if column maps to itself
+    rename_dict = {"col1": "col1", "col2": "col2_new_name"}
+    schema_original.rename_columns(rename_dict)
+
 
 @pytest.mark.parametrize(
     "select_columns, schema",


### PR DESCRIPTION
Closes https://github.com/unionai-oss/pandera/issues/940

I went with removing the no-op key, value pairs from `rename_dict`, but also previously had different logic when calculating `already_in_columns`. I thought my updated logic was cleaner, due to what then later happens inside of `new_columns`, and easier to read, but I don't feel particularly strongly about this. 