### PR TITLE
Bugfix/910

### DIFF
--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -237,6 +237,7 @@ is a convenience method for this functionality.
     coerce: true
     strict: false
     unique: null
+    ordered: false
 
 You can edit this yaml file by specifying column names under the ``column``
 key. The respective values map onto key-word arguments in the

--- a/pandera/io.py
+++ b/pandera/io.py
@@ -154,6 +154,7 @@ def _serialize_schema(dataframe_schema):
         "coerce": dataframe_schema.coerce,
         "strict": dataframe_schema.strict,
         "unique": dataframe_schema.unique,
+        "ordered": dataframe_schema.ordered,
     }
 
 
@@ -266,6 +267,7 @@ def _deserialize_schema(serialized_schema):
         coerce=serialized_schema.get("coerce", False),
         strict=serialized_schema.get("strict", False),
         unique=serialized_schema.get("unique", None),
+        ordered=serialized_schema.get("ordered", False),
     )
 
 


### PR DESCRIPTION
Closes #910 

The `ordered=True`  keyword gets lost when a schema is derived from a YAML definition or the other way around. This should fix that issue.

I've added the keywords to the `io.py` module and added also two tests which are testing that the keyword is still in use after the functions `from_yaml()` and `to_yaml()` are called.

The corresponding issue is linked to [#910](https://github.com/unionai-oss/pandera/issues/910)