### PR TITLE
Fix `infer_schema` for 'empty' dataframes

### DIFF
--- a/pandera/schema_statistics.py
+++ b/pandera/schema_statistics.py
@@ -182,7 +182,7 @@ def _get_array_type(x):
     data_type = pandas_engine.Engine.dtype(x.dtype)
     # for object arrays, try to infer dtype
     if data_type is pandas_engine.Engine.dtype("object"):
-        inferred_alias = pd.api.types.infer_dtype(x, skipna=True)
+        inferred_alias = pd.api.types.infer_dtype(x, skipna=False)
         if inferred_alias != "string":
             data_type = pandas_engine.Engine.dtype(inferred_alias)
     return data_type
@@ -192,6 +192,8 @@ def _get_array_check_statistics(
     x, data_type: dtypes.DataType
 ) -> Union[Dict[str, Any], None]:
     """Get check statistics from an array-like object."""
+    if x.isna().all():
+        return None
     if dtypes.is_datetime(data_type):
         check_stats = {
             "greater_than_or_equal_to": x.min(),

--- a/tests/core/test_schema_statistics.py
+++ b/tests/core/test_schema_statistics.py
@@ -168,8 +168,6 @@ def _test_statistics(statistics, expectations):
         expectation_dtype = expectation.pop("dtype")
 
         assert stats == expectation
-        print(expectation_dtype)
-        print(stat_dtype)
         assert expectation_dtype.check(stat_dtype)
 
 


### PR DESCRIPTION
solves #834

Tested locally with a latest pandas >1.3.0 release as well as pandas <1.3.0 to validate both behaviours.