### PR TITLE
fix modin tests

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -444,7 +444,7 @@ def _check_decimal(
 
     is_decimal = pandas_obj.apply(
         lambda x: isinstance(x, decimal.Decimal)
-    ).astype("boolean") | pd.isnull(pandas_obj)
+    ).astype("bool") | pd.isnull(pandas_obj)
 
     decimals = pandas_obj[is_decimal]
     # fix for modin unamed series raises KeyError

--- a/pandera/typing/modin.py
+++ b/pandera/typing/modin.py
@@ -2,15 +2,23 @@
 
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from packaging import version
+
 from .common import DataFrameBase, IndexBase, SeriesBase
 from .pandas import GenericDtype, Schema
 
 try:
+    import modin
     import modin.pandas as mpd
 
     MODIN_INSTALLED = True
 except ImportError:
     MODIN_INSTALLED = False
+
+
+def modin_version():
+    """Return the modin version."""
+    return version.parse(modin.__version__)
 
 
 # pylint:disable=invalid-name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.pyright]
 include = [ "pandera", "tests" ]
 exclude = [".nox/**", ".nox-*/**"]
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = 20

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -99,7 +99,6 @@ def test_logical_datatype_check(
     assert not any(
         cast(Iterable[bool], expected_datatype.check(SimpleDtype(), data))
     )
-    print(expected_datatype.check(SimpleDtype(), None))
     assert expected_datatype.check(SimpleDtype(), None) is False
 
     # No data container

--- a/tests/modin/test_schemas_on_modin.py
+++ b/tests/modin/test_schemas_on_modin.py
@@ -10,7 +10,7 @@ import pytest
 import pandera as pa
 from pandera import extensions
 from pandera.engines import numpy_engine, pandas_engine
-from pandera.typing.modin import DataFrame, Index, Series
+from pandera.typing.modin import DataFrame, Index, Series, modin_version
 from tests.strategies.test_strategies import NULLABLE_DTYPES
 from tests.strategies.test_strategies import (
     SUPPORTED_DTYPES as SUPPORTED_STRATEGY_DTYPES,
@@ -151,7 +151,7 @@ def test_index_dtypes(
         schema.coerce = coerce
     sample = data.draw(schema.strategy(size=3))
     # pandas (and modin) use object arrays to store boolean data
-    if dtype is bool:
+    if modin_version().release < (0, 16, 0) and dtype is bool:
         assert sample.dtype == "object"
         return
     assert isinstance(


### PR DESCRIPTION
This PR accounts for a change in modin 0.16.0, which now properly uses the boolean dtype to store boolean values in indexes, instead of the pre 0.16.0 behavior, where they were stored in object arrays.

Also, use `bool` instead of `boolean` in the _check_decimal pandas engine type checker. Since this is supposed to work with modin as well, better to use older API instead of pandas-native dtypes for pandera's internal operations.