### PR TITLE
Fix decimal

### DIFF
--- a/docs/source/dtypes.rst
+++ b/docs/source/dtypes.rst
@@ -201,17 +201,19 @@ underlying numpy dtype to coerce an individual value. The ``pandas`` -native
 datatypes like :class:`~pandas.CategoricalDtype` and :class:`~pandas.BooleanDtype`
 are also supported.
 
-As an example of a special-cased ``coerce_value`` implementation, see
-:py:meth:`~pandera.engines.pandas_engine.Category.coerce_value`:
+As an example of a special-cased ``coerce_value`` implementation, see the
+source code for :meth:`pandera.engines.pandas_engine.Category.coerce_value`:
 
+.. code-block:: python
 
-.. literalinclude:: ../../pandera/engines/pandas_engine.py
-   :lines: 580-586
+    def coerce_value(self, value: Any) -> Any:
+        """Coerce an value to a particular type."""
+        if value not in self.categories:  # type: ignore
+            raise TypeError(
+                f"value {value} cannot be coerced to type {self.type}"
+            )
+        return value
 
-And :py:meth:`~pandera.engines.pandas_engine.BOOL.coerce_value`:
-
-.. literalinclude:: ../../pandera/engines/pandas_engine.py
-   :lines: 223-229
 
 Logical data types
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/dtypes.rst
+++ b/docs/source/reference/dtypes.rst
@@ -65,6 +65,7 @@ Passing native pandas dtypes to pandera components is preferred.
    pandera.engines.pandas_engine.DateTime
    pandera.engines.pandas_engine.Date
    pandera.engines.pandas_engine.Decimal
+   pandera.engines.pandas_engine.Category
 
 GeoPandas Dtypes
 ----------------

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 
   # modin extra
   - modin
-  - protobuf <= 3.20
+  - protobuf
 
   # dask extra
   - dask

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 
   # modin extra
   - modin
-  - protobuf
+  - protobuf <= 3.20.3
 
   # dask extra
   - dask

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -407,13 +407,14 @@ class Decimal(_Number):
     """The number of significant digits that the decimal type can represent."""
     scale: int = 0  # default 0 is aligned with pyarrow and various databases.
     """The number of digits after the decimal point."""
+
+    # pylint: disable=line-too-long
     rounding: str = dataclasses.field(
         default_factory=lambda: decimal.getcontext().rounding
     )
-    # pylint: disable=line-too-long
     """
     The `rounding mode <https://docs.python.org/3/library/decimal.html#rounding-modes>`__
-    supported by the Python :doc:`python:decimal` module.
+    supported by the Python :py:class:`decimal.Decimal` class.
     """
 
     def __init__(

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -203,6 +203,13 @@ class Engine(ABCMeta):
         equivalent_data_type = registry.equivalents.get(data_type)
         if equivalent_data_type is not None:
             return equivalent_data_type
+        elif isinstance(data_type, DataType):
+            # in the case where data_type is a parameterized dtypes.DataType instance that isn't
+            # in the equivalents registry, use its type to get the equivalent, and feed
+            # the parameters into the recognized data type class.
+            equivalent_data_type = registry.equivalents.get(type(data_type))
+            if equivalent_data_type is not None:
+                return type(equivalent_data_type)(**data_type.__dict__)
 
         try:
             return registry.dispatch(data_type)

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -482,6 +482,14 @@ class Decimal(DataType, dtypes.Decimal):
     """
 
     type = np.dtype("object")
+    rounding: str = dataclasses.field(
+        default_factory=lambda: decimal.getcontext().rounding
+    )
+    """
+    The `rounding mode <https://docs.python.org/3/library/decimal.html#rounding-modes>`__
+    supported by the Python :py:class:`decimal.Decimal` class.
+    """
+
     _exp: decimal.Decimal = dataclasses.field(init=False)
     _ctx: decimal.Context = dataclasses.field(init=False)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pandas-stubs <= 1.4.3.220807
 pyspark-stubs
 pyspark >= 3.2.0
 modin
-protobuf <= 3.20
+protobuf
 dask
 distributed
 geopandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pandas-stubs <= 1.4.3.220807
 pyspark-stubs
 pyspark >= 3.2.0
 modin
-protobuf
+protobuf <= 3.20.3
 dask
 distributed
 geopandas


### PR DESCRIPTION
Fixes #926

This PR extends the datatype engine to convert parameterized pandera data type instances into the pandas native data type instances, which will cover the case for `dtypes.Decimals`, `dtypes.Category`, and other parameterized datatypes.