### PR TITLE
Add Union support to `check_types`: Bugfix/977

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -107,112 +107,6 @@ In the example above, this will simply be the string `"year"`.
     2  2003  365
 
 
-Validate Against Multiple Schemas
----------------------------------
-The built-in `typing.Union` type is supported for multiple `DataFrame` schemas.
-
-.. testcode:: union_dataframe_schema_models
-
-    from typing import Union
-    import pandas as pd
-    import pandera as pa
-    from pandera.typing import DataFrame, Series
-
-    class OnlyZeroesSchema(pa.SchemaModel):
-        a: Series[int] = pa.Field(eq=0)
-
-    class OnlyOnesSchema(pa.SchemaModel):
-        a: Series[int] = pa.Field(eq=1)
-
-    @pa.check_types
-    def return_zeros_or_ones(
-        df: Union[DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]]
-    ) -> Union[DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]]:
-        return df
-
-    return_zeros_or_ones(pd.DataFrame({"a": [0, 0]}))
-    return_zeros_or_ones(pd.DataFrame({"a": [1, 1]}))
-
-    return_zeros_or_ones(pd.DataFrame({"a": [0, 2]}))
-
-.. testoutput:: union_dataframe_schema_models
-
-    Traceback (most recent call last):
-    ...
-    pandera.errors.SchemaErrors: Schema OnlyOnesSchema: A total of 2 schema errors were found.
-
-    Error Counts
-    ------------
-    - invalid_type: 2
-
-    Schema Error Summary
-    --------------------
-                                        failure_cases  n_failure_cases
-    schema_context  column check
-    DataFrameSchema <NA>   equal_to(0)            [2]                1
-                           equal_to(1)         [0, 2]                2
-
-
-Note that mixtures of `DataFrame` schemas and built-in types will ignore checking built-in types
-with pandera. Pydantic should be used to check any built-in types.
-
-.. testcode:: union_dataframe_built_in_types
-
-    from typing import Union
-    import pandas as pd
-    import pandera as pa
-    from pandera.typing import DataFrame, Series
-
-    class OnlyZeroesSchema(pa.SchemaModel):
-        a: Series[int] = pa.Field(eq=0)
-
-    @pa.check_types
-    def df_and_int_types(
-        val: Union[DataFrame[OnlyZeroesSchema], int]
-    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
-        return val
-
-    df_and_int_types(pd.DataFrame({"a": [0, 0]}))
-    int_val = df_and_int_types(5)
-    str_val = df_and_int_types("5")
-
-    no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
-
-    @pa.check_types(with_pydantic=True)
-    def df_and_int_types_with_pydantic(
-        val: Union[DataFrame[OnlyZeroesSchema], int]
-    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
-        return val
-
-    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
-    int_val_w_pyd = df_and_int_types_with_pydantic(5)
-    str_val_w_pyd = df_and_int_types_with_pydantic("5")
-
-    pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
-
-    print(no_pydantic_report)
-    print(pydantic_report)
-
-    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
-
-.. testoutput:: union_dataframe_built_in_types
-
-    No Pydantic: True, False
-    With Pydantic: True, True
-
-    Traceback (most recent call last):
-    ...
-    pydantic.error_wrappers.ValidationError: 2 validation errors for DfAndIntTypesWithPydantic
-    val
-        <Schema Column(name=a, type=DataType(int64))> failed element-wise validator 0:
-        <Check equal_to: equal_to(0)>
-    failure cases:
-    index  failure_case
-    0      1             2 (type=value_error)
-    val
-        value is not a valid integer (type=type_error.integer)
-
-
 Validate on Initialization
 --------------------------
 
@@ -315,6 +209,118 @@ validate dataframes, which is syntactic sugar that simply delegates to the
     0  2001      3  200
     1  2002      6  156
     2  2003     12  365
+
+
+Validate Against Multiple Schemas
+---------------------------------
+
+The built-in :class:`typing.Union` type is supported for multiple ``DataFrame`` schemas.
+
+.. testcode:: union_dataframe_schema_models
+
+    from typing import Union
+    import pandas as pd
+    import pandera as pa
+    from pandera.typing import DataFrame, Series
+
+    class OnlyZeroesSchema(pa.SchemaModel):
+        a: Series[int] = pa.Field(eq=0)
+
+    class OnlyOnesSchema(pa.SchemaModel):
+        a: Series[int] = pa.Field(eq=1)
+
+    @pa.check_types
+    def return_zeros_or_ones(
+        df: Union[DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]]
+    ) -> Union[DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]]:
+        return df
+
+    return_zeros_or_ones(pd.DataFrame({"a": [0, 0]}))
+    return_zeros_or_ones(pd.DataFrame({"a": [1, 1]}))
+    return_zeros_or_ones(pd.DataFrame({"a": [0, 2]}))
+
+.. testoutput:: union_dataframe_schema_models
+
+    Traceback (most recent call last):
+    ...
+    pandera.errors.SchemaErrors: Schema OnlyOnesSchema: A total of 2 schema errors were found.
+
+    Error Counts
+    ------------
+    - invalid_type: 2
+
+    Schema Error Summary
+    --------------------
+                                        failure_cases  n_failure_cases
+    schema_context  column check
+    DataFrameSchema <NA>   equal_to(0)            [2]                1
+                           equal_to(1)         [0, 2]                2
+
+
+Note that mixtures of ``DataFrame`` schemas and built-in types will ignore checking built-in types
+with pandera. Pydantic should be used to check any built-in types.
+
+.. testcode:: union_dataframe_built_in_types
+
+    from typing import Union
+    import pandas as pd
+    import pandera as pa
+    from pandera.typing import DataFrame, Series
+
+
+    class OnlyZeroesSchema(pa.SchemaModel):
+        a: Series[int] = pa.Field(eq=0)
+
+
+    @pa.check_types
+    def df_and_int_types(
+        val: Union[DataFrame[OnlyZeroesSchema], int]
+    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
+        return val
+
+
+    df_and_int_types(pd.DataFrame({"a": [0, 0]}))
+    int_val = df_and_int_types(5)
+    str_val = df_and_int_types("5")
+
+    no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
+
+
+    @pa.check_types(with_pydantic=True)
+    def df_and_int_types_with_pydantic(
+        val: Union[DataFrame[OnlyZeroesSchema], int]
+    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
+        return val
+
+
+    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
+    int_val_w_pyd = df_and_int_types_with_pydantic(5)
+    str_val_w_pyd = df_and_int_types_with_pydantic("5")
+
+    pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
+
+    print(no_pydantic_report)
+    print(pydantic_report)
+
+    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
+
+.. testoutput:: union_dataframe_built_in_types
+
+    No Pydantic: True, False
+    With Pydantic: True, True
+
+    Traceback (most recent call last):
+    ...
+    pydantic.error_wrappers.ValidationError: 2 validation errors for DfAndIntTypesWithPydantic
+    val
+        <Schema Column(name=a, type=DataType(int64))> failed element-wise validator 0:
+        <Check equal_to: equal_to(0)>
+    failure cases:
+    index  failure_case
+    0      1             2 (type=value_error)
+    val
+        value is not a valid integer (type=type_error.integer)
+
 
 Excluded attributes
 -------------------

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -214,6 +214,8 @@ validate dataframes, which is syntactic sugar that simply delegates to the
 Validate Against Multiple Schemas
 ---------------------------------
 
+*new in 0.14.0*
+
 The built-in :class:`typing.Union` type is supported for multiple ``DataFrame`` schemas.
 
 .. testcode:: union_dataframe_schema_models

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -158,42 +158,42 @@ with pandera. Pydantic should be used to check any built-in types.
 
 .. testcode:: union_dataframe_built_in_types
 
-from typing import Union
-import pandas as pd
-import pandera as pa
-from pandera.typing import DataFrame, Series
+    from typing import Union
+    import pandas as pd
+    import pandera as pa
+    from pandera.typing import DataFrame, Series
 
-class OnlyZeroesSchema(pa.SchemaModel):
-    a: Series[int] = pa.Field(eq=0)
+    class OnlyZeroesSchema(pa.SchemaModel):
+        a: Series[int] = pa.Field(eq=0)
 
-@pa.check_types
-def df_and_int_types(
-    val: Union[DataFrame[OnlyZeroesSchema], int]
-) -> Union[DataFrame[OnlyZeroesSchema], int]:
-    return val
+    @pa.check_types
+    def df_and_int_types(
+        val: Union[DataFrame[OnlyZeroesSchema], int]
+    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
+        return val
 
-df_and_int_types(pd.DataFrame({"a": [0, 0]}))
-int_val = df_and_int_types(5)
-str_val = df_and_int_types("5")
+    df_and_int_types(pd.DataFrame({"a": [0, 0]}))
+    int_val = df_and_int_types(5)
+    str_val = df_and_int_types("5")
 
-no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
+    no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
 
-@pa.check_types(with_pydantic=True)
-def df_and_int_types_with_pydantic(
-    val: Union[DataFrame[OnlyZeroesSchema], int]
-) -> Union[DataFrame[OnlyZeroesSchema], int]:
-    return val
+    @pa.check_types(with_pydantic=True)
+    def df_and_int_types_with_pydantic(
+        val: Union[DataFrame[OnlyZeroesSchema], int]
+    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
+        return val
 
-df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
-int_val_w_pyd = df_and_int_types_with_pydantic(5)
-str_val_w_pyd = df_and_int_types_with_pydantic("5")
+    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
+    int_val_w_pyd = df_and_int_types_with_pydantic(5)
+    str_val_w_pyd = df_and_int_types_with_pydantic("5")
 
-pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
+    pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
 
-print(no_pydantic_report)
-print(pydantic_report)
+    print(no_pydantic_report)
+    print(pydantic_report)
 
-df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
+    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
 
 .. testoutput:: union_dataframe_built_in_types
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -258,7 +258,7 @@ The built-in :class:`typing.Union` type is supported for multiple ``DataFrame`` 
 
 
 Note that mixtures of ``DataFrame`` schemas and built-in types will ignore checking built-in types
-with pandera. Pydantic should be used to check any built-in types.
+with pandera. Pydantic should be used to check and/or coerce any built-in types.
 
 .. testcode:: union_dataframe_built_in_types
 
@@ -302,24 +302,10 @@ with pandera. Pydantic should be used to check any built-in types.
     print(no_pydantic_report)
     print(pydantic_report)
 
-    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
-
 .. testoutput:: union_dataframe_built_in_types
 
     No Pydantic: True, False
     With Pydantic: True, True
-
-    Traceback (most recent call last):
-    ...
-    pydantic.error_wrappers.ValidationError: 2 validation errors for DfAndIntTypesWithPydantic
-    val
-        <Schema Column(name=a, type=DataType(int64))> failed element-wise validator 0:
-        <Check equal_to: equal_to(0)>
-    failure cases:
-    index  failure_case
-    0      1             2 (type=value_error)
-    val
-        value is not a valid integer (type=type_error.integer)
 
 
 Excluded attributes

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -158,42 +158,42 @@ with pandera. Pydantic should be used to check any built-in types.
 
 .. testcode:: union_dataframe_built_in_types
 
-    from typing import Union
-    import pandas as pd
-    import pandera as pa
-    from pandera.typing import DataFrame, Series
+from typing import Union
+import pandas as pd
+import pandera as pa
+from pandera.typing import DataFrame, Series
 
-    class OnlyZeroesSchema(pa.SchemaModel):
-        a: Series[int] = pa.Field(eq=0)
+class OnlyZeroesSchema(pa.SchemaModel):
+    a: Series[int] = pa.Field(eq=0)
 
-    @pa.check_types
-    def df_and_int_types(
-        val: Union[DataFrame[OnlyZeroesSchema], int]
-    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
-        return val
+@pa.check_types
+def df_and_int_types(
+    val: Union[DataFrame[OnlyZeroesSchema], int]
+) -> Union[DataFrame[OnlyZeroesSchema], int]:
+    return val
 
-    df_and_int_types(pd.DataFrame({"a": [0, 0]}))
-    int_val = df_and_int_types(5)
-    str_val = df_and_int_types("5")
+df_and_int_types(pd.DataFrame({"a": [0, 0]}))
+int_val = df_and_int_types(5)
+str_val = df_and_int_types("5")
 
-    no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
+no_pydantic_report = f"No Pydantic: {isinstance(int_val, int)}, {isinstance(str_val, int)}"
 
-    @pa.check_types(with_pydantic=True)
-    def df_and_int_types_with_pydantic(
-        val: Union[DataFrame[OnlyZeroesSchema], int]
-    ) -> Union[DataFrame[OnlyZeroesSchema], int]:
-        return val
+@pa.check_types(with_pydantic=True)
+def df_and_int_types_with_pydantic(
+    val: Union[DataFrame[OnlyZeroesSchema], int]
+) -> Union[DataFrame[OnlyZeroesSchema], int]:
+    return val
 
-    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
-    int_val_w_pyd = df_and_int_types_with_pydantic(5)
-    str_val_w_pyd = df_and_int_types_with_pydantic("5")
+df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 0]}))
+int_val_w_pyd = df_and_int_types_with_pydantic(5)
+str_val_w_pyd = df_and_int_types_with_pydantic("5")
 
-    pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
+pydantic_report = f"With Pydantic: {isinstance(int_val_w_pyd, int)}, {isinstance(str_val_w_pyd, int)}"
 
-    print(no_pydantic_report)
-    print(pydantic_report)
+print(no_pydantic_report)
+print(pydantic_report)
 
-    df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
+df_and_int_types_with_pydantic(pd.DataFrame({"a": [0, 2]}))
 
 .. testoutput:: union_dataframe_built_in_types
 
@@ -205,7 +205,7 @@ with pandera. Pydantic should be used to check any built-in types.
     pydantic.error_wrappers.ValidationError: 2 validation errors for DfAndIntTypesWithPydantic
     val
         <Schema Column(name=a, type=DataType(int64))> failed element-wise validator 0:
-    <Check equal_to: equal_to(0)>
+        <Check equal_to: equal_to(0)>
     failure cases:
     index  failure_case
     0      1             2 (type=value_error)

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -618,6 +618,12 @@ def check_types(
             arg_name, [(None, None)]
         )
 
+        # Don't check if value is a generic built in type
+        if isinstance(
+            arg_value, (int, str, bool, float, dict, list, set, tuple)
+        ):
+            return arg_value
+
         error_handler = SchemaErrorHandler(lazy=True)
         for schema_model, annotation_info in annotation_model_pairs:
             if schema_model is None:

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     NoReturn,
     Optional,
@@ -24,6 +25,7 @@ import wrapt
 from pydantic import validate_arguments
 
 from . import errors, schemas
+from .error_handlers import SchemaErrorHandler
 from .inspection_utils import (
     is_classmethod_from_meta,
     is_decorated_classmethod,
@@ -91,18 +93,39 @@ def _handle_schema_error(
     :raises SchemaError: when ``DataFrame`` violates built-in or custom
         checks.
     """
+    raise _parse_schema_error(
+        decorator_name, fn, schema, arg_df, schema_error
+    ) from schema_error
+
+
+def _parse_schema_error(
+    decorator_name,
+    fn: Callable,
+    schema: Union[schemas.DataFrameSchema, schemas.SeriesSchema],
+    arg_df: pd.DataFrame,
+    schema_error: errors.SchemaError,
+) -> NoReturn:
+    """Parse schema validation error with decorator context.
+
+    :param fn: check the DataFrame or Series input of this function.
+    :param schema: dataframe/series schema object
+    :param arg_df: dataframe/series we are validating.
+    :param schema_error: original exception.
+    :raises SchemaError: when ``DataFrame`` violates built-in or custom
+        checks.
+    """
     func_name = fn.__name__
     if isinstance(fn, types.MethodType):
         func_name = fn.__self__.__class__.__name__ + "." + func_name
     msg = f"error in {decorator_name} decorator of function '{func_name}': {schema_error}"
-    raise errors.SchemaError(
+    return errors.SchemaError(  # type: ignore[misc]
         schema,
         arg_df,
         msg,
         failure_cases=schema_error.failure_cases,
         check=schema_error.check,
         check_index=schema_error.check_index,
-    ) from schema_error
+    )
 
 
 def check_input(
@@ -524,6 +547,7 @@ def check_types(
     lazy: bool = False,
     inplace: bool = False,
 ) -> Callable:
+    # pylint: disable=too-many-statements
     """Validate function inputs and output based on type annotations.
 
     See the :ref:`User Guide <schema_models>` for more.
@@ -558,66 +582,101 @@ def check_types(
         )
 
     # Front-load annotation parsing
-    annotated_schema_models: Dict[str, Tuple[SchemaModel, AnnotationInfo]] = {}
+    annotated_schema_models: Dict[
+        str,
+        Iterable[Tuple[Union[SchemaModel, None], Union[AnnotationInfo, None]]],
+    ] = {}
     for arg_name_, annotation in typing.get_type_hints(wrapped).items():
         annotation_info = AnnotationInfo(annotation)
         if not annotation_info.is_generic_df:
-            continue
+            # pylint: disable=comparison-with-callable
+            if annotation_info.origin == Union:
+                annotation_model_pairs = []
+                for annot in annotation_info.args:  # type: ignore[union-attr]
+                    sub_annotation_info = AnnotationInfo(annot)
+                    if not sub_annotation_info.is_generic_df:
+                        continue
 
-        schema_model = cast(SchemaModel, annotation_info.arg)
-        annotated_schema_models[arg_name_] = (schema_model, annotation_info)
+                    schema_model = cast(SchemaModel, sub_annotation_info.arg)
+                    annotation_model_pairs.append(
+                        (schema_model, sub_annotation_info)
+                    )
+            else:
+                continue
+        else:
+            schema_model = cast(SchemaModel, annotation_info.arg)
+            annotation_model_pairs = [(schema_model, annotation_info)]
+
+        annotated_schema_models[arg_name_] = annotation_model_pairs
 
     def _check_arg(arg_name: str, arg_value: Any) -> Any:
         """
         Validate function's argument if annoted with a schema, else
         pass-through.
         """
-        schema_model, annotation_info = annotated_schema_models.get(
-            arg_name, (None, None)
+        annotation_model_pairs = annotated_schema_models.get(
+            arg_name, [(None, None)]
         )
 
-        if schema_model is None:
-            return arg_value
-
-        if (
-            annotation_info
-            and not (annotation_info.optional and arg_value is None)
-            # the pandera.schema attribute should only be available when
-            # schema.validate has been called in the DF. There's probably
-            # a better way of doing this
-        ):
-            config = schema_model.__config__
-            data_container_type = annotation_info.origin
-            schema = schema_model.to_schema()
-
-            if data_container_type and config and config.from_format:
-                arg_value = data_container_type.from_format(arg_value, config)
+        error_handler = SchemaErrorHandler(lazy=True)
+        for schema_model, annotation_info in annotation_model_pairs:
+            if schema_model is None:
+                return arg_value
 
             if (
-                arg_value.pandera.schema is None
-                # don't re-validate a dataframe that contains the same exact
-                # schema
-                or arg_value.pandera.schema != schema
+                annotation_info
+                and not (annotation_info.optional and arg_value is None)
+                # the pandera.schema attribute should only be available when
+                # schema.validate has been called in the DF. There's probably
+                # a better way of doing this
             ):
-                try:
-                    arg_value = schema.validate(
-                        arg_value,
-                        head,
-                        tail,
-                        sample,
-                        random_state,
-                        lazy,
-                        inplace,
-                    )
-                except errors.SchemaError as e:
-                    _handle_schema_error(
-                        "check_types", wrapped, schema, arg_value, e
+                config = schema_model.__config__
+                data_container_type = annotation_info.origin
+                schema = schema_model.to_schema()
+
+                if data_container_type and config and config.from_format:
+                    arg_value = data_container_type.from_format(
+                        arg_value, config
                     )
 
-            if data_container_type and config and config.to_format:
-                arg_value = data_container_type.to_format(arg_value, config)
+                if (
+                    arg_value.pandera.schema is None
+                    # don't re-validate a dataframe that contains the same exact
+                    # schema
+                    or arg_value.pandera.schema != schema
+                ):
+                    try:
+                        arg_value = schema.validate(
+                            arg_value,
+                            head,
+                            tail,
+                            sample,
+                            random_state,
+                            lazy,
+                            inplace,
+                        )
+                    except errors.SchemaError as e:
+                        error_handler.collect_error(
+                            "invalid_type",
+                            _parse_schema_error(
+                                "check_types", wrapped, schema, arg_value, e
+                            ),
+                        )
+                        continue
 
-            return arg_value
+                if data_container_type and config and config.to_format:
+                    arg_value = data_container_type.to_format(
+                        arg_value, config
+                    )
+
+                return arg_value
+
+        if error_handler.collected_errors:
+            if len(error_handler.collected_errors) == 1:
+                raise error_handler.collected_errors[0]["error"]  # type: ignore[misc]
+            raise errors.SchemaErrors(
+                schema, error_handler.collected_errors, arg_value
+            )
 
     sig = inspect.signature(wrapped)
 

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -618,10 +618,7 @@ def check_types(
             arg_name, [(None, None)]
         )
 
-        # Don't check if value is a generic built in type
-        if isinstance(
-            arg_value, (int, str, bool, float, dict, list, set, tuple)
-        ):
+        if not annotation_model_pairs:
             return arg_value
 
         error_handler = SchemaErrorHandler(lazy=True)
@@ -644,6 +641,12 @@ def check_types(
                     arg_value = data_container_type.from_format(
                         arg_value, config
                     )
+
+                # Don't do checks if value is still a built-in type
+                if isinstance(
+                    arg_value, (int, str, bool, float, dict, list, tuple, set)
+                ):
+                    return arg_value
 
                 if (
                     arg_value.pandera.schema is None

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -208,6 +208,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
 
     Attributes:
         origin: The non-parameterized generic class.
+        args: All generic types for accessing as an iterable.
         arg: The first generic type (SchemaModel does not support more than
             1 argument).
         literal: Whether the annotation is a literal.
@@ -247,6 +248,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.origin = typing_inspect.get_origin(raw_annotation)
         # Replace empty tuple returned from get_args by None
         args = typing_inspect.get_args(raw_annotation) or None
+        self.args = args
         self.arg = args[0] if args else args
 
         self.metadata = getattr(self.arg, "__metadata__", None)

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -936,8 +936,22 @@ def test_check_types_non_dataframes() -> None:
         return val
 
     only_int_type(1)
-    union_int_str_types(2)
-    union_int_str_types("2")
+    int_val = union_int_str_types(2)
+    str_val = union_int_str_types("2")
+    assert isinstance(int_val, int)
+    assert isinstance(str_val, str)
+
+    @check_types(with_pydantic=True)
+    def union_df_int_types_pydantic_check(
+        val: typing.Union[DataFrame[OnlyZeroesSchema], int]
+    ) -> typing.Union[DataFrame[OnlyZeroesSchema], int]:
+        return val
+
+    union_df_int_types_pydantic_check(pd.DataFrame({"a": [0, 0]}))
+    int_val_pydantic = union_df_int_types_pydantic_check(5)
+    str_val_pydantic = union_df_int_types_pydantic_check("5")  # type: ignore[arg-type]
+    assert isinstance(int_val_pydantic, int)
+    assert isinstance(str_val_pydantic, int)
 
 
 def test_coroutines(event_loop: AbstractEventLoop) -> None:

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -894,7 +894,8 @@ def test_check_types_union_args() -> None:
     @check_types
     def validate_union(
         df: typing.Union[
-            DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]
+            DataFrame[OnlyZeroesSchema],
+            DataFrame[OnlyOnesSchema],
         ],
     ) -> typing.Union[DataFrame[OnlyZeroesSchema], DataFrame[OnlyOnesSchema]]:
         return df
@@ -919,6 +920,24 @@ def test_check_types_union_args() -> None:
 
     with pytest.raises(errors.SchemaErrors):
         validate_union_wrong_outputs(pd.DataFrame({"a": [0, 0]}))
+
+
+def test_check_types_non_dataframes() -> None:
+    """Test to skip check_types for non-dataframes"""
+
+    @check_types
+    def only_int_type(val: int) -> int:
+        return val
+
+    @check_types
+    def union_int_str_types(
+        val: typing.Union[int, str]
+    ) -> typing.Union[int, str]:
+        return val
+
+    only_int_type(1)
+    union_int_str_types(2)
+    union_int_str_types("2")
 
 
 def test_coroutines(event_loop: AbstractEventLoop) -> None:


### PR DESCRIPTION
Fixes #977 

This PR adds support for `Union[DataFrame[S1], DataFrame[S2]]` in the `check_types` decorator.  This was done by the following additions

1. `annotated_schema_models` was updated to type of `Dict[str, Iterable[Tuple[Union[SchemaModel, None], Union[AnnotationInfo, None]]]].  Specifically this could be a `List[Tuple[]]` but it was kept as `Iterable` per the discussion in the issue.  The `Nones` were added for mypy checking in the `_check_arg` function, rather than turning off the mypy warning there.
2. If the `annotation_info` for an annotation is determined to be generic, it is checked against the Union type.  If it is a Union, all the annotations are looped through with model pairs being added the way they were outside.  Otherwise the previous `continue` behavior was maintained if not a Union.
3. The `_check_arg` function was updated to properly handle Union cases in the following ways:
a. The annotation_model_pairs values are now looped through from the `Iterable` level.
b. When a schema validates in this for loop, the same behavior is maintained and the `arg_value` should be returned after that initial validation.
c. When a `SchemaError` is encountered in the `except` statement, it is passed to a `SchemaErrorHandler` object rather than being immediately raised.  The next annotation_model_pair in the loop is moved to in searching for a validation.
d. If nothing validates, then the errors passed to the `SchemaErrorHandler` get raised after looping through all options.  A singular error gets raised in the same way it was raised before.  If there are multiple errors they get raised as an `errors.SchemaErrors` object.
4. The `test_check_types_union_args()` test was written to both validate inputs as expected and ensure there is a validation error on the outputs of functions with the `check_types` decorator.  Open to suggestions on other tests I should add if there are other edge cases I seem to have added that aren't covered by these or previous tests.
5. Two existing tests were altered (`test_check_types_error_input` and `test_check_types_error_output`) because when the `SchemaError` gets passed to the `SchemaErrorHandler` the `.data` object gets scrubbed.  Hence the assertion that the input and validated data are equal was not able to pass anymore with the `check_types` decorator.  The validation still occurs correctly, it is just not possible to ensure the returned data in the error is able to be checked against the input data.  One option was to remove the data scrubbing by the `SchemaErrorHandler`, but that seemed to have the potential to make that object potentially large so the test was altered assuming that type of output is no longer available with the `check_types` decorator.

Note, this seems to have picked up a couple upstream changes that weren't made by me in the following files:
`.github/workflows/ci-tests.yml`
`.pre-commit-config.yaml`
`docs/source/extensions.rst`
`environment.yml`
`pandera/extensions.py`
`requirements-dev.txt`
`tests/core/test_extensions.py`
some of the decorator tests, specifically `test_check_decorator_coercion`, `test_check_output_coercion_error`, and `test_check_instance_method_decorator_error`