### PR TITLE
unpin pandas-stubs version

### DIFF
--- a/docs/source/mypy_integration.rst
+++ b/docs/source/mypy_integration.rst
@@ -39,6 +39,9 @@ Then enable the plugin in your ``mypy.ini`` or ``setug.cfg`` file:
     if they find any false positives or negatives being reported by ``mypy``.
     A list of such issues can be found `here <https://github.com/pandera-dev/pandera/labels/mypy>`__.
 
+    Also, be aware that the latest pandas-stubs versions only support Python 3.8+. 
+    So, if you are using Python 3.7, you will not face an error when installing this package, 
+    but pip will install an older version of pandas-stubs with outdated type annotations.
 
 In the example below, we define a few schemas to see how type-linting with
 pandera works.

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pydantic
 
   # mypy extra
-  - pandas-stubs >= 1.4.3.220822
+  - pandas-stubs
   - pyspark-stubs
 
   # pyspark extra

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pydantic
 
   # mypy extra
-  - pandas-stubs <= 1.4.3.220807
+  - pandas-stubs >= 1.4.3.220822
   - pyspark-stubs
 
   # pyspark extra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ typing_extensions >= 3.7.4.3
 frictionless
 pyarrow
 pydantic
-pandas-stubs >= 1.4.3.220822
+pandas-stubs
 pyspark-stubs
 pyspark >= 3.2.0
 modin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ typing_extensions >= 3.7.4.3
 frictionless
 pyarrow
 pydantic
-pandas-stubs <= 1.4.3.220807
+pandas-stubs >= 1.4.3.220822
 pyspark-stubs
 pyspark >= 3.2.0
 modin

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _extras_require = {
     "modin-ray": ["modin", "ray <= 1.7.0"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
-    "mypy": ["pandas-stubs <= 1.4.3.220807"],
+    "mypy": ["pandas-stubs >= 1.4.3.220822"],
     "fastapi": ["fastapi"],
     "geopandas": ["geopandas", "shapely"],
 }

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _extras_require = {
     "modin-ray": ["modin", "ray <= 1.7.0"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
-    "mypy": ["pandas-stubs >= 1.4.3.220822"],
+    "mypy": ["pandas-stubs"],
     "fastapi": ["fastapi"],
     "geopandas": ["geopandas", "shapely"],
 }


### PR DESCRIPTION
Fixes: https://github.com/unionai-oss/pandera/issues/968

Since the issue on pandas-stubs was fixed, I think it's safe again to unpin them.
https://github.com/pandas-dev/pandas-stubs/issues/197#issuecomment-1222285872

