### PR TITLE
Fix handling of decimals with scale=0

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -436,7 +436,9 @@ class Decimal(_Number):
         object.__setattr__(self, "scale", scale)
         object.__setattr__(self, "rounding", rounding)
         object.__setattr__(
-            self, "_exp", _scale_to_exp(scale) if scale else decimal.Decimal("1.")
+            self,
+            "_exp",
+            _scale_to_exp(scale) if scale else decimal.Decimal("1."),
         )
         object.__setattr__(
             self,

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -436,7 +436,7 @@ class Decimal(_Number):
         object.__setattr__(self, "scale", scale)
         object.__setattr__(self, "rounding", rounding)
         object.__setattr__(
-            self, "_exp", _scale_to_exp(scale) if scale else None
+            self, "_exp", _scale_to_exp(scale) if scale else decimal.Decimal("1.")
         )
         object.__setattr__(
             self,

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -440,6 +440,8 @@ def _check_decimal(
     is_decimal = pandas_obj.apply(
         lambda x: isinstance(x, decimal.Decimal)
     ).astype("bool") | pd.isnull(pandas_obj)
+    if not is_decimal.any():
+        return is_decimal
 
     decimals = pandas_obj[is_decimal]
     # fix for modin unamed series raises KeyError
@@ -447,6 +449,8 @@ def _check_decimal(
     decimals.name = "decimals"
 
     splitted = decimals.astype("string").str.split(".", n=1, expand=True)
+    if splitted.shape[1] < 2:
+        splitted[1] = ""
     len_left = splitted[0].str.len().fillna(0)
     len_right = splitted[1].str.len().fillna(0)
     precisions = len_left + len_right
@@ -502,15 +506,13 @@ class Decimal(DataType, dtypes.Decimal):
         dtypes.Decimal.__init__(self, precision, scale, rounding)
 
     def coerce_value(self, value: Any) -> decimal.Decimal:
-        """Coerce an value to a particular type."""
+        """Coerce a value to a particular type."""
 
         if pd.isna(value):
             return pd.NA
 
         dec = decimal.Decimal(str(value))
-        if self._exp:
-            return dec.quantize(self._exp, context=self._ctx)
-        return dec
+        return dec.quantize(self._exp, context=self._ctx)
 
     def coerce(self, data_container: pd.Series) -> pd.Series:
         return data_container.apply(self.coerce_value)

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -530,7 +530,7 @@ class Decimal(DataType, dtypes.Decimal):
             if data_container is None:
                 return False
             else:
-                return np.full_like(data_container, False)
+                return np.full_like(data_container, False, dtype=bool)
         if data_container is None:
             return True
         return _check_decimal(

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -295,6 +295,8 @@ def test_decimal_scale_zero_coercions(value):
     check_type = pandas_engine.Decimal(28, 0)
 
     coerced = check_type.coerce(value)
-    result = check_type.check(pandas_engine.Engine.dtype(coerced.dtype), coerced)
+    result = check_type.check(
+        pandas_engine.Engine.dtype(coerced.dtype), coerced
+    )
 
     assert result.all()

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -237,7 +237,7 @@ def test_decimal_scale_zero(value):
     """Testing if a scale of 0 works."""
     check_type = pandas_engine.Decimal(28, 0)
 
-    result = check_type.check(pa.Object, value)
+    result = check_type.check(value.dtype, value)
 
     assert result.all()
 
@@ -260,26 +260,19 @@ def test_decimal_scale_zero_violations(value):
     """
     check_type = pandas_engine.Decimal(28, 0)
 
-    result = check_type.check(pa.Object, value)
+    result = check_type.check(value.dtype, value)
 
     assert not result.any()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "This call should raise a schema error , but float values lead"
-        "to type errors instead - something wrong within the validate."
-    ),
-    raises=TypeError,
-    strict=True,
-)
 def test_decimal_scale_zero_missing_violation():
-    """Should be deleted once `check_output | isna` works with floats."""
-    schema = pa.DataFrameSchema({"x": pa.Column(pandas_engine.Decimal)})
-    df = pd.DataFrame({"x": [1.1]})
+    """Additional regression test for #1008: `Decimal.check` returned non-bool Series."""
+    check_type = pandas_engine.Decimal(28, 0)
+    value = pd.Series([1.1])
 
-    with pytest.raises(SchemaError):
-        schema.validate(df)
+    result = check_type.check(value.dtype, value)
+
+    assert result.dtype == bool
 
 
 @pytest.mark.parametrize(
@@ -302,6 +295,6 @@ def test_decimal_scale_zero_coercions(value):
     check_type = pandas_engine.Decimal(28, 0)
 
     coerced = check_type.coerce(value)
-    result = check_type.check(pa.Object, coerced)
+    result = check_type.check(value.dtype, coerced)
 
     assert result.all()

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -12,7 +12,7 @@ from pandas.testing import assert_series_equal
 
 import pandera as pa
 from pandera.engines import pandas_engine
-from pandera.errors import ParserError, SchemaError
+from pandera.errors import ParserError
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -233,7 +233,8 @@ def test_invalid_decimal_params(precision: int, scale: int):
         pd.Series([Decimal("100000")]),
     ],
 )
-def test_decimal_precision_zero(value):
+def test_decimal_scale_zero(value):
+    """Testing if a scale of 0 works."""
     check_type = pandas_engine.Decimal(28, 0)
 
     result = check_type.check(pa.Object, value)
@@ -252,8 +253,11 @@ def test_decimal_precision_zero(value):
         pd.Series([1.1]),
     ],
 )
-def test_decimal_precision_zero_violations(value):
-    """We want proper violations here, no raised exceptions."""
+def test_decimal_scale_zero_violations(value):
+    """Make sure we get proper violations here.
+
+    First half of regression test for #1008.
+    """
     check_type = pandas_engine.Decimal(28, 0)
 
     result = check_type.check(pa.Object, value)
@@ -269,7 +273,8 @@ def test_decimal_precision_zero_violations(value):
     raises=TypeError,
     strict=True,
 )
-def test_decimal_precision_zero_missing_violation():
+def test_decimal_scale_zero_missing_violation():
+    """Should be deleted once `check_output | isna` works with floats."""
     schema = pa.DataFrameSchema({"x": pa.Column(pandas_engine.Decimal)})
     df = pd.DataFrame({"x": [1.1]})
 
@@ -289,7 +294,11 @@ def test_decimal_precision_zero_missing_violation():
         pd.Series([1.1]),
     ],
 )
-def test_decimal_precision_zero_coercions(value):
+def test_decimal_scale_zero_coercions(value):
+    """Make sure coercions work.
+
+    Other half of regression test for #1008.
+    """
     check_type = pandas_engine.Decimal(28, 0)
 
     coerced = check_type.coerce(value)

--- a/tests/core/test_logical_dtypes.py
+++ b/tests/core/test_logical_dtypes.py
@@ -295,6 +295,6 @@ def test_decimal_scale_zero_coercions(value):
     check_type = pandas_engine.Decimal(28, 0)
 
     coerced = check_type.coerce(value)
-    result = check_type.check(value.dtype, coerced)
+    result = check_type.check(pandas_engine.Engine.dtype(coerced.dtype), coerced)
 
     assert result.all()


### PR DESCRIPTION
Resolves #1008

Result of the test-cases listed in the bug-ticket:

```python
foo.validate(pd.DataFrame({"x": [Decimal('1')]}))    # valid schema
bar.validate(pd.DataFrame({"x": [Decimal('1')]}))    # valid schema
foo.validate(pd.DataFrame({"x": [Decimal('1.1')]}))  # SchemaError
bar.validate(pd.DataFrame({"x": [Decimal('1.1')]}))  # successful coercion
foo.validate(pd.DataFrame({"x": ['1']}))             # SchemaError
bar.validate(pd.DataFrame({"x": ['1']}))             # successful coercion
foo.validate(pd.DataFrame({"x": ['1.1']}))           # SchemaError
bar.validate(pd.DataFrame({"x": ['1.1']}))           # successful coercion
foo.validate(pd.DataFrame({"x": [1]}))               # SchemaError
bar.validate(pd.DataFrame({"x": [1]}))               # successful coercion
foo.validate(pd.DataFrame({"x": [1.1]}))             # TypeError ⚡
bar.validate(pd.DataFrame({"x": [1.1]}))             # successful coercion
```

The weird type error originates in `check_utils.prepare_series_check_output` and not the definitions that make up the `Decimal` type, so I didn't try to fix it in this PR and just added an `xfail` for it in the tests.