### PR TITLE
Schema Model manipulation docs

### DIFF
--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -777,7 +777,7 @@ the class scope, and it will respect the alias.
 Manipulating Schema Models post-definition
 ------------------------------------------
 
-One caveat of using inheritance to build schemata on top of each other is that there
+One caveat of using inheritance to build schemas on top of each other is that there
 is no clear way of how a child class can e.g. remove fields or update them without
 completely overriding previous settings, inheritance is strictly additive.
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -788,7 +788,7 @@ Schema Model's :func:`~pandera.model.SchemaModel.to_schema` method.
 Schema Models are for the most part just a proxy for the ``DataFrameSchema`` API; calling
 :func:`~pandera.model.SchemaModel.validate` will just redirect to the validate method of
 the Data Frame Schema's :class:`~pandera.schemas.DataFrameSchema.validate` returned by
-`to_schema`. As such, any updates to the schema that took place in there will propagate
+``to_schema``. As such, any updates to the schema that took place in there will propagate
 cleanly.
 
 As an example, the following class hierarchy can not remove the fields `b` and `c` from

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -781,7 +781,7 @@ One caveat of using inheritance to build schemas on top of each other is that th
 is no clear way of how a child class can e.g. remove fields or update them without
 completely overriding previous settings. This is because inheritance is strictly additive.
 
-:class:`~pandera.schemas.DataFrameSchema`s do have these options though, as described in
+:class:`~pandera.schemas.DataFrameSchema` objects do have these options though, as described in
 :ref:`_dataframe schema transformations`, which you can leverage by overriding your
 Schema Model's :func:`~pandera.model.SchemaModel.to_schema` method.
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -826,7 +826,7 @@ get rid of them like this:
 
     There are drawbacks to manipulating schema shape in this way:
      - Static code analysis has no way to figure out which fields a class.
-     - Any children of classes which have overriden `to_schema` might experience
-       surprising behavior -- if a child of `Baz` tries to define a field `b` or `c` again,
-       it will lose it in its `to_schema` call because `Baz`'s `to_schema` will always
+     - Any children of classes which have overriden ``to_schema`` might experience
+       surprising behavior -- if a child of ``Baz`` tries to define a field ``b`` or ``c`` again,
+       it will lose it in its ``to_schema`` call because ``Baz``'s ``to_schema`` will always
        be executed after any child's class body has already been fully assembled.

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -825,7 +825,8 @@ get rid of them like this:
 .. note::
 
     There are drawbacks to manipulating schema shape in this way:
-     - Static code analysis has no way to figure out which fields a class.
+     - Static code analysis has no way to figure out what fields have been removed/updated from
+       the class definitions and inheritance hierarchy.
      - Any children of classes which have overriden ``to_schema`` might experience
        surprising behavior -- if a child of ``Baz`` tries to define a field ``b`` or ``c`` again,
        it will lose it in its ``to_schema`` call because ``Baz``'s ``to_schema`` will always

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -808,7 +808,7 @@ get rid of them like this:
         c: pa.typing.Series[int]
         d: pa.typing.Series[int]
 
-    class Baz(pa.SchemaModel):
+    class Baz(Foo, Bar):
         @classmethod
         def to_schema(cls) -> pa.DataFrameSchema:
             schema = super().to_schema()

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -785,7 +785,7 @@ completely overriding previous settings. This is because inheritance is strictly
 :ref:`_dataframe schema transformations`, which you can leverage by overriding your
 Schema Model's :func:`~pandera.model.SchemaModel.to_schema` method.
 
-Schema Models are for the most part just a proxy for the Data Frame Schema API -- calling
+Schema Models are for the most part just a proxy for the ``DataFrameSchema`` API; calling
 :func:`~pandera.model.SchemaModel.validate` will just redirect to the validate method of
 the Data Frame Schema's :class:`~pandera.schemas.DataFrameSchema.validate` returned by
 `to_schema`. As such, any updates to the schema that took place in there will propagate

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -815,7 +815,7 @@ get rid of them like this:
             return schema.remove_columns(["b", "c"])
 
     df = pd.DataFrame({"a": [99], "d": [101]})
-    print(Schema.validate(df))
+    print(Baz.validate(df))
 
 .. testoutput:: dataframe_schema_model
 

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -779,7 +779,7 @@ Manipulating Schema Models post-definition
 
 One caveat of using inheritance to build schemas on top of each other is that there
 is no clear way of how a child class can e.g. remove fields or update them without
-completely overriding previous settings, inheritance is strictly additive.
+completely overriding previous settings. This is because inheritance is strictly additive.
 
 :class:`~pandera.schemas.DataFrameSchema`s do have these options though, as described in
 :ref:`_dataframe schema transformations`, which you can leverage by overriding your

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -791,8 +791,8 @@ the Data Frame Schema's :class:`~pandera.schemas.DataFrameSchema.validate` retur
 ``to_schema``. As such, any updates to the schema that took place in there will propagate
 cleanly.
 
-As an example, the following class hierarchy can not remove the fields `b` and `c` from
-`Baz` into a base-class without completely convoluting the inheritance tree. So, we can
+As an example, the following class hierarchy can not remove the fields ``b`` and ``c`` from
+``Baz`` into a base-class without completely convoluting the inheritance tree. So, we can
 get rid of them like this:
 
 .. testcode:: dataframe_schema_model

--- a/docs/source/schema_models.rst
+++ b/docs/source/schema_models.rst
@@ -772,3 +772,61 @@ the class scope, and it will respect the alias.
 
           2020    a
     0       99  101
+
+
+Manipulating Schema Models post-definition
+------------------------------------------
+
+One caveat of using inheritance to build schemata on top of each other is that there
+is no clear way of how a child class can e.g. remove fields or update them without
+completely overriding previous settings, inheritance is strictly additive.
+
+:class:`~pandera.schemas.DataFrameSchema`s do have these options though, as described in
+:ref:`_dataframe schema transformations`, which you can leverage by overriding your
+Schema Model's :func:`~pandera.model.SchemaModel.to_schema` method.
+
+Schema Models are for the most part just a proxy for the Data Frame Schema API -- calling
+:func:`~pandera.model.SchemaModel.validate` will just redirect to the validate method of
+the Data Frame Schema's :class:`~pandera.schemas.DataFrameSchema.validate` returned by
+`to_schema`. As such, any updates to the schema that took place in there will propagate
+cleanly.
+
+As an example, the following class hierarchy can not remove the fields `b` and `c` from
+`Baz` into a base-class without completely convoluting the inheritance tree. So, we can
+get rid of them like this:
+
+.. testcode:: dataframe_schema_model
+
+    import pandera as pa
+    import pandas as pd
+
+    class Foo(pa.SchemaModel):
+        a: pa.typing.Series[int]
+        b: pa.typing.Series[int]
+
+    class Bar(pa.SchemaModel):
+        c: pa.typing.Series[int]
+        d: pa.typing.Series[int]
+
+    class Baz(pa.SchemaModel):
+        @classmethod
+        def to_schema(cls) -> pa.DataFrameSchema:
+            schema = super().to_schema()
+            return schema.remove_columns(["b", "c"])
+
+    df = pd.DataFrame({"a": [99], "d": [101]})
+    print(Schema.validate(df))
+
+.. testoutput:: dataframe_schema_model
+
+        a    d
+    0  99  101
+
+.. note::
+
+    There are drawbacks to manipulating schema shape in this way:
+     - Static code analysis has no way to figure out which fields a class.
+     - Any children of classes which have overriden `to_schema` might experience
+       surprising behavior -- if a child of `Baz` tries to define a field `b` or `c` again,
+       it will lose it in its `to_schema` call because `Baz`'s `to_schema` will always
+       be executed after any child's class body has already been fully assembled.


### PR DESCRIPTION
Generalized the intitial explanation offered in https://github.com/unionai-oss/pandera/discussions/990 a bit, and checked implementations for side effects. One that I mention in the docs is that class body resolution happens before any parent's `to_schema` can be called, leading to potentially unexpected behavior ("why does my parent's `to_schema` remove an attribute that I defined in a child?").

I tried to conform to the docs style, please update as you see fit @cosmicBboy 