### PR TITLE
Turn failure-cases to string to avoid hashing unhashable objects

### DIFF
--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -166,7 +166,7 @@ class SchemaErrors(ReducedPickleExceptionBase):
             msg += f"- {k}: {v}\n"
 
         def agg_failure_cases(df):
-            # FIXME(arne): hack to support unhashable types, #260 would enable
+            # FIXME(arne): hack to support unhashable types, wait for #260
             df.failure_case = df.failure_case.astype(str)
             # NOTE: this is a hack to add modin support
             if type(df).__module__.startswith("modin.pandas"):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -166,7 +166,8 @@ class SchemaErrors(ReducedPickleExceptionBase):
             msg += f"- {k}: {v}\n"
 
         def agg_failure_cases(df):
-            # FIXME(arne): hack to support unhashable types, wait for #260
+            # TODO(arne): hack to support unhashable types, proper solution that only
+            #  casts where required: https://github.com/unionai-oss/pandera/issues/260
             df.failure_case = df.failure_case.astype(str)
             # NOTE: this is a hack to add modin support
             if type(df).__module__.startswith("modin.pandas"):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -166,8 +166,8 @@ class SchemaErrors(ReducedPickleExceptionBase):
             msg += f"- {k}: {v}\n"
 
         def agg_failure_cases(df):
-            # TODO(arne): hack to support unhashable types, proper solution that only
-            #  casts where required: https://github.com/unionai-oss/pandera/issues/260
+            # Note: hack to support unhashable types, proper solution that only transforms
+            # when requires https://github.com/unionai-oss/pandera/issues/260
             df.failure_case = df.failure_case.astype(str)
             # NOTE: this is a hack to add modin support
             if type(df).__module__.startswith("modin.pandas"):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -166,6 +166,8 @@ class SchemaErrors(ReducedPickleExceptionBase):
             msg += f"- {k}: {v}\n"
 
         def agg_failure_cases(df):
+            # FIXME(arne): hack to support unhashable types, #260 would enable
+            df.failure_case = df.failure_case.astype(str)
             # NOTE: this is a hack to add modin support
             if type(df).__module__.startswith("modin.pandas"):
                 return (
@@ -287,6 +289,5 @@ class SchemaErrors(ReducedPickleExceptionBase):
             concat_fn(check_failure_cases)
             .reset_index(drop=True)
             .sort_values("schema_context", ascending=False)
-            .drop_duplicates()
         )
         return error_counts, failure_cases

--- a/tests/core/test_errors.py
+++ b/tests/core/test_errors.py
@@ -327,7 +327,10 @@ def test_pickling_parser_error():
 
 
 def test_unhashable_types_rendered_on_failing_checks_with_lazy_validation():
-    """Regression test for #1013, make sure the SchemaErrors are well-built."""
+    """Make sure that SchemaErrors from unhashable values are up to specification.
+
+    Regression test for https://github.com/unionai-oss/pandera/issues/1013
+    """
     schema = DataFrameSchema({"x": Column(numpy_engine.Object, Check.eq(0))})
     unhashables = [set(), {}, []]
 


### PR DESCRIPTION
Resolves: #1013 

Ad-hoc benchmarking with what I assume is a pretty-bad case:

```python
# setup
import pandas, pandera, numpy
foo = pandera.DataFrameSchema({"x": pandera.Column(int, checks=[pandera.Check.eq(0)])})
x = pandas.DataFrame(numpy.arange(0, 1_000_000, 1), columns=["x"])
# timed code
foo.validate(x, lazy=True)
```
```bash
$ code=$'try: foo.validate(x, lazy=True)\nexcept: pass'
# without `astype(str)`
$ python -m timeit -s "import pandas, pandera, numpy" -s "foo = pandera.DataFrameSchema({'x': pandera.Column(int, checks=[pandera.Check.eq(0)])})" -s "x = pandas.DataFrame(numpy.arange(0, 1_000_000, 1), columns=['x'])" "${code}"
1 loop, best of 5: 2.06 sec per loop
# # with `astype(str)`
$ python -m timeit -s "import pandas, pandera, numpy" -s "foo = pandera.DataFrameSchema({'x': pandera.Column(int, checks=[pandera.Check.eq(0)])})" -s "x = pandas.DataFrame(numpy.arange(0, 1_000_000, 1), columns=['x'])" "${code}"
1 loop, best of 5: 3.08 sec per loop
```
Seems like turning a row of integers into strings adds ~50% overall runtime to the error rendering. Given that the example is extreme, I think that's not too bad, but having the option to only run it on a Series that actually contains unhashables would be preferable. Another option would be to do this instead:

```python
def agg_failure_cases(df):
    try:
        # NOTE: this is a hack to add modin support
        if type(df).__module__.startswith("modin.pandas"):
            return (
                df.groupby(["schema_context", "column", "check"])
                .agg({"failure_case": "unique"})
                .failure_case
            )
        return df.groupby(
            ["schema_context", "column", "check"]
        ).failure_case.unique()
    except TypeError:
        # FIXME(arne): hack to support unhashable types, wait for #260
        df.failure_case = df.failure_case.astype(str)
        agg_failure_cases(df)
```

This would avoid running `astype(str)` when it's not necessary, but felt like the worse implementation to me.