### PR TITLE
Adding option for arbitrary callable to pandas from/to_format

### DIFF
--- a/docs/source/data_format_conversion.rst
+++ b/docs/source/data_format_conversion.rst
@@ -72,7 +72,7 @@ dataframe.
 
 Note that the ``{to/from}_format_kwargs`` configuration option should be
 supplied with a dictionary of key-word arguments to be passed into the
-respective pandas ``to_{format}`` method.
+respective pandas ``{to/from}_format`` method.
 
 Finally, we redefine our ``transform`` function:
 
@@ -122,6 +122,30 @@ We can test this out using a buffer to store the parquet file.
         }
     ]
 
+In addition to specifying a literal string argument for ``{to/from}_format`` a generic callable that returns a pandas dataframe can be passed. For example, ``pd.read_excel``, ``pd.read_sql``, or ``pd.read_gbq``. Depending on the function passed, some of the kwargs arguments may be required rather than optional in ``{to/from}_format_kwargs`` (``pd.read_sql`` requires a connection object).
+
+The full set of configuration options are:
+
+.. list-table:: Title
+   :widths: 50 60
+   :header-rows: 1
+
+   * - Format
+     - Argument
+   * - dict
+     - "dict" 
+   * - csv
+     - "csv"
+   * - json
+     - "json"
+   * - feather
+     - "feather"
+   * - parquet
+     - "parquet"
+   * - pickle
+     - "pickle"
+   * - Callable
+     - Callable
 
 Takeaway
 --------

--- a/docs/source/data_format_conversion.rst
+++ b/docs/source/data_format_conversion.rst
@@ -122,7 +122,19 @@ We can test this out using a buffer to store the parquet file.
         }
     ]
 
-In addition to specifying a literal string argument for ``{to/from}_format`` a generic callable that returns a pandas dataframe can be passed. For example, ``pd.read_excel``, ``pd.read_sql``, or ``pd.read_gbq``. Depending on the function passed, some of the kwargs arguments may be required rather than optional in ``{to/from}_format_kwargs`` (``pd.read_sql`` requires a connection object).
+In addition to specifying a literal string argument for ``from_format`` a generic callable that returns a pandas dataframe can be passed. For example, ``pd.read_excel``, ``pd.read_sql``, or ``pd.read_gbq``. Depending on the function passed, some of the kwargs arguments may be required rather than optional in ``from_format_kwargs`` (``pd.read_sql`` requires a connection object).
+
+A callable can also be an argument for the ``to_format`` parameter, with the additional, optional, ``to_format_buffer`` parameter. Some pandas dataframe writing methods, such as ``pd.to_pickle``, have a required path argument, that must be either a string file path or a bytes object. An example for writing data to a pickle file would be:
+
+.. testcode:: format_serialization
+
+    def custom_to_pickle(data, *args, **kwargs):
+        return data.to_pickle(*args, **kwargs)
+
+    class OutSchemaPickleCallable(OutSchema):
+        class Config:
+            to_format = custom_to_pickle
+            to_format_buffer = "pickle_file.pkl"
 
 The full set of configuration options are:
 

--- a/docs/source/data_format_conversion.rst
+++ b/docs/source/data_format_conversion.rst
@@ -122,19 +122,44 @@ We can test this out using a buffer to store the parquet file.
         }
     ]
 
-In addition to specifying a literal string argument for ``from_format`` a generic callable that returns a pandas dataframe can be passed. For example, ``pd.read_excel``, ``pd.read_sql``, or ``pd.read_gbq``. Depending on the function passed, some of the kwargs arguments may be required rather than optional in ``from_format_kwargs`` (``pd.read_sql`` requires a connection object).
+Custom Converters with Callables
+--------------------------------
 
-A callable can also be an argument for the ``to_format`` parameter, with the additional, optional, ``to_format_buffer`` parameter. Some pandas dataframe writing methods, such as ``pd.to_pickle``, have a required path argument, that must be either a string file path or a bytes object. An example for writing data to a pickle file would be:
+In addition to specifying a literal string argument for ``from_format`` a
+generic callable that returns a pandas dataframe can be passed. For example,
+``pd.read_excel``, ``pd.read_sql``, or ``pd.read_gbq``. Depending on the function
+passed, some of the kwargs arguments may be required rather than optional in
+``from_format_kwargs`` (``pd.read_sql`` requires a connection object).
+
+A callable can also be an argument for the ``to_format`` parameter, with the
+additional, optional, ``to_format_buffer`` parameter. Some pandas dataframe writing
+methods, such as ``pd.to_pickle``, have a required path argument, that must be
+either a string file path or a bytes object. An example for writing data to a
+pickle file would be:
 
 .. testcode:: format_serialization
+
+    import tempfile
 
     def custom_to_pickle(data, *args, **kwargs):
         return data.to_pickle(*args, **kwargs)
 
+    def custom_to_pickle_buffer():
+        """Create a named temporary file handle to write the pickle file."""
+        return tempfile.NamedTemporaryFile()
+
     class OutSchemaPickleCallable(OutSchema):
         class Config:
             to_format = custom_to_pickle
-            to_format_buffer = "pickle_file.pkl"
+
+            # If provided, the output of this function will be supplied as
+            # the first positional argument to the ``to_format`` function.
+            to_format_buffer = custom_to_pickle_buffer
+
+In this example, we use a ``custom_to_pickle_buffer`` function as the
+``to_format_buffer`` property, which returns a :func:`tempfile.NamedTemporaryFile`.
+This will be supplied as a positional argument to the ``custom_to_pickle``
+function.
 
 The full set of configuration options are:
 
@@ -145,7 +170,7 @@ The full set of configuration options are:
    * - Format
      - Argument
    * - dict
-     - "dict" 
+     - "dict"
    * - csv
      - "csv"
    * - json

--- a/pandera/api/pandas/model_config.py
+++ b/pandera/api/pandas/model_config.py
@@ -64,6 +64,8 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: ``pa.typing.DataFrame[Schema](data)``. If None, returns a dataframe.
     to_format: Optional[Union[Format, Callable]] = None
 
+    to_format_buffer: Optional[Union[str, Callable]] = None
+
     #: a dictionary keyword arguments to pass into the writer function that
     #: converts the pandera-validate-able object to type ``to_format``.
     #: The writer function is implemented in the pandera.typing

--- a/pandera/api/pandas/model_config.py
+++ b/pandera/api/pandas/model_config.py
@@ -1,6 +1,6 @@
 """Class-based dataframe model API configuration for pandas."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from pandera.api.base.model_config import BaseModelConfig
 from pandera.api.pandas.types import PandasDtypeInputTypes, StrictType
@@ -51,7 +51,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: schemas used in the context of the pandera type constructor
     #: ``pa.typing.DataFrame[Schema](data)``. If None, assumes a data structure
     #: compatible with the ``pandas.DataFrame`` constructor.
-    from_format: Optional[Format] = None
+    from_format: Optional[Union[Format, Callable]] = None
 
     #: a dictionary keyword arguments to pass into the reader function that
     #: converts the object of type ``from_format`` to a pandera-validate-able
@@ -62,7 +62,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: data format to serialize into after validation. This option only applies
     #: to  schemas used in the context of the pandera type constructor
     #: ``pa.typing.DataFrame[Schema](data)``. If None, returns a dataframe.
-    to_format: Optional[Format] = None
+    to_format: Optional[Union[Format, Callable]] = None
 
     #: a dictionary keyword arguments to pass into the writer function that
     #: converts the pandera-validate-able object to type ``to_format``.

--- a/pandera/api/pandas/model_config.py
+++ b/pandera/api/pandas/model_config.py
@@ -64,6 +64,8 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: ``pa.typing.DataFrame[Schema](data)``. If None, returns a dataframe.
     to_format: Optional[Union[Format, Callable]] = None
 
+    #: Buffer to be provided when to_format is a custom callable. See docs for
+    #: example of how to implement an example of a to format function.
     to_format_buffer: Optional[Union[str, Callable]] = None
 
     #: a dictionary keyword arguments to pass into the writer function that

--- a/pandera/typing/formats.py
+++ b/pandera/typing/formats.py
@@ -1,7 +1,7 @@
 """Serialization formats for dataframes."""
 
 from enum import Enum
-from typing import Union
+from typing import Callable, Union
 
 try:
     from typing import Literal  # type: ignore
@@ -41,6 +41,9 @@ class Formats(Enum):
     #: python pickle file format
     pickle = "pickle"
 
+    #: generic callable function for import / export
+    custom = Callable
+
 
 Format = Union[
     Literal[Formats.csv],
@@ -49,4 +52,5 @@ Format = Union[
     Literal[Formats.feather],
     Literal[Formats.parquet],
     Literal[Formats.pickle],
+    Literal[Formats.custom],
 ]

--- a/pandera/typing/formats.py
+++ b/pandera/typing/formats.py
@@ -41,9 +41,6 @@ class Formats(Enum):
     #: python pickle file format
     pickle = "pickle"
 
-    #: generic callable function for import / export
-    custom = Callable
-
 
 Format = Union[
     Literal[Formats.csv],
@@ -52,5 +49,4 @@ Format = Union[
     Literal[Formats.feather],
     Literal[Formats.parquet],
     Literal[Formats.pickle],
-    Literal[Formats.custom],
 ]

--- a/pandera/typing/formats.py
+++ b/pandera/typing/formats.py
@@ -1,7 +1,7 @@
 """Serialization formats for dataframes."""
 
 from enum import Enum
-from typing import Callable, Union
+from typing import Union
 
 try:
     from typing import Literal  # type: ignore

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -4,7 +4,6 @@ import io
 from typing import (  # type: ignore[attr-defined]
     TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
     Generic,
     List,
@@ -112,7 +111,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                     ) from exc
             return obj
 
-        if isinstance(config.from_format, Callable):
+        if callable(config.from_format):
             reader = config.from_format
         else:
             reader = {
@@ -139,7 +138,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         if config.to_format is None:
             return data
 
-        if isinstance(config.to_format, Callable):
+        if callable(config.to_format):
             writer, buffer = config.to_format, None
         else:
             writer, buffer = {

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -143,16 +143,15 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
             writer = functools.partial(config.to_format, data)
             if callable(config.to_format_buffer):
                 buffer = config.to_format_buffer()
-            elif isinstance(config.to_format_buffer, str):
-                buffer = config.to_format_buffer
             elif config.to_format_buffer is None:
                 buffer = None
             else:
                 raise TypeError(
-                    "To format buffer must be None, callable, or str"
+                    "to_format_buffer must be Callable or None, found "
+                    f"{config.to_format_buffer}"
                 )
         else:
-            writer, buffer = {
+            writer, buffer = {  # type: ignore[assignment]
                 Formats.dict: (data.to_dict, None),
                 Formats.csv: (data.to_csv, None),
                 Formats.json: (data.to_json, None),

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -141,7 +141,16 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
 
         if callable(config.to_format):
             writer = functools.partial(config.to_format, data)
-            buffer = config.to_format_buffer or None
+            if callable(config.to_format_buffer):
+                buffer = config.to_format_buffer()
+            elif isinstance(config.to_format_buffer, str):
+                buffer = config.to_format_buffer
+            elif config.to_format_buffer is None:
+                buffer = None
+            else:
+                raise TypeError(
+                    "To format buffer must be None, callable, or str"
+                )
         else:
             writer, buffer = {
                 Formats.dict: (data.to_dict, None),

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -145,7 +145,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 buffer = config.to_format_buffer()
             elif config.to_format_buffer is None:
                 buffer = None
-            else:
+            else:  # pragma: no cover
                 raise TypeError(
                     "to_format_buffer must be Callable or None, found "
                     f"{config.to_format_buffer}"

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -1,5 +1,6 @@
 """Typing definitions and helpers."""
 # pylint:disable=abstract-method,disable=too-many-ancestors
+import functools
 import io
 from typing import (  # type: ignore[attr-defined]
     TYPE_CHECKING,
@@ -139,7 +140,8 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
             return data
 
         if callable(config.to_format):
-            writer, buffer = config.to_format, None
+            writer = functools.partial(config.to_format, data)
+            buffer = config.to_format_buffer or None
         else:
             writer, buffer = {
                 Formats.dict: (data.to_dict, None),

--- a/tests/core/test_from_to_format_conversions.py
+++ b/tests/core/test_from_to_format_conversions.py
@@ -2,6 +2,7 @@
 """Test conversion of data from and to different formats."""
 
 import io
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -18,6 +19,11 @@ class InSchema(pa.DataFrameModel):
 class InSchemaCsv(InSchema):
     class Config:
         from_format = "csv"
+
+
+class InSchemaCsvCallable(InSchema):
+    class Config:
+        from_format = pd.read_csv
 
 
 class InSchemaDict(InSchema):
@@ -46,6 +52,11 @@ class InSchemaPickle(InSchema):
         from_format = "pickle"
 
 
+class InSchemaPickleCallable(InSchema):
+    class Config:
+        from_format = pd.read_pickle
+
+
 class OutSchema(InSchema):
     float_col: pa.typing.Series[float]
 
@@ -53,6 +64,16 @@ class OutSchema(InSchema):
 class OutSchemaCsv(OutSchema):
     class Config:
         to_format = "csv"
+        to_format_kwargs = {"index": None}
+
+
+def custom_to_csv(data: Any, *args, **kwargs):
+    return data.to_csv(*args, **kwargs)
+
+
+class OutSchemaCsvCallable(OutSchema):
+    class Config:
+        to_format = custom_to_csv
         to_format_kwargs = {"index": None}
 
 
@@ -83,6 +104,16 @@ class OutSchemaPickle(OutSchema):
         to_format = "pickle"
 
 
+def custom_to_pickle(data: Any, *args, **kwargs):
+    return data.to_pickle(*args, **kwargs)
+
+
+class OutSchemaPickleCallable(OutSchema):
+    class Config:
+        to_format = custom_to_pickle
+        to_format_buffer = io.BytesIO()
+
+
 def mock_dataframe() -> pd.DataFrame:
     """Create a valid mock dataframe."""
     return pd.DataFrame({"str_col": ["a"], "int_col": [1]})
@@ -110,6 +141,8 @@ def _needs_pyarrow(schema) -> bool:
     "schema,to_fn,buf_cls",
     [
         [InSchemaCsv, lambda df, x: df.to_csv(x, index=None), io.StringIO],
+        [InSchemaCsvCallable,
+            lambda df, x: df.to_csv(x, index=None), io.StringIO],
         [InSchemaDict, lambda df: df.to_dict(orient="records"), None],
         [
             InSchemaJson,
@@ -120,6 +153,7 @@ def _needs_pyarrow(schema) -> bool:
         [InSchemaFeather, lambda df, x: df.to_feather(x), io.BytesIO],
         [InSchemaParquet, lambda df, x: df.to_parquet(x), io.BytesIO],
         [InSchemaPickle, lambda df, x: df.to_pickle(x), io.BytesIO],
+        [InSchemaPickleCallable, lambda df, x: df.to_pickle(x), io.BytesIO],
     ],
 )
 def test_from_format(schema, to_fn, buf_cls):
@@ -166,11 +200,13 @@ def test_from_format(schema, to_fn, buf_cls):
     "schema,from_fn,buf_cls",
     [
         [OutSchemaCsv, pd.read_csv, io.StringIO],
+        [OutSchemaCsvCallable, pd.read_csv, io.StringIO],
         [OutSchemaDict, pd.DataFrame, None],
         [OutSchemaJson, lambda x: pd.read_json(x, orient="records"), None],
         [OutSchemaFeather, pd.read_feather, io.BytesIO],
         [OutSchemaParquet, pd.read_parquet, io.BytesIO],
         [OutSchemaPickle, pd.read_pickle, io.BytesIO],
+        [OutSchemaPickleCallable, pd.read_pickle, io.BytesIO],
     ],
 )
 def test_to_format(schema, from_fn, buf_cls):

--- a/tests/core/test_from_to_format_conversions.py
+++ b/tests/core/test_from_to_format_conversions.py
@@ -68,6 +68,15 @@ class OutSchemaCsv(OutSchema):
 
 
 def custom_to_csv(data: Any, *args, **kwargs):
+    """
+    Function to save data to csv, used in to_format function.
+
+    Args:
+        data: The data object to be saved.
+
+    Returns:
+        Returns none if file path provided, else to_format buffer
+    """
     return data.to_csv(*args, **kwargs)
 
 
@@ -105,13 +114,22 @@ class OutSchemaPickle(OutSchema):
 
 
 def custom_to_pickle(data: Any, *args, **kwargs):
+    """
+    Function to save data to pickle, used in to_format function.
+
+    Args:
+        data: The data object to be saved.
+
+    Returns:
+        Returns none if file path provided, else to_format buffer
+    """
     return data.to_pickle(*args, **kwargs)
 
 
 class OutSchemaPickleCallable(OutSchema):
     class Config:
         to_format = custom_to_pickle
-        to_format_buffer = io.BytesIO()
+        to_format_buffer = io.BytesIO
 
 
 def mock_dataframe() -> pd.DataFrame:


### PR DESCRIPTION
Called new format custom, can change. Could also add an elif check after the Callable instance check to verify it's a str that's within the Formats enum, and raise an error if not.