### PR TITLE
Fix issue where str dtype in a multiindex dataframe schema results in invalid example

### DIFF
--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -1192,7 +1192,7 @@ def multiindex_strategy(
         if dtype in {"object", "str"} or dtype.startswith("string"):
             # pylint: disable=cell-var-from-loop,undefined-loop-variable
             strategy = strategy.map(
-                lambda df: df.assign(**{name: df[name].map(str)})
+                lambda df, name=name: df.assign(**{name: df[name].map(str)})
             )
 
     if any(nullable_index.values()):


### PR DESCRIPTION
Signed-off-by: Glenn Sugar <glenn.sugar@gmail.com>

Fixes #1049 