### PR TITLE
Unpinning ray from requirements-dev.txt

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,10 +101,8 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pandas-version: ["1.2.0", "1.3.0", "latest"]
+        pandas-version: ["1.3.0", "latest"]
         exclude:
-        - python-version: "3.10"
-          pandas-version: "1.2.0"
         - python-version: "3.10"
           pandas-version: "1.3.0"
         include:
@@ -212,7 +210,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ (matrix.os != 'windows-latest' && matrix.python-version != '3.10') || matrix.python-version != '3.7' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray
@@ -221,9 +219,9 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Check Docstrings
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.python-version != '3.7' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session doctests
 
       - name: Check Docs
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.python-version != '3.7' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session docs

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }}
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
 
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -211,7 +211,8 @@ jobs:
         # ray CI issues with the following:
         # - windows, python 3.10
         # - mac, python 3.7
-        if: ${{ (matrix.os != 'windows-latest' && matrix.python-version != '3.10') || (matrix.os != 'macos-latest' && matrix.python-version != '3.7') }}
+        # Tracking issue: https://github.com/modin-project/modin/issues/5466
+        if: ${{ (matrix.os != 'windows-latest' && matrix.python-version != '3.10') || matrix.python-version != '3.7' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,11 +149,11 @@ jobs:
 
       - name: Install Conda Deps [Latest]
         if: ${{ matrix.pandas-version == 'latest' }}
-        run: mamba install -c conda-forge pandas geopandas ray
+        run: mamba install -c conda-forge pandas geopandas ray-default
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas ray
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas ray-default
 
       - name: Install Pip Deps
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -208,7 +208,10 @@ jobs:
           CI_MODIN_ENGINES: dask
 
       - name: Unit Tests - Modin-Ray
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
+        # ray CI issues with the following:
+        # - windows, python 3.10
+        # - mac, python 3.7
+        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' || matrix.os != 'macos-latest' && matrix.python-version != '3.7' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -210,7 +210,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray
@@ -219,9 +219,9 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Check Docstrings
-        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session doctests
 
       - name: Check Docs
-        if: ${{ matrix.os != 'windows-latest' && !contains(['3.7', '3.10'], matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session docs

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -211,7 +211,7 @@ jobs:
         # ray CI issues with the following:
         # - windows, python 3.10
         # - mac, python 3.7
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' || matrix.os != 'macos-latest' && matrix.python-version != '3.7' }}
+        if: ${{ (matrix.os != 'windows-latest' && matrix.python-version != '3.10') || (matrix.os != 'macos-latest' && matrix.python-version != '3.7') }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,11 +149,16 @@ jobs:
 
       - name: Install Conda Deps [Latest]
         if: ${{ matrix.pandas-version == 'latest' }}
-        run: mamba install -c conda-forge pandas geopandas ray-default
+        run: mamba install -c conda-forge pandas geopandas
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas ray-default
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }}
+
+      # ray currently cannot be installed on python 3.10, windows
+      - name: Remove Ray from Deps
+        if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
+        run: sed -i 's/^ray//g' requirements-dev.txt
 
       - name: Install Pip Deps
         run: |
@@ -203,7 +208,7 @@ jobs:
           CI_MODIN_ENGINES: dask
 
       - name: Unit Tests - Modin-Ray
-        if: ${{ matrix.python-version != '3.10' }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,11 +149,11 @@ jobs:
 
       - name: Install Conda Deps [Latest]
         if: ${{ matrix.pandas-version == 'latest' }}
-        run: mamba install -c conda-forge pandas geopandas
+        run: mamba install -c conda-forge pandas geopandas ray
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas ray
 
       - name: Install Pip Deps
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -80,7 +80,7 @@ dependencies:
 
   - pip:
       - furo
-      - ray <= 1.7.0; python_version < '3.10'
+      - ray
       - types-click
       - types-pyyaml
       - types-pkg_resources

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,7 @@ twine
 asv
 pre_commit
 furo
-ray <= 1.7.0; python_version < '3.10'
+ray; python_version < '3.10'
 types-click
 types-pyyaml
 types-pkg_resources

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,7 @@ twine
 asv
 pre_commit
 furo
-ray; python_version < '3.10'
+ray
 types-click
 types-pyyaml
 types-pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.md") as f:
     long_description = f.read()
@@ -12,8 +12,8 @@ _extras_require = {
     "hypotheses": ["scipy"],
     "io": ["pyyaml >= 5.1", "black", "frictionless"],
     "pyspark": ["pyspark >= 3.2.0"],
-    "modin": ["modin", "ray <= 1.7.0", "dask"],
-    "modin-ray": ["modin", "ray <= 1.7.0"],
+    "modin": ["modin", "ray", "dask"],
+    "modin-ray": ["modin", "ray"],
     "modin-dask": ["modin", "dask"],
     "dask": ["dask"],
     "mypy": ["pandas-stubs"],


### PR DESCRIPTION
As discussed in the discord channel, need to unpin `ray` in the `requirements-dev.txt` file.

Issue first came up because of an error (`ERROR: Could not find a version that satisfies the requirement ray<=1.7.0`) when running `pip install -r requirements-dev.txt` on mac with an apple silicon processor. The error happens because there are no available wheels for ray < 1.8.0 for apple silicon processors.

Signed-off-by: erichamers <erichamers@gmail.com>