### PR TITLE
Small fixes for Category

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -604,6 +604,9 @@ class Category(DataType, dtypes.Category):
         """Convert a categorical to
         a Pandera :class:`pandera.dtypes.pandas_engine.Category`."""
         return cls(categories=cat.categories, ordered=cat.ordered)  # type: ignore
+    
+    def __str__(self) -> str:
+        return repr(self.type)
 
 
 if PANDAS_1_3_0_PLUS:

--- a/pandera/engines/utils.py
+++ b/pandera/engines/utils.py
@@ -29,7 +29,7 @@ def numpy_pandas_coercible(series: pd.Series, type_: Any) -> pd.Series:
         except Exception:  # pylint:disable=broad-except
             return False
 
-    return series.map(_coercible)
+    return series.map(_coercible).astype(bool)
 
 
 def numpy_pandas_coerce_failure_cases(


### PR DESCRIPTION
This PR solves issue with the `Category` type.

####  Makes numpy_pandas_coercible return a Series of `bool`

It solves #1073

#### More informative error message when coercing category

#931

The error message would now be  
```
pandera.errors.SchemaError: 
Error while coercing 'category' to type CategoricalDtype(categories=[1, 2], ordered=False): 
Could not coerce <class 'pandas.core.series.Series'> data_container into type category:
```
instead of 
```
pandera.errors.SchemaError: 
Error while coercing 'category' to type category:
Could not coerce <class 'pandas.core.series.Series'> data_container into type category:
```

- [ ] Should a custom f-string be used instead of `repr(self.dtype)` ? As `repr` is multiline whene there is too much categories, it may be better to use a oneline string.

#### closes 

closes #1073
closes #931