### PR TITLE
multimethod is a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,9 @@ setup(
     packages=find_packages(include=["pandera*"]),
     package_data={"pandera": ["py.typed"]},
     install_requires=[
-        "packaging >= 20.0",
+        "multimethod",
         "numpy >= 1.19.0",
+        "packaging >= 20.0",
         "pandas >= 1.2.0",
         "pydantic",
         "typing_extensions >= 3.7.4.3 ; python_version<'3.8'",


### PR DESCRIPTION
`python -c "import pandera"`
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/__init__.py", line 5, in <module>
    from pandera.accessors import pandas_accessor
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/accessors/pandas_accessor.py", line 7, in <module>
    from pandera.api.pandas.array import SeriesSchema
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/api/pandas/__init__.py", line 3, in <module>
    from pandera.api.pandas.array import SeriesSchema
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/api/pandas/array.py", line 11, in <module>
    from pandera.backends.pandas.array import (
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/backends/__init__.py", line 4, in <module>
    import pandera.backends.base.builtin_checks
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/backends/base/builtin_checks.py", line 14, in <module>
    from pandera.api.checks import Check
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/api/checks.py", line 18, in <module>
    from pandera.api.base.checks import BaseCheck, CheckResult
  File "/opt/homebrew/lib/python3.11/site-packages/pandera/api/base/checks.py", line 18, in <module>
    from multimethod import multidispatch as _multidispatch
ModuleNotFoundError: No module named 'multimethod'
```