### PR TITLE
Use isinstance if data_container contains a subtype of str

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -695,7 +695,7 @@ class NpString(numpy_engine.String):
                 ["<class 'str'>", "<class 'numpy.str_'>"]
             )
         else:
-            is_python_string = data_container.map(type).isin([str, np.str_])  # type: ignore[operator]
+            is_python_string = data_container.map(lambda x: isinstance(x, str))
         return is_python_string | data_container.isna()
 
 


### PR DESCRIPTION
After one of the latest releases (probably 0.14.0) it looks like subtypes of `str` results in a schema error. This PR suggest to allow subtypes of `str` by using `isinstance` instead of checking that `type` is in a predefined list (which limits the allowed values to `str` and `numpy.str_`.

An example of use case which is not allowed at the moment is `StrEnum` which is part of the standard library from python v3.11, and as a third-party package for earlier versions. I'd expect that the dataframe created below should be valid, but it results in a schema error because subtypes of `str` are not recognized as strings.

```python
try:
    from enum import StrEnum
except ImportError:
    # <3.11
    from strenum import StrEnum

import pandas as pd
from pandera import SchemaModel, Field
from pandera.typing import Series 

class Direction(StrEnum):
    NORTH = "N"
    SOUTH = "S"
    EAST = "E"
    WEST = "W"

class DestinationSchema(SchemaModel):
    city: Series[str] = Field()
    direction: Series[str] = Field(isin=Direction)

assert isinstance(Direction.SOUTH, str) 
DestinationSchema(pd.DataFrame({"city": ["Berlin"], "direction": [Direction.SOUTH]}))
```
  