### PR TITLE
add jupyterlite as docs dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -87,4 +87,5 @@ dependencies:
       - types-pkg_resources
       - types-requests
       - types-pytz
+      - jupyterlite
       - jupyterlite_sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -54,4 +54,5 @@ types-pyyaml
 types-pkg_resources
 types-requests
 types-pytz
+jupyterlite
 jupyterlite_sphinx


### PR DESCRIPTION
not specifying jupyterlite as a dependency caused issues with the `jupyterlite_sphinx` extension where the pyodide kernel was not available in the deployed docs