### PR TITLE
Add `default` column value param

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,6 @@ dependencies:
 
   # testing
   - isort >= 5.7.0
-  - codecov
   - mypy <= 0.982
   - pylint = 2.12.2
   - pytest

--- a/pandera/api/base/model_components.py
+++ b/pandera/api/base/model_components.py
@@ -42,6 +42,7 @@ class BaseFieldInfo:
         "dtype_kwargs",
         "title",
         "description",
+        "default",
     )
 
     def __init__(
@@ -56,6 +57,7 @@ class BaseFieldInfo:
         dtype_kwargs: Optional[Dict[str, Any]] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        default: Optional[Any] = None,
     ) -> None:
         self.checks = to_checklist(checks)
         self.nullable = nullable
@@ -68,6 +70,7 @@ class BaseFieldInfo:
         self.dtype_kwargs = dtype_kwargs
         self.title = title
         self.description = description
+        self.default = default
 
     @property
     def name(self) -> str:

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -181,7 +181,6 @@ class ArraySchema(BaseSchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
-            default=self.default,
         )
 
     def __call__(

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -36,7 +36,7 @@ class ArraySchema(BaseSchema):
         name: Any = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        default:  Optional[Any] = None,
+        default: Optional[Any] = None,
     ) -> None:
         """Initialize array schema.
 

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -63,7 +63,6 @@ class ArraySchema(BaseSchema):
         :param title: A human-readable label for the series.
         :param description: An arbitrary textual description of the series.
         :param default: The default value for missing values in the series.
-        :type nullable: bool
         """
 
         super().__init__(
@@ -300,6 +299,7 @@ class SeriesSchema(ArraySchema):
         name: str = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        default: Optional[Any] = None,
     ) -> None:
         """Initialize series schema base object.
 
@@ -326,6 +326,7 @@ class SeriesSchema(ArraySchema):
         :param name: series name.
         :param title: A human-readable label for the series.
         :param description: An arbitrary textual description of the series.
+        :param default: The default value for missing values in the series.
 
         """
         super().__init__(
@@ -338,6 +339,7 @@ class SeriesSchema(ArraySchema):
             name,
             title,
             description,
+            default,
         )
         self.index = index
 

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -36,6 +36,7 @@ class ArraySchema(BaseSchema):
         name: Any = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        default:  Optional[Any] = None,
     ) -> None:
         """Initialize array schema.
 
@@ -61,6 +62,7 @@ class ArraySchema(BaseSchema):
         :param name: column name in dataframe to validate.
         :param title: A human-readable label for the series.
         :param description: An arbitrary textual description of the series.
+        :param default: The default value for missing values in the series.
         :type nullable: bool
         """
 
@@ -84,6 +86,7 @@ class ArraySchema(BaseSchema):
         self.report_duplicates = report_duplicates
         self.title = title
         self.description = description
+        self.default = default
 
         for check in self.checks:
             if check.groupby is not None and not self._allow_groupby:
@@ -178,6 +181,7 @@ class ArraySchema(BaseSchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
+            default=self.default,
         )
 
     def __call__(

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -98,6 +98,7 @@ class Column(ArraySchema):
         self.required = required
         self.name = name
         self.regex = regex
+        self.default = default
 
     @property
     def _allow_groupby(self) -> bool:
@@ -167,6 +168,7 @@ class Column(ArraySchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
+            default=self.default
         )
 
     def get_regex_columns(

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -98,7 +98,6 @@ class Column(ArraySchema):
         self.required = required
         self.name = name
         self.regex = regex
-        self.default = default
 
     @property
     def _allow_groupby(self) -> bool:
@@ -292,7 +291,6 @@ class Index(ArraySchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
-            default=self.default,
         )
 
     def __eq__(self, other):

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -84,7 +84,7 @@ class Column(ArraySchema):
             name=name,
             title=title,
             description=description,
-            default=default
+            default=default,
         )
         if (
             name is not None
@@ -265,7 +265,6 @@ class Index(ArraySchema):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-        default: Optional[Any] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrameSchema or SeriesSchema Index.
 
@@ -293,7 +292,7 @@ class Index(ArraySchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
-            default=self.default
+            default=self.default,
         )
 
     def __eq__(self, other):

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -29,6 +29,7 @@ class Column(ArraySchema):
         regex: bool = False,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        default: Optional[Any] = None,
     ) -> None:
         """Create column validator object.
 
@@ -52,6 +53,7 @@ class Column(ArraySchema):
             regex pattern to apply to multiple columns in a dataframe.
         :param title: A human-readable label for the column.
         :param description: An arbitrary textual description of the column.
+        :param default: The default value for missing values in the column.
 
         :raises SchemaInitError: if impossible to build schema from parameters
 
@@ -82,6 +84,7 @@ class Column(ArraySchema):
             name=name,
             title=title,
             description=description,
+            default=default
         )
         if (
             name is not None
@@ -116,6 +119,7 @@ class Column(ArraySchema):
             "regex": self.regex,
             "title": self.title,
             "description": self.description,
+            "default": self.default,
         }
 
     def set_name(self, name: str):
@@ -260,6 +264,7 @@ class Index(ArraySchema):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
+
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrameSchema or SeriesSchema Index.
 

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -168,7 +168,6 @@ class Column(ArraySchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
-            default=self.default
         )
 
     def get_regex_columns(
@@ -266,7 +265,7 @@ class Index(ArraySchema):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-
+        default: Optional[Any] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
         """Validate DataFrameSchema or SeriesSchema Index.
 
@@ -294,6 +293,7 @@ class Index(ArraySchema):
             random_state=random_state,
             lazy=lazy,
             inplace=inplace,
+            default=self.default
         )
 
     def __eq__(self, other):

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -317,6 +317,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         # NOTE: Move this into its own schema-backend variant. This is where
         # the benefits of separating the schema spec from the backend
         # implementation comes in.
+
         if hasattr(check_obj, "dask"):
             # special case for dask dataframes
             if inplace:

--- a/pandera/api/pandas/model_components.py
+++ b/pandera/api/pandas/model_components.py
@@ -120,6 +120,7 @@ def Field(
     dtype_kwargs: Optional[Dict[str, Any]] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    default: Optional[Any] = None,
     **kwargs,
 ) -> Any:
     """Used to provide extra information about a field of a DataFrameModel.
@@ -148,6 +149,7 @@ def Field(
         field.
     :param title: A human-readable label for the field.
     :param description: An arbitrary textual description of the field.
+    :param default: Optional default value of the field.
     :param kwargs: Specify custom checks that have been registered with the
         :class:`~pandera.extensions.register_check_method` decorator.
     """
@@ -189,6 +191,7 @@ def Field(
         alias=alias,
         title=title,
         description=description,
+        default=default,
         dtype_kwargs=dtype_kwargs,
     )
 

--- a/pandera/api/pandas/model_components.py
+++ b/pandera/api/pandas/model_components.py
@@ -70,6 +70,7 @@ class FieldInfo(BaseFieldInfo):
             checks=checks,
             title=self.title,
             description=self.description,
+            default=self.default
         )
 
     def to_index(
@@ -89,6 +90,7 @@ class FieldInfo(BaseFieldInfo):
             checks=checks,
             title=self.title,
             description=self.description,
+            default=self.default,
         )
 
 

--- a/pandera/api/pandas/model_components.py
+++ b/pandera/api/pandas/model_components.py
@@ -70,7 +70,7 @@ class FieldInfo(BaseFieldInfo):
             checks=checks,
             title=self.title,
             description=self.description,
-            default=self.default
+            default=self.default,
         )
 
     def to_index(

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -75,8 +75,6 @@ class ArraySchemaBackend(PandasSchemaBackend):
             random_state,
         )
 
-
-
         # run the core checks
         for core_check, args in (
             (self.check_name, (field_obj_subsample, schema)),

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -43,9 +43,6 @@ class ArraySchemaBackend(PandasSchemaBackend):
         default: Optional[Any] = None,
     ):
         # pylint: disable=too-many-locals
-        if pd.notna(schema.default):
-            inplace = True
-
         error_handler = SchemaErrorHandler(lazy)
         check_obj = self.preprocess(check_obj, inplace)
 

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -1,6 +1,6 @@
 """Pandera array backends."""
 
-from typing import cast, Any, List, Optional
+from typing import cast, List, Optional
 
 import pandas as pd
 from multimethod import DispatchError
@@ -40,21 +40,20 @@ class ArraySchemaBackend(PandasSchemaBackend):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-        default: Optional[Any] = None,
     ):
         # pylint: disable=too-many-locals
         error_handler = SchemaErrorHandler(lazy)
         check_obj = self.preprocess(check_obj, inplace)
+
+        # fill nans with `default` if it's present
+        if pd.notna(schema.default):
+            check_obj.fillna(schema.default, inplace=True)
 
         if schema.coerce:
             try:
                 check_obj = self.coerce_dtype(check_obj, schema=schema)
             except SchemaError as exc:
                 error_handler.collect_error(exc.reason_code, exc)
-
-        # fill nans with `default` if it's present
-        if not pd.isnull(default):
-            check_obj.fillna(default, inplace=True)
 
         field_obj_subsample = self.subsample(
             check_obj if is_field(check_obj) else check_obj[schema.name],

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -37,6 +37,10 @@ class ColumnBackend(ArraySchemaBackend):
         inplace: bool = False,
     ) -> pd.DataFrame:
         """Validation backend implementation for pandas dataframe columns.."""
+
+        if pd.notna(self.default):
+            inplace = True
+
         if not inplace:
             check_obj = check_obj.copy()
 

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -37,10 +37,6 @@ class ColumnBackend(ArraySchemaBackend):
         inplace: bool = False,
     ) -> pd.DataFrame:
         """Validation backend implementation for pandas dataframe columns.."""
-
-        if pd.notna(self.default):
-            inplace = True
-
         if not inplace:
             check_obj = check_obj.copy()
 
@@ -50,7 +46,7 @@ class ColumnBackend(ArraySchemaBackend):
             raise SchemaError(
                 schema,
                 check_obj,
-                "column name is set to None. Pass the ``name` argument when "
+                "column name is set to None. Pass the ``name`` argument when "
                 "initializing a Column object, or use the ``set_name`` "
                 "method.",
             )
@@ -244,7 +240,7 @@ class IndexBackend(ArraySchemaBackend):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-        default: Optional[Any] = None
+        default: Optional[Any] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
         if is_multiindex(check_obj.index):
             raise SchemaError(

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -2,7 +2,7 @@
 
 import traceback
 from copy import copy, deepcopy
-from typing import Iterable, List, Optional, Union
+from typing import Any, Iterable, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -240,6 +240,7 @@ class IndexBackend(ArraySchemaBackend):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
+        default: Optional[Any] = None
     ) -> Union[pd.DataFrame, pd.Series]:
         if is_multiindex(check_obj.index):
             raise SchemaError(
@@ -266,6 +267,7 @@ class IndexBackend(ArraySchemaBackend):
                 random_state=random_state,
                 lazy=lazy,
                 inplace=inplace,
+                default=default,
             ),
         )
         return check_obj

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -2,7 +2,7 @@
 
 import traceback
 from copy import copy, deepcopy
-from typing import Any, Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -240,7 +240,6 @@ class IndexBackend(ArraySchemaBackend):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-        default: Optional[Any] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
         if is_multiindex(check_obj.index):
             raise SchemaError(
@@ -267,7 +266,6 @@ class IndexBackend(ArraySchemaBackend):
                 random_state=random_state,
                 lazy=lazy,
                 inplace=inplace,
-                default=default,
             ),
         )
         return check_obj

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,6 @@ shapely
 fastapi
 black >= 22.1.0
 isort >= 5.7.0
-codecov
 mypy <= 0.982
 pylint == 2.12.2
 pytest

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -878,7 +878,6 @@ def test_column_default_works_when_dtype_match(dtype: Any, default: Any):
     """Test ``default`` fills ``nan`` values as expected when the ``dtype`` matches that of the ``Column``"""
     column = Column(dtype, name="column1", default=default)
     df = pd.DataFrame({"column1": [None]})
-
     column.validate(df, inplace=True)
 
     assert df.iloc[0]["column1"] == default
@@ -900,12 +899,3 @@ def test_column_default_errors_on_dtype_mismatch(dtype: Any, default: Any):
 
     with pytest.raises(errors.SchemaError):
         column.validate(df, inplace=True)
-
-
-def test_error_is_raised_when_default_is_set_and_inplace_is_false():
-    """Test that setting a ``default`` raises an error is ``inplace = False``"""
-    column = Column(str, name="column1", default="a default")
-    df = pd.DataFrame({"column1": [None]})
-
-    with pytest.raises(errors.SchemaError):
-        column.validate(df, inplace=False)

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -874,7 +874,7 @@ def test_index_validation_pandas_string_dtype():
         ("Int64", 0),
     ],
 )
-def test_column_default_works_when_dtype_match(dtype: Any, default: any):
+def test_column_default_works_when_dtype_match(dtype: Any, default: Any):
     """Test ``default`` fills ``nan`` values as expected when the ``dtype`` matches that of the ``Column``"""
     column = Column(dtype, name="column1", default=default)
     df = pd.DataFrame({"column1": [None]})
@@ -893,7 +893,7 @@ def test_column_default_works_when_dtype_match(dtype: Any, default: any):
         ("Int64", "a default"),
     ],
 )
-def test_column_default_errors_on_dtype_mismatch(dtype: Any, default: any):
+def test_column_default_errors_on_dtype_mismatch(dtype: Any, default: Any):
     """Test that setting a ``default`` of different ``dtype`` to that of the ```Column`` raises an error"""
     column = Column(dtype, name="column1", default=default)
     df = pd.DataFrame({"column1": [None]})

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -876,10 +876,26 @@ def test_index_validation_pandas_string_dtype():
 def test_column_default_works_when_dtype_match(dtype: Any, default:any):
     column_name = 'column1'
     col =  Column(dtype, default=default)
-
     df = pd.DataFrame({column_name: [None]})
-
     schema = DataFrameSchema(columns={column_name: col})
     df = schema.validate(df)
 
     assert df.iloc[0][column_name] == default
+
+@pytest.mark.parametrize(
+    "dtype,default",
+    [
+        (str, 1),
+        (bool, 42.0),
+        (float, True),
+        ("Int64", "a default"),
+   ]
+)
+def test_column_default_errors_on_dtype_mismatch(dtype: Any, default:any):
+    column_name = 'column1'
+    col =  Column(dtype, default=default)
+    df = pd.DataFrame({column_name: [None]})
+    schema = DataFrameSchema(columns={column_name: col})
+
+    with pytest.raises(errors.SchemaError):
+        schema.validate(df)

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -874,13 +874,12 @@ def test_index_validation_pandas_string_dtype():
    ]
 )
 def test_column_default_works_when_dtype_match(dtype: Any, default:any):
-    column_name = 'column1'
-    col =  Column(dtype, default=default)
-    df = pd.DataFrame({column_name: [None]})
-    schema = DataFrameSchema(columns={column_name: col})
-    df = schema.validate(df)
+    column =  Column(dtype, name='column1', default=default)
+    df = pd.DataFrame({'column1': [None]})
 
-    assert df.iloc[0][column_name] == default
+    df = column.validate(df)
+
+    assert df.iloc[0]['column1'] == default
 
 @pytest.mark.parametrize(
     "dtype,default",
@@ -892,10 +891,10 @@ def test_column_default_works_when_dtype_match(dtype: Any, default:any):
    ]
 )
 def test_column_default_errors_on_dtype_mismatch(dtype: Any, default:any):
-    column_name = 'column1'
-    col =  Column(dtype, default=default)
-    df = pd.DataFrame({column_name: [None]})
-    schema = DataFrameSchema(columns={column_name: col})
+    column =  Column(dtype, name='column1', default=default)
+    df = pd.DataFrame({'column1': [None]})
 
     with pytest.raises(errors.SchemaError):
-        schema.validate(df)
+        column.validate(df)
+
+

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -863,3 +863,23 @@ def test_index_validation_pandas_string_dtype():
     )
 
     assert isinstance(schema.validate(df), pd.DataFrame)
+
+@pytest.mark.parametrize(
+    "dtype,default",
+    [
+        (str, "a default"),
+        (bool, True),
+        (float, 42.0),
+        ("Int64", 0),
+   ]
+)
+def test_column_default_works_when_dtype_match(dtype: Any, default:any):
+    column_name = 'column1'
+    col =  Column(dtype, default=default)
+
+    df = pd.DataFrame({column_name: [None]})
+
+    schema = DataFrameSchema(columns={column_name: col})
+    df = schema.validate(df)
+
+    assert df.iloc[0][column_name] == default

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -864,6 +864,7 @@ def test_index_validation_pandas_string_dtype():
 
     assert isinstance(schema.validate(df), pd.DataFrame)
 
+
 @pytest.mark.parametrize(
     "dtype,default",
     [
@@ -871,15 +872,17 @@ def test_index_validation_pandas_string_dtype():
         (bool, True),
         (float, 42.0),
         ("Int64", 0),
-   ]
+    ],
 )
-def test_column_default_works_when_dtype_match(dtype: Any, default:any):
-    column =  Column(dtype, name='column1', default=default)
-    df = pd.DataFrame({'column1': [None]})
+def test_column_default_works_when_dtype_match(dtype: Any, default: any):
+    """Test ``default`` fills ``nan`` values as expected when the ``dtype`` matches that of the ``Column``"""
+    column = Column(dtype, name="column1", default=default)
+    df = pd.DataFrame({"column1": [None]})
 
-    df = column.validate(df)
+    column.validate(df, inplace=True)
 
-    assert df.iloc[0]['column1'] == default
+    assert df.iloc[0]["column1"] == default
+
 
 @pytest.mark.parametrize(
     "dtype,default",
@@ -888,13 +891,21 @@ def test_column_default_works_when_dtype_match(dtype: Any, default:any):
         (bool, 42.0),
         (float, True),
         ("Int64", "a default"),
-   ]
+    ],
 )
-def test_column_default_errors_on_dtype_mismatch(dtype: Any, default:any):
-    column =  Column(dtype, name='column1', default=default)
-    df = pd.DataFrame({'column1': [None]})
+def test_column_default_errors_on_dtype_mismatch(dtype: Any, default: any):
+    """Test that setting a ``default`` of different ``dtype`` to that of the ```Column`` raises an error"""
+    column = Column(dtype, name="column1", default=default)
+    df = pd.DataFrame({"column1": [None]})
 
     with pytest.raises(errors.SchemaError):
-        column.validate(df)
+        column.validate(df, inplace=True)
 
 
+def test_error_is_raised_when_default_is_set_and_inplace_is_false():
+    """Test that setting a ``default`` raises an error is ``inplace = False``"""
+    column = Column(str, name="column1", default="a default")
+    df = pd.DataFrame({"column1": [None]})
+
+    with pytest.raises(errors.SchemaError):
+        column.validate(df, inplace=False)

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1995,49 +1995,45 @@ def test_missing_columns():
 
 
 @pytest.mark.parametrize(
-    "array_schema,series,expected_values",
+    "series_schema,series,expected_values",
     [
         (
-            ArraySchema(str, default="the second"),
+            SeriesSchema(str, default="the second"),
             pd.Series(["the first", None], dtype=str),
             ["the first", "the second"],
         ),
         (
-            ArraySchema(float, default=0.0),
+            SeriesSchema(float, default=0.0),
             pd.Series([1.0, None], dtype=float),
             [1.0, 0.0],
         ),
         (
-            ArraySchema(bool, default=False),
+            SeriesSchema(bool, default=False),
             pd.Series([True, None], dtype=bool),
             [True, False],
         ),
         (
-            ArraySchema("Int64", default=0),
+            SeriesSchema("Int64", default=0),
             pd.Series([1, None], dtype="Int64"),
             [1, 0],
         ),
     ],
 )
 def test_default_with_correct_dtype(
-    array_schema: ArraySchema, series: pd.Series, expected_values: list
+    series_schema: SeriesSchema, series: pd.Series, expected_values: list
 ):
     """Test that missing rows are backfilled with the default if missing"""
-    array_schema.validate(series)
-
-    assert set(series.values) == set(expected_values)
+    validated_series = series_schema.validate(series)
+    assert set(validated_series.values) == set(expected_values)
 
 
 def test_default_with_incorrect_dtype_raises_error():
     """Test that if a default with the incorrect dtype is passed, a SchemaError is raised"""
-    array_schema = ArraySchema(
-        str,
-        default=1,
-    )
+    series_schema = SeriesSchema(str, default=1)
 
     series = pd.Series(["the first", None])
     with pytest.raises(errors.SchemaError):
-        array_schema.validate(series)
+        series_schema.validate(series)
 
 
 def test_pandas_dataframe_subclass_validation():

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1993,6 +1993,29 @@ def test_missing_columns():
             "column2",
         ]
 
+def test_default_with_correct_dtype():
+    """Test that missing rows are backfilled with the default if missing"""
+    array_schema = ArraySchema(
+        str,
+        default="the second",
+    )
+
+    series = pd.Series(["the first", None])
+
+    array_schema.validate(series)
+
+    assert set(series.values) == set(["the first", "the second"])
+
+def test_default_with_incorrect_dtype_raises_error():
+    """Test that if a default with the incorrect dtype is passed, a SchemaError is raised"""
+    array_schema = ArraySchema(
+        str,
+        default=1,
+    )
+
+    series = pd.Series(["the first", None])
+    with pytest.raises(errors.SchemaError):
+        array_schema.validate(series)
 
 def test_pandas_dataframe_subclass_validation():
     """Test that DataFrame subclasses can be validated by pandera."""

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1993,36 +1993,40 @@ def test_missing_columns():
             "column2",
         ]
 
+
 @pytest.mark.parametrize(
     "array_schema,series,expected_values",
     [
-       (
-        ArraySchema(str, default="the second"),
-        pd.Series(["the first", None], dtype=str),
-        ["the first", "the second"]
-       ),
-       (
-        ArraySchema(float, default=0.0),
-        pd.Series([1.0, None], dtype=float),
-        [1.0, 0.0]
-       ),
-       (
-        ArraySchema(bool, default=False),
-        pd.Series([True, None], dtype=bool),
-        [True, False]
-       ),
-       (
-        ArraySchema("Int64", default=0),
-        pd.Series([1, None], dtype="Int64"),
-        [1, 0]
-       )
+        (
+            ArraySchema(str, default="the second"),
+            pd.Series(["the first", None], dtype=str),
+            ["the first", "the second"],
+        ),
+        (
+            ArraySchema(float, default=0.0),
+            pd.Series([1.0, None], dtype=float),
+            [1.0, 0.0],
+        ),
+        (
+            ArraySchema(bool, default=False),
+            pd.Series([True, None], dtype=bool),
+            [True, False],
+        ),
+        (
+            ArraySchema("Int64", default=0),
+            pd.Series([1, None], dtype="Int64"),
+            [1, 0],
+        ),
     ],
 )
-def test_default_with_correct_dtype(array_schema: ArraySchema, series: pd.Series, expected_values: list):
+def test_default_with_correct_dtype(
+    array_schema: ArraySchema, series: pd.Series, expected_values: list
+):
     """Test that missing rows are backfilled with the default if missing"""
     array_schema.validate(series)
 
     assert set(series.values) == set(expected_values)
+
 
 def test_default_with_incorrect_dtype_raises_error():
     """Test that if a default with the incorrect dtype is passed, a SchemaError is raised"""
@@ -2034,6 +2038,7 @@ def test_default_with_incorrect_dtype_raises_error():
     series = pd.Series(["the first", None])
     with pytest.raises(errors.SchemaError):
         array_schema.validate(series)
+
 
 def test_pandas_dataframe_subclass_validation():
     """Test that DataFrame subclasses can be validated by pandera."""

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1993,18 +1993,36 @@ def test_missing_columns():
             "column2",
         ]
 
-def test_default_with_correct_dtype():
+@pytest.mark.parametrize(
+    "array_schema,series,expected_values",
+    [
+       (
+        ArraySchema(str, default="the second"),
+        pd.Series(["the first", None], dtype=str),
+        ["the first", "the second"]
+       ),
+       (
+        ArraySchema(float, default=0.0),
+        pd.Series([1.0, None], dtype=float),
+        [1.0, 0.0]
+       ),
+       (
+        ArraySchema(bool, default=False),
+        pd.Series([True, None], dtype=bool),
+        [True, False]
+       ),
+       (
+        ArraySchema("Int64", default=0),
+        pd.Series([1, None], dtype="Int64"),
+        [1, 0]
+       )
+    ],
+)
+def test_default_with_correct_dtype(array_schema: ArraySchema, series: pd.Series, expected_values: list):
     """Test that missing rows are backfilled with the default if missing"""
-    array_schema = ArraySchema(
-        str,
-        default="the second",
-    )
-
-    series = pd.Series(["the first", None])
-
     array_schema.validate(series)
 
-    assert set(series.values) == set(["the first", "the second"])
+    assert set(series.values) == set(expected_values)
 
 def test_default_with_incorrect_dtype_raises_error():
     """Test that if a default with the incorrect dtype is passed, a SchemaError is raised"""

--- a/tests/pyspark/test_schemas_on_pyspark.py
+++ b/tests/pyspark/test_schemas_on_pyspark.py
@@ -293,7 +293,7 @@ def test_nullable(
 
     if version.parse(np.__version__) >= version.parse(
         "1.24.0"
-    ) and SPARK_VERSION <= version.parse("3.3.1"):
+    ) and SPARK_VERSION <= version.parse("3.3.2"):
         # this should raise an error due to pyspark code using numpy.bool,
         # which is deprecated.
         pytest.xfail()
@@ -430,7 +430,7 @@ def test_dtype_coercion(from_dtype, to_dtype, data):
 
     if version.parse(np.__version__) >= version.parse(
         "1.24.0"
-    ) and SPARK_VERSION <= version.parse("3.3.1"):
+    ) and SPARK_VERSION <= version.parse("3.3.2"):
         # this should raise an error due to pyspark code using numpy.bool,
         # which is deprecated.
         pytest.xfail()


### PR DESCRIPTION
In relation to https://github.com/unionai-oss/pandera/issues/502, this PR (and this fork) introduces a default value using `pandas.fillna()`! When building `Column`s in a `DataFrameSchema`, you can add a `default` argument to fill `NaN`s in dataframe being validated:

```python
>>> df = pd.DataFrame({"some_col": [None]})
>>> df
    some_col
0  None
>>> schema = DataFrameSchema(columns={"some_col": Column(str, default="the default value")})
>>> df = schema.validate(df)
>>> df
    some_col
0  the default value
>>> 🚀 
```

This PR includes the updated code, tests to assert `default` works as expected, and adds docstrings in line with the rest of the codebase.

TODO:
- [x] Linting? Confirm what standards are used 💅 
- [ ] Approval! Ensure this PR covers the full scope ✅ 

