### PR TITLE
Refactor schema backends

### DIFF
--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -133,8 +133,8 @@ catch these errors and inspect the failure cases in a more granular form:
 
     Schema errors and failure cases:
         schema_context        column                check check_number  \
-    0  DataFrameSchema          None  column_in_dataframe         None
-    1  DataFrameSchema          None     column_in_schema         None
+    0  DataFrameSchema          None     column_in_schema         None
+    1  DataFrameSchema          None  column_in_dataframe         None
     2           Column    int_column       dtype('int64')         None
     3           Column  float_column     dtype('float64')         None
     4           Column  float_column      greater_than(0)            0
@@ -142,8 +142,8 @@ catch these errors and inspect the failure cases in a more granular form:
     6           Column    str_column          equal_to(a)            0
 
          failure_case index
-    0     date_column  None
-    1  unknown_column  None
+    0  unknown_column  None
+    1     date_column  None
     2          object  None
     3           int64  None
     4               0     0

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -6,13 +6,9 @@ from pandera.accessors import pandas_accessor
 from pandera.api import extensions
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
-from pandera.api.pandas import (
-    Column,
-    DataFrameSchema,
-    Index,
-    MultiIndex,
-    SeriesSchema,
-)
+from pandera.api.pandas.array import SeriesSchema
+from pandera.api.pandas.container import DataFrameSchema
+from pandera.api.pandas.components import Column, Index, MultiIndex
 from pandera.api.pandas.model import DataFrameModel, SchemaModel
 from pandera.api.pandas.model_components import Field, check, dataframe_check
 from pandera.dtypes import (
@@ -60,7 +56,9 @@ from pandera.engines.pandas_engine import (
     pandas_version,
 )
 
-import pandera.backends
+import pandera.backends.base.builtin_checks
+import pandera.backends.base.builtin_hypotheses
+import pandera.backends.pandas
 
 from pandera.schema_inference.pandas import infer_schema
 from pandera.decorators import check_input, check_io, check_output, check_types

--- a/pandera/api/base/checks.py
+++ b/pandera/api/base/checks.py
@@ -1,6 +1,5 @@
 """Data validation base check."""
 
-from collections import namedtuple
 import inspect
 from itertools import chain
 from typing import (
@@ -8,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    NamedTuple,
     Optional,
     Tuple,
     Type,
@@ -20,10 +20,14 @@ from multimethod import multidispatch as _multidispatch
 
 from pandera.backends.base import BaseCheckBackend
 
-CheckResult = namedtuple(
-    "CheckResult",
-    ["check_output", "check_passed", "checked_object", "failure_cases"],
-)
+
+class CheckResult(NamedTuple):
+    """Check result for user-defined checks."""
+
+    check_output: Any
+    check_passed: bool
+    checked_object: Any
+    failure_cases: Any
 
 
 GroupbyObject = Union[

--- a/pandera/api/base/schema.py
+++ b/pandera/api/base/schema.py
@@ -10,7 +10,7 @@ from abc import ABC
 from functools import wraps
 from typing import Any, Dict, Tuple, Type, Union
 
-# from pandera.backends.base import BaseSchemaBackend
+from pandera.backends.base import BaseSchemaBackend
 from pandera.errors import BackendNotFoundError
 from pandera.dtypes import DataType
 
@@ -20,8 +20,8 @@ DtypeInputTypes = Union[str, type, DataType, Type]
 class BaseSchema(ABC):
     """Core schema specification."""
 
-    BACKEND_REGISTRY: Dict[  # type: ignore
-        Tuple[Type, Type], Type["BaseSchemaBackend"]  # type: ignore
+    BACKEND_REGISTRY: Dict[
+        Tuple[Type, Type], Type[BaseSchemaBackend]
     ] = {}  # noqa
 
     def __init__(
@@ -64,12 +64,12 @@ class BaseSchema(ABC):
         raise NotImplementedError
 
     @classmethod
-    def register_backend(cls, type_: Type, backend: Type["BaseSchemaBackend"]):  # type: ignore
+    def register_backend(cls, type_: Type, backend: Type[BaseSchemaBackend]):
         """Register a schema backend for this class."""
         cls.BACKEND_REGISTRY[(cls, type_)] = backend
 
     @classmethod
-    def get_backend(cls, check_obj: Any) -> Type["BaseSchemaBackend"]:  # type: ignore
+    def get_backend(cls, check_obj: Any) -> BaseSchemaBackend:
         """Get the backend associated with the type of ``check_obj`` ."""
         check_obj_cls = type(check_obj)
         classes = inspect.getmro(check_obj_cls)

--- a/pandera/api/pandas/__init__.py
+++ b/pandera/api/pandas/__init__.py
@@ -1,5 +1,1 @@
 """Pandas core."""
-
-from pandera.api.pandas.array import SeriesSchema
-from pandera.api.pandas.components import Column, Index, MultiIndex
-from pandera.api.pandas.container import DataFrameSchema

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -8,10 +8,6 @@ import pandas as pd
 
 from pandera import errors
 from pandera import strategies as st
-from pandera.backends.pandas.array import (
-    ArraySchemaBackend,
-    SeriesSchemaBackend,
-)
 from pandera.api.base.schema import BaseSchema, inferred_schema_guard
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
@@ -28,8 +24,6 @@ TArraySchemaBase = TypeVar("TArraySchemaBase", bound="ArraySchema")
 
 class ArraySchema(BaseSchema):
     """Base array validator object."""
-
-    BACKEND = ArraySchemaBackend()
 
     def __init__(
         self,
@@ -144,7 +138,7 @@ class ArraySchema(BaseSchema):
             (including time series).
         :returns: ``Series`` with coerced data type
         """
-        return self.BACKEND.coerce_dtype(check_obj, schema=self)
+        return self.get_backend(check_obj).coerce_dtype(check_obj, schema=self)
 
     def validate(
         self,
@@ -175,7 +169,7 @@ class ArraySchema(BaseSchema):
         :returns: validated DataFrame or Series.
 
         """
-        return self.BACKEND.validate(
+        return self.get_backend(check_obj).validate(
             check_obj,
             schema=self,
             head=head,
@@ -290,8 +284,6 @@ class ArraySchema(BaseSchema):
 
 class SeriesSchema(ArraySchema):
     """Series validator."""
-
-    BACKEND = SeriesSchemaBackend()
 
     def __init__(
         self,

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -1,7 +1,7 @@
 """Core pandas schema component specifications."""
 
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import pandas as pd
 
@@ -173,9 +173,12 @@ class Column(ArraySchema):
         :param columns: columns to regex pattern match
         :returns: matchin columns
         """
-        return self.get_backend(pd.DataFrame()).get_regex_columns(
-            self, columns
-        )
+        # pylint: disable=import-outside-toplevel
+        from pandera.backends.pandas.components import ColumnBackend
+
+        return cast(
+            ColumnBackend, self.get_backend(pd.DataFrame())
+        ).get_regex_columns(self, columns)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -7,11 +7,6 @@ import pandas as pd
 
 import pandera.strategies as st
 from pandera import errors
-from pandera.backends.pandas.components import (
-    ColumnBackend,
-    IndexBackend,
-    MultiIndexBackend,
-)
 from pandera.api.pandas.array import ArraySchema
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.types import CheckList, PandasDtypeInputTypes
@@ -20,8 +15,6 @@ from pandera.dtypes import UniqueSettings
 
 class Column(ArraySchema):
     """Validate types and properties of DataFrame columns."""
-
-    BACKEND = ColumnBackend()
 
     def __init__(
         self,
@@ -161,7 +154,7 @@ class Column(ArraySchema):
             otherwise creates a copy of the data.
         :returns: validated DataFrame.
         """
-        return self.BACKEND.validate(
+        return self.get_backend(check_obj).validate(
             check_obj,
             self,
             head=head,
@@ -180,7 +173,9 @@ class Column(ArraySchema):
         :param columns: columns to regex pattern match
         :returns: matchin columns
         """
-        return self.BACKEND.get_regex_columns(self, columns)
+        return self.get_backend(pd.DataFrame()).get_regex_columns(
+            self, columns
+        )
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -243,8 +238,6 @@ class Column(ArraySchema):
 class Index(ArraySchema):
     """Validate types and properties of a DataFrame Index."""
 
-    BACKEND = IndexBackend()
-
     @property
     def names(self):
         """Get index names in the Index schema component."""
@@ -282,7 +275,7 @@ class Index(ArraySchema):
             otherwise creates a copy of the data.
         :returns: validated DataFrame or Series.
         """
-        return self.BACKEND.validate(
+        return self.get_backend(check_obj).validate(
             check_obj,
             self,
             head=head,
@@ -349,8 +342,6 @@ class MultiIndex(DataFrameSchema):
     This class inherits from :class:`~pandera.api.pandas.container.DataFrameSchema` to
     leverage its validation logic.
     """
-
-    BACKEND = MultiIndexBackend()
 
     def __init__(
         self,
@@ -480,7 +471,7 @@ class MultiIndex(DataFrameSchema):
             otherwise creates a copy of the data.
         :returns: validated DataFrame or Series.
         """
-        return self.BACKEND.validate(
+        return self.get_backend(check_obj).validate(
             check_obj,
             schema=self,
             head=head,

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -12,7 +12,6 @@ import pandas as pd
 
 from pandera import errors
 from pandera import strategies as st
-from pandera.backends.pandas.container import DataFrameSchemaBackend
 from pandera.api.base.schema import BaseSchema, inferred_schema_guard
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
@@ -29,8 +28,6 @@ N_INDENT_SPACES = 4
 
 class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
     """A light-weight pandas DataFrame validator."""
-
-    BACKEND = DataFrameSchemaBackend()
 
     def __init__(
         self,
@@ -225,7 +222,9 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 regex_dtype.update(
                     {
                         c: column.dtype
-                        for c in column.BACKEND.get_regex_columns(
+                        for c in column.get_backend(
+                            dataframe
+                        ).get_regex_columns(
                             column,
                             dataframe.columns,
                         )
@@ -249,7 +248,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         self._dtype = pandas_engine.Engine.dtype(value) if value else None
 
     def coerce_dtype(self, check_obj: pd.DataFrame) -> pd.DataFrame:
-        return self.BACKEND.coerce_dtype(check_obj, schema=self)
+        return self.get_backend(check_obj).coerce_dtype(check_obj, schema=self)
 
     def validate(
         self,
@@ -367,7 +366,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 UserWarning,
             )
 
-        return self.BACKEND.validate(
+        return self.get_backend(check_obj).validate(
             check_obj,
             schema=self,
             head=head,

--- a/pandera/backends/__init__.py
+++ b/pandera/backends/__init__.py
@@ -1,7 +1,7 @@
 """Pandera backends."""
 
 # ensure that base builtin checks and hypothesis are registered
-import pandera.backends.base.builtin_checks
-import pandera.backends.base.builtin_hypotheses
+# import pandera.backends.base.builtin_checks
+# import pandera.backends.base.builtin_hypotheses
 
-import pandera.backends.pandas
+# import pandera.backends.pandas

--- a/pandera/backends/__init__.py
+++ b/pandera/backends/__init__.py
@@ -1,7 +1,1 @@
 """Pandera backends."""
-
-# ensure that base builtin checks and hypothesis are registered
-# import pandera.backends.base.builtin_checks
-# import pandera.backends.base.builtin_hypotheses
-
-# import pandera.backends.pandas

--- a/pandera/backends/base/__init__.py
+++ b/pandera/backends/base/__init__.py
@@ -6,16 +6,30 @@ together to implement the pandera schema specification.
 """
 
 from abc import ABC
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 
-from pandera.errors import SchemaErrorReason
+# from pandera.api.base.checks import BaseCheck
+from pandera.errors import SchemaError, SchemaErrorReason
 
 
-class SchemaFunctionResult(NamedTuple):
+class CoreCheckResult(NamedTuple):
+    """Namedtuple for holding results of core checks."""
+
     passed: bool
+    check: Union[str, "BaseCheck"]  # type: ignore
+    check_index: Optional[int] = None
+    check_output: Optional[Any] = None
     reason_code: Optional[SchemaErrorReason] = None
     message: Optional[str] = None
     failure_cases: Optional[Any] = None
+    schema_error: Optional[SchemaError] = None
+    original_exc: Optional[Exception] = None
+
+
+class CoreParserResult(NamedTuple):
+    """Namedtuple for holding core parser results."""
+
+    ...
 
 
 class BaseSchemaBackend(ABC):
@@ -61,7 +75,6 @@ class BaseSchemaBackend(ABC):
     def coerce_dtype(
         self,
         check_obj,
-        *,
         schema=None,
         error_handler=None,
     ):
@@ -79,7 +92,7 @@ class BaseSchemaBackend(ABC):
         """Run a single check on the check object."""
         raise NotImplementedError
 
-    def run_checks(self, check_obj, schema, error_handler):
+    def run_checks(self, check_obj, schema):
         """Run a list of checks on the check object."""
         raise NotImplementedError
 
@@ -88,7 +101,6 @@ class BaseSchemaBackend(ABC):
         check_obj,
         schema_components,
         lazy,
-        error_handler,
     ):
         """Run checks for all schema components."""
         raise NotImplementedError

--- a/pandera/backends/base/__init__.py
+++ b/pandera/backends/base/__init__.py
@@ -6,7 +6,16 @@ together to implement the pandera schema specification.
 """
 
 from abc import ABC
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
+
+from pandera.errors import SchemaErrorReason
+
+
+class SchemaFunctionResult(NamedTuple):
+    passed: bool
+    reason_code: Optional[SchemaErrorReason] = None
+    message: Optional[str] = None
+    failure_cases: Optional[Any] = None
 
 
 class BaseSchemaBackend(ABC):

--- a/pandera/backends/base/__init__.py
+++ b/pandera/backends/base/__init__.py
@@ -76,7 +76,6 @@ class BaseSchemaBackend(ABC):
         self,
         check_obj,
         schema=None,
-        error_handler=None,
     ):
         """Coerce the data type of the check object."""
         raise NotImplementedError
@@ -122,7 +121,7 @@ class BaseSchemaBackend(ABC):
         raise NotImplementedError
 
     def failure_cases_metadata(
-        self, schema_name: str, schema_errors: List[Dict[str, Any]]
+        self, schema_name: str, schema_errors: List[SchemaError]
     ):
         """Get failure cases metadata for lazy validation."""
         raise NotImplementedError

--- a/pandera/backends/pandas/__init__.py
+++ b/pandera/backends/pandas/__init__.py
@@ -5,34 +5,79 @@ import pandas as pd
 import pandera.typing
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
+from pandera.api.pandas.array import SeriesSchema
+from pandera.api.pandas.container import DataFrameSchema
+from pandera.api.pandas.components import Column, Index, MultiIndex
 
+from pandera.backends.pandas import builtin_checks, builtin_hypotheses
 from pandera.backends.pandas.checks import PandasCheckBackend
 from pandera.backends.pandas.hypotheses import PandasHypothesisBackend
-from pandera.backends.pandas import builtin_checks, builtin_hypotheses
+from pandera.backends.pandas.array import SeriesSchemaBackend
+from pandera.backends.pandas.container import DataFrameSchemaBackend
+from pandera.backends.pandas.components import (
+    ColumnBackend,
+    IndexBackend,
+    MultiIndexBackend,
+)
 
 
-data_types = [pd.DataFrame, pd.Series]
+dataframe_datatypes = [pd.DataFrame]
+series_datatypes = [pd.Series]
+index_datatypes = [pd.Index]
+multiindex_datatypes = [pd.MultiIndex]
 
 if pandera.typing.dask.DASK_INSTALLED:
     import dask.dataframe as dd
 
-    data_types.extend([dd.DataFrame, dd.Series])
+    dataframe_datatypes.append(dd.DataFrame)
+    series_datatypes.append(dd.Series)
+    index_datatypes.append(dd.Index)
 
 if pandera.typing.modin.MODIN_INSTALLED:
     import modin.pandas as mpd
 
-    data_types.extend([mpd.DataFrame, mpd.Series])
+    dataframe_datatypes.append(mpd.DataFrame)
+    series_datatypes.append(mpd.Series)
+    index_datatypes.append(mpd.Index)
+    multiindex_datatypes.append(mpd.MultiIndex)
 
 if pandera.typing.pyspark.PYSPARK_INSTALLED:
     import pyspark.pandas as ps
 
-    data_types.extend([ps.DataFrame, ps.Series])
+    dataframe_datatypes.append(ps.DataFrame)
+    series_datatypes.append(ps.Series)
+    index_datatypes.append(ps.Index)
+    multiindex_datatypes.append(ps.MultiIndex)
 
 if pandera.typing.geopandas.GEOPANDAS_INSTALLED:
     import geopandas as gpd
 
-    data_types.extend([gpd.GeoDataFrame, gpd.GeoSeries])
+    dataframe_datatypes.append(gpd.GeoDataFrame)
+    series_datatypes.append(gpd.GeoSeries)
 
-for t in data_types:
+for t in [
+    *dataframe_datatypes,
+    *series_datatypes,
+    *index_datatypes,
+]:
     Check.register_backend(t, PandasCheckBackend)
     Hypothesis.register_backend(t, PandasHypothesisBackend)
+
+for t in dataframe_datatypes:
+    DataFrameSchema.register_backend(t, DataFrameSchemaBackend)
+    # SeriesSchema.register_backend(t, SeriesSchemaBackend)
+    Column.register_backend(t, ColumnBackend)
+    MultiIndex.register_backend(t, MultiIndexBackend)
+    Index.register_backend(t, IndexBackend)
+
+for t in series_datatypes:
+    # DataFrameSchema.register_backend(t, DataFrameSchemaBackend)
+    SeriesSchema.register_backend(t, SeriesSchemaBackend)
+    Column.register_backend(t, ColumnBackend)
+    Index.register_backend(t, IndexBackend)
+
+for t in index_datatypes:
+    Index.register_backend(t, IndexBackend)
+
+for t in multiindex_datatypes:
+    MultiIndex.register_backend(t, MultiIndexBackend)

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -47,9 +47,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
 
         if schema.coerce:
             try:
-                check_obj = self.coerce_dtype(
-                    check_obj, schema=schema, error_handler=error_handler
-                )
+                check_obj = self.coerce_dtype(check_obj, schema=schema)
             except SchemaError as exc:
                 error_handler.collect_error(exc.reason_code, exc)
 
@@ -75,10 +73,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
             (self.check_nullable, (field_obj_subsample, schema)),
             (self.check_unique, (field_obj_subsample, schema)),
             (self.check_dtype, (field_obj_subsample, schema)),
-            (
-                self.run_checks,
-                (check_obj_subsample, schema, error_handler, lazy),
-            ),
+            (self.run_checks, (check_obj_subsample, schema)),
         ):
             results = core_check(*args)
             if isinstance(results, CoreCheckResult):
@@ -120,7 +115,6 @@ class ArraySchemaBackend(PandasSchemaBackend):
         check_obj,
         schema=None,
         # pylint: disable=unused-argument
-        error_handler: SchemaErrorHandler = None,
     ):
         """Coerce type of a pd.Series by type specified in dtype.
 
@@ -292,14 +286,11 @@ class SeriesSchemaBackend(ArraySchemaBackend):
         self,
         check_obj,
         schema=None,
-        error_handler: SchemaErrorHandler = None,
     ):
         if hasattr(check_obj, "pandera"):
             check_obj = check_obj.pandera.add_schema(schema)
 
-        check_obj = super().coerce_dtype(
-            check_obj, schema=schema, error_handler=error_handler
-        )
+        check_obj = super().coerce_dtype(check_obj, schema=schema)
 
         if hasattr(check_obj, "pandera"):
             check_obj = check_obj.pandera.add_schema(schema)

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -1,11 +1,11 @@
 """Pandera array backends."""
 
-import traceback
-from typing import cast, Iterable, NamedTuple, Optional
+from typing import cast, List, Optional
 
 import pandas as pd
 from multimethod import DispatchError
 
+from pandera.backends.base import CoreCheckResult
 from pandera.backends.pandas.base import PandasSchemaBackend
 from pandera.backends.pandas.error_formatters import (
     reshape_failure_cases,
@@ -21,16 +21,6 @@ from pandera.errors import (
     SchemaErrors,
     SchemaErrorReason,
 )
-
-
-class CoreCheckResult(NamedTuple):
-    """Namedtuple for holding results of core checks."""
-
-    check: str
-    reason_code: SchemaErrorReason
-    passed: bool
-    message: Optional[str] = None
-    failure_cases: Optional[Iterable] = None
 
 
 class ArraySchemaBackend(PandasSchemaBackend):
@@ -80,30 +70,42 @@ class ArraySchemaBackend(PandasSchemaBackend):
         )
 
         # run the core checks
-        for core_check in (
-            self.check_name,
-            self.check_nullable,
-            self.check_unique,
-            self.check_dtype,
+        for core_check, args in (
+            (self.check_name, (field_obj_subsample, schema)),
+            (self.check_nullable, (field_obj_subsample, schema)),
+            (self.check_unique, (field_obj_subsample, schema)),
+            (self.check_dtype, (field_obj_subsample, schema)),
+            (
+                self.run_checks,
+                (check_obj_subsample, schema, error_handler, lazy),
+            ),
         ):
-            check_result = core_check(field_obj_subsample, schema)
-            if not check_result.passed:
-                error_handler.collect_error(
-                    check_result.reason_code,
-                    SchemaError(
+            results = core_check(*args)
+            if isinstance(results, CoreCheckResult):
+                results = [results]
+            results = cast(List[CoreCheckResult], results)
+            for result in results:
+                if result.passed:
+                    continue
+
+                if result.schema_error is not None:
+                    error = result.schema_error
+                else:
+                    error = SchemaError(
                         schema=schema,
                         data=check_obj,
-                        message=check_result.message,
-                        failure_cases=check_result.failure_cases,
-                        check=check_result.check,
-                        reason_code=check_result.reason_code,
-                    ),
-                )
-
-        check_results = self.run_checks(
-            check_obj_subsample, schema, error_handler, lazy
-        )
-        assert all(check_results)
+                        message=result.message,
+                        failure_cases=result.failure_cases,
+                        check=result.check,
+                        check_index=result.check_index,
+                        check_output=result.check_output,
+                        reason_code=result.reason_code,
+                    )
+                    error_handler.collect_error(
+                        result.reason_code,
+                        error,
+                        original_exc=result.original_exc,
+                    )
 
         if lazy and error_handler.collected_errors:
             raise SchemaErrors(
@@ -116,7 +118,6 @@ class ArraySchemaBackend(PandasSchemaBackend):
     def coerce_dtype(
         self,
         check_obj,
-        *,
         schema=None,
         # pylint: disable=unused-argument
         error_handler: SchemaErrorHandler = None,
@@ -145,11 +146,11 @@ class ArraySchemaBackend(PandasSchemaBackend):
                 check=f"coerce_dtype('{schema.dtype}')",
             ) from exc
 
-    def check_name(self, check_obj: pd.Series, schema):
+    def check_name(self, check_obj: pd.Series, schema) -> CoreCheckResult:
         return CoreCheckResult(
+            passed=schema.name is None or check_obj.name == schema.name,
             check=f"field_name('{schema.name}')",
             reason_code=SchemaErrorReason.WRONG_FIELD_NAME,
-            passed=schema.name is None or check_obj.name == schema.name,
             message=(
                 f"Expected {type(check_obj)} to have name '{schema.name}', "
                 f"found '{check_obj.name}'"
@@ -157,13 +158,13 @@ class ArraySchemaBackend(PandasSchemaBackend):
             failure_cases=scalar_failure_case(check_obj.name),
         )
 
-    def check_nullable(self, check_obj: pd.Series, schema):
+    def check_nullable(self, check_obj: pd.Series, schema) -> CoreCheckResult:
         isna = check_obj.isna()
         passed = schema.nullable or not isna.any()
         return CoreCheckResult(
+            passed=cast(bool, passed),
             check="not_nullable",
             reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,
-            passed=cast(bool, passed),
             message=(
                 f"non-nullable series '{check_obj.name}' contains "
                 f"null values:\n{check_obj[isna]}"
@@ -173,7 +174,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
             ),
         )
 
-    def check_unique(self, check_obj: pd.Series, schema):
+    def check_unique(self, check_obj: pd.Series, schema) -> CoreCheckResult:
         passed = True
         failure_cases = None
         message = None
@@ -204,14 +205,14 @@ class ArraySchemaBackend(PandasSchemaBackend):
                 )
 
         return CoreCheckResult(
+            passed=passed,
             check="field_uniqueness",
             reason_code=SchemaErrorReason.SERIES_CONTAINS_DUPLICATES,
-            passed=passed,
             message=message,
             failure_cases=failure_cases,
         )
 
-    def check_dtype(self, check_obj: pd.Series, schema):
+    def check_dtype(self, check_obj: pd.Series, schema) -> CoreCheckResult:
         passed = True
         failure_cases = None
         msg = None
@@ -240,16 +241,16 @@ class ArraySchemaBackend(PandasSchemaBackend):
                 )
 
         return CoreCheckResult(
+            passed=passed,
             check=f"dtype('{schema.dtype}')",
             reason_code=SchemaErrorReason.WRONG_DATATYPE,
-            passed=passed,
             message=msg,
             failure_cases=failure_cases,
         )
 
     # pylint: disable=unused-argument
-    def run_checks(self, check_obj, schema, error_handler, lazy):
-        check_results = []
+    def run_checks(self, check_obj, schema) -> List[CoreCheckResult]:
+        check_results: List[CoreCheckResult] = []
         for check_index, check in enumerate(schema.checks):
             check_args = [None] if is_field(check_obj) else [schema.name]
             try:
@@ -262,11 +263,6 @@ class ArraySchemaBackend(PandasSchemaBackend):
                         *check_args,
                     )
                 )
-            except SchemaError as err:
-                error_handler.collect_error(
-                    SchemaErrorReason.DATAFRAME_CHECK,
-                    err,
-                )
             except Exception as err:  # pylint: disable=broad-except
                 # catch other exceptions that may occur when executing the Check
                 if isinstance(err, DispatchError):
@@ -274,21 +270,17 @@ class ArraySchemaBackend(PandasSchemaBackend):
                     # multimethod, get the underlying __cause__
                     err = err.__cause__
                 err_msg = f'"{err.args[0]}"' if len(err.args) > 0 else ""
-                err_str = f"{err.__class__.__name__}({ err_msg})"
-                error_handler.collect_error(
-                    SchemaErrorReason.CHECK_ERROR,
-                    SchemaError(
-                        schema=schema,
-                        data=check_obj,
-                        message=(
-                            f"Error while executing check function: {err_str}\n"
-                            + traceback.format_exc()
-                        ),
-                        failure_cases=scalar_failure_case(err_str),
+                msg = f"{err.__class__.__name__}({err_msg})"
+                check_results.append(
+                    CoreCheckResult(
+                        passed=False,
                         check=check,
                         check_index=check_index,
-                    ),
-                    original_exc=err,
+                        reason_code=SchemaErrorReason.CHECK_ERROR,
+                        message=msg,
+                        failure_cases=scalar_failure_case(msg),
+                        original_exc=err,
+                    )
                 )
         return check_results
 
@@ -299,7 +291,6 @@ class SeriesSchemaBackend(ArraySchemaBackend):
     def coerce_dtype(
         self,
         check_obj,
-        *,
         schema=None,
         error_handler: SchemaErrorHandler = None,
     ):

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -2,8 +2,6 @@
 
 import warnings
 from typing import (
-    Any,
-    Dict,
     FrozenSet,
     Iterable,
     List,
@@ -25,7 +23,7 @@ from pandera.backends.pandas.error_formatters import (
     reshape_failure_cases,
     scalar_failure_case,
 )
-from pandera.errors import FailureCaseMetadata, SchemaErrorReason
+from pandera.errors import FailureCaseMetadata, SchemaError, SchemaErrorReason
 
 
 class ColumnInfo(NamedTuple):
@@ -139,7 +137,7 @@ class PandasSchemaBackend(BaseSchemaBackend):
     def failure_cases_metadata(
         self,
         schema_name: str,
-        schema_errors: List[Dict[str, Any]],
+        schema_errors: List[SchemaError],
     ) -> FailureCaseMetadata:
         """Create failure cases metadata required for SchemaErrors exception."""
         failure_cases = consolidate_failure_cases(schema_errors)

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -15,7 +15,8 @@ from typing import (
 
 import pandas as pd
 
-from pandera.backends.base import BaseSchemaBackend
+from pandera.api.base.checks import CheckResult
+from pandera.backends.base import BaseSchemaBackend, CoreCheckResult
 from pandera.backends.pandas.error_formatters import (
     format_generic_error_message,
     format_vectorized_error_message,
@@ -24,7 +25,7 @@ from pandera.backends.pandas.error_formatters import (
     reshape_failure_cases,
     scalar_failure_case,
 )
-from pandera.errors import SchemaError, FailureCaseMetadata
+from pandera.errors import FailureCaseMetadata, SchemaErrorReason
 
 
 class ColumnInfo(NamedTuple):
@@ -83,45 +84,57 @@ class PandasSchemaBackend(BaseSchemaBackend):
         check,
         check_index: int,
         *args,
-    ) -> bool:
+    ) -> CoreCheckResult:
         """Handle check results, raising SchemaError on check failure.
 
-        :param check_index: index of check in the schema component check list.
+        :param check_obj: data object to be validated.
+        :param schema: pandera schema object
         :param check: Check object used to validate pandas object.
-        :param check_args: arguments to pass into check object.
+        :param check_index: index of check in the schema component check list.
+        :param args: arguments to pass into check object.
         :returns: True if check results pass or check.raise_warning=True, otherwise
             False.
         """
-        check_result = check(check_obj, *args)
-        if not check_result.check_passed:
+        check_result: CheckResult = check(check_obj, *args)
+
+        passed = check_result.check_passed
+        failure_cases = None
+        message = None
+
+        if not passed:
             if check_result.failure_cases is None:
                 # encode scalar False values explicitly
                 failure_cases = scalar_failure_case(check_result.check_passed)
-                error_msg = format_generic_error_message(
+                message = format_generic_error_message(
                     schema, check, check_index
                 )
             else:
                 failure_cases = reshape_failure_cases(
                     check_result.failure_cases, check.ignore_na
                 )
-                error_msg = format_vectorized_error_message(
+                message = format_vectorized_error_message(
                     schema, check, check_index, failure_cases
                 )
 
             # raise a warning without exiting if the check is specified to do so
+            # but make sure the check passes
             if check.raise_warning:
-                warnings.warn(error_msg, UserWarning)
-                return True
-            raise SchemaError(
-                schema,
-                check_obj,
-                error_msg,
-                failure_cases=failure_cases,
-                check=check,
-                check_index=check_index,
-                check_output=check_result.check_output,
-            )
-        return check_result.check_passed
+                warnings.warn(message, UserWarning)
+                return CoreCheckResult(
+                    passed=True,
+                    check=check,
+                    reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+                )
+
+        return CoreCheckResult(
+            passed=passed,
+            check=check,
+            check_index=check_index,
+            check_output=check_result.check_output,
+            reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+            message=message,
+            failure_cases=failure_cases,
+        )
 
     def failure_cases_metadata(
         self,

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -159,7 +159,6 @@ class ColumnBackend(ArraySchemaBackend):
     def coerce_dtype(
         self,
         check_obj: Union[pd.DataFrame, pd.Series],
-        *,
         schema=None,
         error_handler: SchemaErrorHandler = None,
     ) -> Union[pd.DataFrame, pd.Series]:
@@ -182,7 +181,7 @@ class ColumnBackend(ArraySchemaBackend):
             axis="columns",
         )
 
-    def run_checks(self, check_obj, schema, error_handler, lazy):
+    def run_checks(self, check_obj, schema, error_handler):
         check_results = []
         for check_index, check in enumerate(schema.checks):
             check_args = [None] if is_field(check_obj) else [schema.name]
@@ -272,7 +271,6 @@ class MultiIndexBackend(DataFrameSchemaBackend):
         # pylint: disable=fixme
         # TODO: make MultiIndex not inherit from DataFrameSchemaBackend
         check_obj: pd.MultiIndex,
-        *,
         schema=None,
         error_handler: SchemaErrorHandler = None,
     ) -> pd.MultiIndex:

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -216,7 +216,7 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             if col_schema.regex:
                 try:
                     column_names.extend(
-                        col_schema.BACKEND.get_regex_columns(
+                        col_schema.get_backend(check_obj).get_regex_columns(
                             col_schema, check_obj.columns
                         )
                     )
@@ -420,9 +420,9 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
         for colname, col_schema in schema.columns.items():
             if col_schema.regex:
                 try:
-                    matched_columns = col_schema.BACKEND.get_regex_columns(
-                        col_schema, obj.columns
-                    )
+                    matched_columns = col_schema.get_backend(
+                        obj
+                    ).get_regex_columns(col_schema, obj.columns)
                 except SchemaError:
                     matched_columns = pd.Index([])
 

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -1,11 +1,11 @@
 """Make schema error messages human-friendly."""
 
 from collections import defaultdict
-from typing import Any, Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import pandas as pd
 
-from pandera.errors import SchemaErrorReason
+from pandera.errors import SchemaError, SchemaErrorReason
 
 
 def format_generic_error_message(
@@ -142,7 +142,7 @@ def _multiindex_to_frame(df):
     return df.index.to_frame().drop_duplicates()
 
 
-def consolidate_failure_cases(schema_errors: List[Dict[str, Any]]):
+def consolidate_failure_cases(schema_errors: List[SchemaError]):
     """Consolidate schema error dicts to produce data for error message."""
     assert schema_errors, (
         "schema_errors input cannot be empty. Check how the backend "
@@ -159,9 +159,8 @@ def consolidate_failure_cases(schema_errors: List[Dict[str, Any]]):
         "index",
     ]
 
-    for schema_error_dict in schema_errors:
-        reason_code = schema_error_dict["reason_code"]
-        err = schema_error_dict["error"]
+    for schema_error in schema_errors:
+        err, reason_code = schema_error, schema_error.reason_code
 
         check_identifier = (
             None
@@ -257,14 +256,14 @@ except SchemaErrors as err:
 
 def summarize_failure_cases(
     schema_name: str,
-    schema_errors: List[Dict[str, Any]],
+    schema_errors: List[SchemaError],
     failure_cases: pd.DataFrame,
 ) -> Tuple[str, Dict[str, int]]:
     """Format error message."""
 
     error_counts = defaultdict(int)  # type: ignore
-    for schema_error_dict in schema_errors:
-        reason_code = schema_error_dict["reason_code"]
+    for schema_error in schema_errors:
+        reason_code = schema_error.reason_code
         error_counts[reason_code] += 1
 
     msg = (

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -24,7 +24,8 @@ import wrapt
 from pydantic import validate_arguments
 
 from pandera import errors
-from pandera.api.pandas import DataFrameSchema, SeriesSchema
+from pandera.api.pandas.array import SeriesSchema
+from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.model import SchemaModel
 from pandera.error_handlers import SchemaErrorHandler
 from pandera.inspection_utils import (

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -683,7 +683,7 @@ def check_types(
 
         if error_handler.collected_errors:
             if len(error_handler.collected_errors) == 1:
-                raise error_handler.collected_errors[0]["error"]  # type: ignore[misc]
+                raise error_handler.collected_errors[0]  # type: ignore[misc]
             raise errors.SchemaErrors(
                 schema=schema,
                 schema_errors=error_handler.collected_errors,

--- a/pandera/error_handlers.py
+++ b/pandera/error_handlers.py
@@ -1,8 +1,8 @@
 """Handle schema errors."""
 
-from typing import Dict, List, Optional, Union
+from typing import List, Optional
 
-from pandera.errors import SchemaError, SchemaErrorReason
+from pandera.errors import SchemaError, SchemaErrors, SchemaErrorReason
 
 
 class SchemaErrorHandler:
@@ -15,7 +15,7 @@ class SchemaErrorHandler:
             SchemaError objects. Otherwise raise a SchemaError immediately.
         """
         self._lazy = lazy
-        self._collected_errors = []  # type: ignore
+        self._collected_errors: List[SchemaError] = []  # type: ignore
 
     @property
     def lazy(self) -> bool:
@@ -30,8 +30,9 @@ class SchemaErrorHandler:
     ):
         """Collect schema error, raising exception if lazy is False.
 
-        :param reason_code: string representing reason for error
+        :param reason_code: string representing reason for error.
         :param schema_error: ``SchemaError`` object.
+        :param original_exc: original exception associated with the SchemaError.
         """
         if not self._lazy:
             raise schema_error from original_exc
@@ -42,14 +43,30 @@ class SchemaErrorHandler:
         del schema_error.data
         schema_error.data = None
 
-        self._collected_errors.append(
-            {
-                "reason_code": reason_code,
-                "error": schema_error,
-            }
-        )
+        if reason_code is not None:
+            schema_error.reason_code = reason_code
+
+        self._collected_errors.append(schema_error)
+
+    def collect_errors(
+        self,
+        schema_errors: SchemaErrors,
+        original_exc: BaseException = None,
+    ):
+        """Collect schema errors from a SchemaErrors exception.
+
+        :param reason_code: string representing reason for error.
+        :param schema_error: ``SchemaError`` object.
+        :param original_exc: original exception associated with the SchemaError.
+        """
+        for schema_error in schema_errors.schema_errors:
+            self.collect_error(
+                schema_error.reason_code,
+                schema_error,
+                original_exc or schema_errors,
+            )
 
     @property
-    def collected_errors(self) -> List[Dict[str, Union[SchemaError, str]]]:
+    def collected_errors(self) -> List[SchemaError]:
         """Retrieve SchemaError objects collected during lazy validation."""
         return self._collected_errors

--- a/pandera/error_handlers.py
+++ b/pandera/error_handlers.py
@@ -1,6 +1,6 @@
 """Handle schema errors."""
 
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pandera.errors import SchemaError, SchemaErrorReason
 
@@ -24,7 +24,7 @@ class SchemaErrorHandler:
 
     def collect_error(
         self,
-        reason_code: SchemaErrorReason,
+        reason_code: Optional[SchemaErrorReason],
         schema_error: SchemaError,
         original_exc: BaseException = None,
     ):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -5,8 +5,14 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple
 
 
+class BackendNotFoundError(Exception):
+    """
+    Raised when a backend is not found for a particular schema of check backend.
+    """
+
+
 class ReducedPickleExceptionBase(Exception):
-    """Base class for Excption with non-conserved state under pickling.
+    """Base class for Exception with non-conserved state under pickling.
 
     Derived classes define attributes to be transformed to
     string via `TO_STRING_KEYS`.
@@ -168,9 +174,9 @@ class SchemaErrors(ReducedPickleExceptionBase):
         self.schema_errors = schema_errors
         self.data = data
 
-        failure_cases_metadata = schema.BACKEND.failure_cases_metadata(
-            schema.name, schema_errors
-        )
+        failure_cases_metadata = schema.get_backend(
+            data
+        ).failure_cases_metadata(schema.name, schema_errors)
         self.error_counts = failure_cases_metadata.error_counts
         self.failure_cases = failure_cases_metadata.failure_cases
         super().__init__(failure_cases_metadata.message)

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -167,7 +167,7 @@ class SchemaErrors(ReducedPickleExceptionBase):
     def __init__(
         self,
         schema,
-        schema_errors: List[Dict[str, Any]],
+        schema_errors: List[SchemaError],
         data: Any,
     ):
         self.schema = schema

--- a/tests/core/test_pandas_accessor.py
+++ b/tests/core/test_pandas_accessor.py
@@ -7,6 +7,7 @@ import pytest
 
 import pandera as pa
 import pandera.api.pandas.container
+from pandera.errors import BackendNotFoundError
 
 
 @pytest.mark.parametrize(
@@ -51,10 +52,10 @@ def test_dataframe_series_add_schema(
         assert validated_data_1.pandera.schema == schema1
     assert validated_data_2.pandera.schema == schema2
 
-    with pytest.raises(TypeError, match=f"expected pd.{type(data).__name__}"):
+    with pytest.raises((BackendNotFoundError, TypeError)):
         schema1(invalid_data)  # type: ignore
 
-    with pytest.raises(TypeError, match=f"expected pd.{type(data).__name__}"):
+    with pytest.raises((BackendNotFoundError, TypeError)):
         schema2(invalid_data)  # type: ignore
 
     with patch.object(
@@ -67,8 +68,8 @@ def test_dataframe_series_add_schema(
             "is_field",
             return_value=True,
         ):
-            with pytest.raises(TypeError, match="schema arg"):
+            with pytest.raises(BackendNotFoundError):
                 schema1(invalid_data)  # type: ignore
 
-            with pytest.raises(TypeError, match="schema arg"):
+            with pytest.raises(BackendNotFoundError):
                 schema2(invalid_data)  # type: ignore

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1944,11 +1944,11 @@ def test_schema_level_unique_missing_columns():
     except errors.SchemaErrors as err:
         assert len(err.failure_cases) == 3
         assert (
-            err.schema_errors[0]["reason_code"]
+            err.schema_errors[0].reason_code
             == errors.SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME
         )
         assert (
-            err.schema_errors[1]["reason_code"]
+            err.schema_errors[1].reason_code
             == errors.SchemaErrorReason.DUPLICATES
         )
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1326,8 +1326,8 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
     assert err.value.failure_cases[["check", "failure_case"]].fillna(
         "NaN"
     ).to_dict(orient="records") == [
-        {"check": "column_in_dataframe", "failure_case": "date_col"},
         {"check": "column_in_schema", "failure_case": "unexpected_column"},
+        {"check": "column_in_dataframe", "failure_case": "date_col"},
         {
             "check": "str_length(3, 80)",
             "failure_case": "dddddddddddddddddddddddddddddddddddddddddddddddddddd"
@@ -1343,12 +1343,12 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
             "failure_case": "789c",
         },
         {"check": "str_length(3, 80)", "failure_case": "a"},
+        {"check": "coerce_dtype('float64')", "failure_case": "a"},
         {"check": "less_than_or_equal_to(30)", "failure_case": 113},
         {"check": "in_range(10, 99)", "failure_case": 180},
         {"check": "in_range(10, 99)", "failure_case": 1},
         {"check": "field_uniqueness", "failure_case": 12},
         {"check": "field_uniqueness", "failure_case": 12},
-        {"check": "coerce_dtype('float64')", "failure_case": "a"},
         {"check": "dtype('float64')", "failure_case": "object"},
     ], "validation failure cases not as expected"
 


### PR DESCRIPTION
This PR refactors the `api` package schemas to use the corresponding `backends`:
- Add `BaseSchema.register_backend` and `get_backend` methods.