### PR TITLE
Add title and description to _get_series_base_schema_statistics

### DIFF
--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -117,6 +117,8 @@ def _get_series_base_schema_statistics(series_schema_base):
         "coerce": series_schema_base.coerce,
         "name": series_schema_base.name,
         "unique": series_schema_base.unique,
+        "title": series_schema_base.title,
+        "description": series_schema_base.description,
     }
 
 

--- a/tests/core/test_schema_statistics.py
+++ b/tests/core/test_schema_statistics.py
@@ -512,6 +512,8 @@ def test_get_dataframe_schema_statistics():
                 "coerce": False,
                 "name": "int_index",
                 "unique": False,
+                "description": None,
+                "title": None,
             }
         ],
         "coerce": False,
@@ -541,6 +543,8 @@ def test_get_series_schema_statistics():
         "name": None,
         "coerce": False,
         "unique": False,
+        "description": None,
+        "title": None,
     }
 
 
@@ -568,6 +572,8 @@ def test_get_series_schema_statistics():
                     "name": "int_index",
                     "coerce": False,
                     "unique": False,
+                    "description": None,
+                    "title": None,
                 }
             ],
         ]


### PR DESCRIPTION
I recreated this PR, because I wanted to make sure I do everything properly this time. I modified the failing tests, because they didn't expect title and description to be included in the statistics for the index. I do not see any reason why they should not be there, especially as the IO Code also expects them to be there. 

Closes https://github.com/unionai-oss/pandera/issues/1140 .

Thank you for your amazing work!