### PR TITLE
support bare data type annotations in DataFrameModel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
         description: Simply check whether files parse as valid python
       - id: check-case-conflict
         description: Check for files that would conflict in case-insensitive filesystems
-      - id: check-docstring-first
-        description: Checks for a common error of placing code before the docstring.
       - id: check-merge-conflict
         description: Check for files that contain merge conflict strings
       - id: check-yaml

--- a/docs/source/dataframe_models.rst
+++ b/docs/source/dataframe_models.rst
@@ -91,7 +91,7 @@ Basic Usage
     0      2          1999
 
 
-As you can see in the example above, you can define a schema by sub-classing
+As you can see in the examples above, you can define a schema by sub-classing
 :class:`~pandera.api.pandas.model.DataFrameModel` and defining column/index fields as class attributes.
 The :func:`~pandera.decorators.check_types` decorator is required to perform validation of the dataframe at
 run-time.
@@ -117,6 +117,24 @@ In the example above, this will simply be the string `"year"`.
     0  2001  200
     1  2002  156
     2  2003  365
+
+
+Using Data Types directly for Column Type Annotations
+-----------------------------------------------------
+
+*new in 0.15.0*
+
+For conciseness, you can also use type annotations for columns without using
+the :py:class:`~pandera.typing.Series` generic. This class attributes will be
+interpreted as :py:class:`~pandera.api.pandas.components.Column` objects
+under the hood.
+
+.. testcode:: dataframe_schema_model
+
+    class InputSchema(pa.DataFrameModel):
+        year: int = pa.Field(gt=2000, coerce=True)
+        month: int = pa.Field(ge=1, le=12, coerce=True)
+        day: int = pa.Field(ge=0, le=365, coerce=True)
 
 
 Validate on Initialization

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -361,7 +361,8 @@ class DataFrameModel(BaseModel):
             dtype = None if dtype is Any else dtype
 
             if (
-                annotation.origin in SERIES_TYPES
+                annotation.origin is None
+                or annotation.origin in SERIES_TYPES
                 or annotation.raw_annotation in SERIES_TYPES
             ):
                 col_constructor = field.to_column if field else Column

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -254,11 +254,19 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.arg = args[0] if args else args
 
         self.metadata = getattr(self.arg, "__metadata__", None)
+        self.literal = typing_inspect.is_literal_type(self.arg)
         if self.metadata:
             self.arg = typing_inspect.get_args(self.arg)[0]
-
-        self.literal = typing_inspect.is_literal_type(self.arg)
-        if self.literal:
+        elif self.literal:
             self.arg = typing_inspect.get_args(self.arg)[0]
+        elif self.origin is None:
+            if isinstance(raw_annotation, type) and issubclass(
+                raw_annotation, SeriesBase
+            ):
+                # handle case where the provided annotation is just a pandera Series generic.
+                self.arg = Any
+            else:
+                # otherwise assume that the annotation is the data type itself.
+                self.arg = raw_annotation
 
         self.default_dtype = getattr(raw_annotation, "default_dtype", None)


### PR DESCRIPTION
This PR adds support for indicating the bare data type in the DataFrameModel for columns:

```python
    class Model(pa.DataFrameModel):
        a: int
        b: str
        c: Any
        d: float
```

Indexes still need to be indicated via the `pandera.typing.Index` generic.