### PR TITLE
Support pandas 2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
-        run: grep -v ray environment.yml > environment.yml
+        run: sed '/ray/d' environment.yml > environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,9 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
-        run: |
-          grep -v ray environment.yml > environment.yml
-          grep -v ray requirements-dev.txt > requirements-dev.txt
+        run: grep -v ray environment.yml > environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}
@@ -100,10 +100,12 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pandas-version: ["1.3.0", "latest"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pandas-version: ["1.3.0", "2.0.0", "latest"]
         exclude:
         - python-version: "3.10"
+          pandas-version: "1.3.0"
+        - python-version: "3.11"
           pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,10 +149,11 @@ jobs:
           use-only-tar-bz2: true
 
       - name: Install Conda Deps [Latest]
-        if: ${{ matrix.pandas-version == 'latest' }}
+        if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
+          pip install pandas==${{ matrix.pandas-version }}
 
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps
@@ -161,9 +162,8 @@ jobs:
 
       - name: Install Pip Deps
         run: |
-          mamba install -c conda-forge asv pandas geopandas bokeh
+          mamba install -c conda-forge asv pandas==${{ matrix.pandas-version }} geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }}
 
       - run: |
           conda info

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        pandas-version: ["1.3.0", "2.0.0", "latest"]
+        pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
         - python-version: "3.10"
           pandas-version: "1.3.0"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -150,12 +150,13 @@ jobs:
           channel-priority: true
           use-only-tar-bz2: true
 
-      - name: Install Conda Deps [Latest]
+      # need to install via pip: conda installation is on the fritz
+      - name: Install Conda Deps [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }}
+          pip install pandas==${{ matrix.pandas-version }} dask==2023.3.2
 
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pandas-version: ["1.3.0", "2.0.0", "latest"]
+        pandas-version: ["1.3.0", "2.0.1"]
         exclude:
         - python-version: "3.10"
           pandas-version: "1.3.0"
@@ -154,10 +154,6 @@ jobs:
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
 
-      - name: Install Conda Deps
-        if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
-
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps
         if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
@@ -165,8 +161,9 @@ jobs:
 
       - name: Install Pip Deps
         run: |
-          mamba install -c conda-forge asv pandas==${{ matrix.pandas-version }} geopandas bokeh
+          mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
+          pip install pandas==${{ matrix.pandas-version }}
 
       - run: |
           conda info

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -105,6 +105,8 @@ jobs:
         exclude:
         - python-version: "3.10"
           pandas-version: "1.3.0"
+        - python-version: "3.11"
+          pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest
           pip-cache: ~/.cache/pip

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,8 +154,12 @@ jobs:
 
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
-        if: ${{ matrix.python-version == '3.11' }}
-        run: sed '/ray/d' environment.yml > environment.yml
+        if: ${{ matrix.python-version == '3.11' && runner.os != 'macos-latest' }}
+        run: sed -i '/ray/d' environment.yml
+
+      - name: Remove Ray from Deps
+        if: ${{ matrix.python-version == '3.11' && runner.os == 'macos-latest' }}
+        run: sed -i '' '/ray/d' environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]
@@ -164,11 +168,7 @@ jobs:
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
           pip install pandas==${{ matrix.pandas-version }}
-
-      # need to install pandas2-compatible version of dask
-      - name: Install Dask [pandas 2]
-        if: ${{ matrix.pandas-version == '2.0.1' }}
-        run: pip install --user dask>=2023.3.2
+          pip install --user dask>=2023.3.2
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != '2.0.1' }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,9 +154,9 @@ jobs:
       - name: Install Conda Deps [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
-          mamba install -c conda-forge asv pandas geopandas bokeh
+          mamba install -c conda-forge asv pandas geopandas bokeh dask>=2023.3.2
           mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }} dask==2023.3.2
+          pip install pandas==${{ matrix.pandas-version }}
 
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -210,7 +210,7 @@ jobs:
         run: pytest tests/dask ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Pyspark
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.pandas-version != '1.1.5' && matrix.pandas-version != '2.0.1' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.10", "3.11"]'), matrix.python-version) && !contains(fromJson('["2.0.1""]'), matrix.pandas-version) }}
         run: pytest tests/pyspark ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Modin-Dask
@@ -224,7 +224,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version)  && matrix.pandas-version != '2.0.1' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version) && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -103,6 +103,8 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         pandas-version: ["1.3.0", "2.0.1"]
         exclude:
+        - python-version: "3.7"
+          pandas-version: "2.0.1"
         - python-version: "3.10"
           pandas-version: "1.3.0"
         include:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,16 +100,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        pandas-version: ["1.3.0", "2.0.0", "latest"]
         exclude:
-        - python-version: "3.7"
-          pandas-version: "1.5.2"
-        - python-version: "3.7"
-          pandas-version: "2.0.1"
         - python-version: "3.10"
-          pandas-version: "1.3.0"
-        - python-version: "3.11"
           pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest
@@ -154,22 +148,24 @@ jobs:
           channel-priority: true
           use-only-tar-bz2: true
 
+      - name: Install Conda Deps [Latest]
+        if: ${{ matrix.pandas-version == 'latest' }}
+        run: |
+          mamba install -c conda-forge asv pandas geopandas bokeh
+          mamba env update -n pandera-dev -f environment.yml
+
+      - name: Install Conda Deps
+        if: ${{ matrix.pandas-version != 'latest' }}
+        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
+
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps
         if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
         run: sed -i 's/^ray//g' requirements-dev.txt
 
-      - name: Install Conda Deps [Latest]
-        if: ${{ matrix.pandas-version == '2.0.1' }}
+      - name: Install Pip Deps
         run: |
-          mamba install -c conda-forge asv pandas geopandas bokeh
-          mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }}
-
-      - name: Install Conda Deps
-        if: ${{ matrix.pandas-version != 'latest' }}
-        run: |
-          mamba install -c conda-forge asv pandas=${{ matrix.pandas-version }} geopandas bokeh
+          mamba install -c conda-forge asv pandas==${{ matrix.pandas-version }} geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
 
       - run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -156,8 +156,7 @@ jobs:
         run: |
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }}
-          mamba install -c conda-forge dask>=2023.3.2
+          pip install pandas==${{ matrix.pandas-version }} dask>=2023.3.2
 
       # ray currently cannot be installed on python 3.10, windows
       # - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -109,6 +109,8 @@ jobs:
           pandas-version: "1.5.2"
         - python-version: "3.10"
           pandas-version: "1.3.0"
+        - python-version: "3.11"
+          pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest
           pip-cache: ~/.cache/pip

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -103,6 +103,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
+        - python-version: "3.7"
+          pandas-version: "1.5.2"
+        - python-version: "3.7"
+          pandas-version: "2.0.1"
         - python-version: "3.10"
           pandas-version: "1.3.0"
         - python-version: "3.11"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -163,7 +163,6 @@ jobs:
         run: |
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
-          mamba install -c conda-forge dask>=2023.3.2
           pip install pandas==${{ matrix.pandas-version }}
 
       # need to install pandas2-compatible version of dask

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
-        run: sed '/ray/d' environment.yml > environment.yml
+        run: sed '/ray/d' environment.yml | echo
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
         - python-version: "3.7"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          sed -i '/- ray/d' environment.yml
-          sed -i '/ray/d' requirements-dev.txt
+          grep -v "\- ray" environment.yml > environment.yml
+          grep -v "ray" requirements-dev.txt > requirements-dev.txt
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,12 +100,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
         - python-version: "3.10"
-          pandas-version: "1.3.0"
-        - python-version: "3.11"
           pandas-version: "1.3.0"
         include:
         - os: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,12 +154,12 @@ jobs:
 
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
-        if: ${{ matrix.python-version == '3.11' && runner.os != 'macos-latest' }}
-        run: sed -i '/ray/d' environment.yml
-
-      - name: Remove Ray from Deps
-        if: ${{ matrix.python-version == '3.11' && runner.os == 'macos-latest' }}
-        run: sed -i .bak '/ray/d' environment.yml
+        run: |
+          if [ "{{ runner.os }}" == "macos-latest" ]; then
+            sed -i .bak '/ray/d' environment.yml
+          else
+            sed -i '/ray/d' environment.yml
+          fi
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -214,7 +214,7 @@ jobs:
         run: pytest tests/pyspark ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Modin-Dask
-        if: ${{ matrix.pandas-version != '2.0.1' }}
+        if: ${{ !contains(fromJson('["3.11"]'), matrix.python-version) && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: dask

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -150,7 +150,7 @@ jobs:
           channel-priority: true
           use-only-tar-bz2: true
 
-      # need to install via pip: conda installation is on the fritz
+      # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
@@ -159,9 +159,10 @@ jobs:
           mamba install -c conda-forge dask>=2023.3.2
           pip install pandas==${{ matrix.pandas-version }}
 
+      # need to install pandas2-compatible version of dask
       - name: Install Dask [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
-        run: mamba install -c conda-forge dask>=2023.3.2
+        run: pip install --user dask>=2023.3.2
 
       # ray currently cannot be installed on python 3.10, windows
       # - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -197,13 +197,15 @@ jobs:
         run: pytest tests/geopandas ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Dask
+        if: ${{ matrix.pandas-version != '2.0.1' }}
         run: pytest tests/dask ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Pyspark
-        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.pandas-version != '1.1.5' }}
+        if: ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.pandas-version != '1.1.5' && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/pyspark ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Modin-Dask
+        if: ${{ matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: dask
@@ -213,7 +215,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version)  && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,24 +154,22 @@ jobs:
           channel-priority: true
           use-only-tar-bz2: true
 
-      - name: Install Conda Deps [Latest]
-        if: ${{ matrix.pandas-version == 'latest' }}
-        run: |
-          mamba install -c conda-forge asv pandas geopandas bokeh
-          mamba env update -n pandera-dev -f environment.yml
-
-      - name: Install Conda Deps
-        if: ${{ matrix.pandas-version != 'latest' }}
-        run: mamba install -c conda-forge pandas==${{ matrix.pandas-version }} geopandas
-
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps
         if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
         run: sed -i 's/^ray//g' requirements-dev.txt
 
-      - name: Install Pip Deps
+      - name: Install Conda Deps [Latest]
+        if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
-          mamba install -c conda-forge asv pandas==${{ matrix.pandas-version }} geopandas bokeh
+          mamba install -c conda-forge asv pandas geopandas bokeh
+          mamba env update -n pandera-dev -f environment.yml
+          pip install pandas==${{ matrix.pandas-version }}
+
+      - name: Install Conda Deps
+        if: ${{ matrix.pandas-version != 'latest' }}
+        run: |
+          mamba install -c conda-forge asv pandas=${{ matrix.pandas-version }} geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
 
       - run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
         - python-version: "3.10"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         run: |
-          if [ "{{ runner.os }}" == "macos-latest" ]; then
+          if [ "${{ runner.os }}" == "macos-latest" ]; then
             sed -i .bak '/ray/d' environment.yml
           else
             sed -i '/ray/d' environment.yml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,12 +154,12 @@ jobs:
 
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
-        run: |
-          if [[ "${{ runner.os }}" == "macos-latest" ]]; then
-            sed -i .bak '/ray/d' environment.yml
-          else
-            sed -i '/ray/d' environment.yml
-          fi
+        if: ${{ matrix.python-version == '3.11' && matrix.os != 'macos-latest' }}
+        run: sed -i '/ray/d' environment.yml
+
+      - name: Remove Ray from Deps
+        if: ${{ matrix.python-version == '3.11' && matrix.os == 'macos-latest' }}
+        run: sed -i .bak '/ray/d' environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
-        run: sed '/ray/d' environment.yml | echo
+        run: sed '/ray/d' environment.yml > environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -156,7 +156,8 @@ jobs:
         run: |
           mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
-          pip install pandas==${{ matrix.pandas-version }} dask>=2023.3.2
+          mamba install -c conda-forge dask>=2023.3.2
+          pip install pandas==${{ matrix.pandas-version }}
 
       # ray currently cannot be installed on python 3.10, windows
       # - name: Remove Ray from Deps

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -159,6 +159,10 @@ jobs:
           mamba install -c conda-forge dask>=2023.3.2
           pip install pandas==${{ matrix.pandas-version }}
 
+      - name: Install Dask [pandas 2]
+        if: ${{ matrix.pandas-version == '2.0.1' }}
+        run: mamba install -c conda-forge dask>=2023.3.2
+
       # ray currently cannot be installed on python 3.10, windows
       # - name: Remove Ray from Deps
       #   if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          grep -v "\- ray" environment.yml > environment.yml
-          grep -v "ray" requirements-dev.txt > requirements-dev.txt
+          grep -v ray environment.yml > environment.yml
+          grep -v ray requirements-dev.txt > requirements-dev.txt
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,10 +101,12 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pandas-version: ["1.3.0", "2.0.1"]
+        pandas-version: ["1.3.0", "1.5.2", "2.0.1"]
         exclude:
         - python-version: "3.7"
           pandas-version: "2.0.1"
+        - python-version: "3.7"
+          pandas-version: "1.5.2"
         - python-version: "3.10"
           pandas-version: "1.3.0"
         include:
@@ -141,7 +143,6 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          # mamba-version: "*"
           miniforge-version: latest
           miniforge-variant: Mambaforge
           use-mamba: true
@@ -163,11 +164,6 @@ jobs:
       - name: Install Dask [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
         run: pip install --user dask>=2023.3.2
-
-      # ray currently cannot be installed on python 3.10, windows
-      # - name: Remove Ray from Deps
-      #   if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
-      #   run: sed -i 's/^ray//g' requirements-dev.txt
 
       - name: Install Conda Deps
         if: ${{ matrix.pandas-version != '2.0.1' }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Remove Ray from Deps
         if: ${{ matrix.python-version == '3.11' && runner.os == 'macos-latest' }}
-        run: sed -i '' '/ray/d' environment.yml
+        run: sed -i .bak '/ray/d' environment.yml
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
       # ray currently cannot be installed on python 3.11
       - name: Remove Ray from Deps
         run: |
-          if [ "${{ runner.os }}" == "macos-latest" ]; then
+          if [[ "${{ runner.os }}" == "macos-latest" ]]; then
             sed -i .bak '/ray/d' environment.yml
           else
             sed -i '/ray/d' environment.yml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -160,11 +160,12 @@ jobs:
           mamba install -c conda-forge dask>=2023.3.2
 
       # ray currently cannot be installed on python 3.10, windows
-      - name: Remove Ray from Deps
-        if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
-        run: sed -i 's/^ray//g' requirements-dev.txt
+      # - name: Remove Ray from Deps
+      #   if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.10' }}
+      #   run: sed -i 's/^ray//g' requirements-dev.txt
 
-      - name: Install Pip Deps
+      - name: Install Conda Deps
+        if: ${{ matrix.pandas-version != '2.0.1' }}
         run: |
           mamba install -c conda-forge asv pandas==${{ matrix.pandas-version }} geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -210,7 +210,7 @@ jobs:
         run: pytest tests/dask ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Pyspark
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.10", "3.11"]'), matrix.python-version) && !contains(fromJson('["2.0.1""]'), matrix.pandas-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version) && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/pyspark ${{ env.PYTEST_FLAGS }}
 
       - name: Unit Tests - Modin-Dask
@@ -224,7 +224,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version) && matrix.pandas-version != '2.0.1' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version)  && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -119,7 +119,6 @@ jobs:
         - os: windows-latest
           pip-cache: ~/AppData/Local/pip/Cache
 
-
     steps:
       - uses: actions/checkout@v2
 
@@ -152,6 +151,13 @@ jobs:
           channels: conda-forge
           channel-priority: true
           use-only-tar-bz2: true
+
+      # ray currently cannot be installed on python 3.11
+      - name: Remove Ray from Deps
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          sed -i '/- ray/d' environment.yml
+          sed -i '/ray/d' requirements-dev.txt
 
       # need to install pandas via pip: conda installation is on the fritz
       - name: Install Conda Deps [pandas 2]
@@ -221,7 +227,7 @@ jobs:
         # - windows, python 3.10
         # - mac, python 3.7
         # Tracking issue: https://github.com/modin-project/modin/issues/5466
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version)  && matrix.pandas-version != '2.0.1' }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version)  && matrix.pandas-version != '2.0.1' }}
         run: pytest tests/modin ${{ env.PYTEST_FLAGS }}
         env:
           CI_MODIN_ENGINES: ray
@@ -230,9 +236,9 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Check Docstrings
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session doctests
 
       - name: Check Docs
-        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10"]'), matrix.python-version) }}
+        if: ${{ matrix.os != 'windows-latest' && !contains(fromJson('["3.7", "3.10", "3.11"]'), matrix.python-version) }}
         run: nox ${{ env.NOX_FLAGS }} --session docs

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -154,9 +154,10 @@ jobs:
       - name: Install Conda Deps [pandas 2]
         if: ${{ matrix.pandas-version == '2.0.1' }}
         run: |
-          mamba install -c conda-forge asv pandas geopandas bokeh dask>=2023.3.2
+          mamba install -c conda-forge asv pandas geopandas bokeh
           mamba env update -n pandera-dev -f environment.yml
           pip install pandas==${{ matrix.pandas-version }}
+          mamba install -c conda-forge dask>=2023.3.2
 
       # ray currently cannot be installed on python 3.10, windows
       - name: Remove Ray from Deps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
-    rev: v2.12.2
+    rev: v2.17.3
     hooks:
       - id: pylint
         args: ["--disable=import-error"]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [BASIC]
-ignore=mypy.py
+ignore=mypy.py,noxfile.py
 good-names=
     T,
     F,
@@ -22,12 +22,15 @@ good-names=
     lt,
     le,
     dt,
-    tz
+    tz,
+    TBaseModel,
+    TArraySchemaBase,
+    TDataFrameModel,
+    _DataType
 
 [MESSAGES CONTROL]
 disable=
     # C0330 conflicts with black: https://github.com/psf/black/issues/48
-    C0330,
     R0913,
     duplicate-code,
     too-many-instance-attributes,
@@ -41,4 +44,5 @@ disable=
     ungrouped-imports,
     function-redefined,
     arguments-differ,
-    no-self-use
+    unnecessary-dunder-call,
+    use-dict-literal

--- a/.pylintrc
+++ b/.pylintrc
@@ -21,7 +21,8 @@ good-names=
     ge,
     lt,
     le,
-    dt
+    dt,
+    tz
 
 [MESSAGES CONTROL]
 disable=

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,10 @@ else:
 
 SKIP = sys.version_info < (3, 6)
 PY36 = sys.version_info < (3, 7)
-SKIP_PANDAS_LT_V1 = version.parse(pd.__version__).release < (1, 0) or PY36
+PANDAS_LT_V2 = version.parse(pd.__version__).release < (1, 0)
+PANDAS_GT_V2 = version.parse(pd.__version__).release >= (2, 0)
+SKIP_PANDAS_LT_V1 = PANDAS_LT_V2 or PY36
+SKIP_PANDAS_LT_V1_OR_GT_V2 = PANDAS_LT_V2 or PANDAS_GT_V2 or PY36
 SKIP_SCALING = True
 SKIP_SCHEMA_MODEL = SKIP_PANDAS_LT_V1
 SKIP_MODIN = True

--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -118,7 +118,7 @@ catch these errors and inspect the failure cases in a more granular form:
 
 
 .. testcode:: lazy_validation
-    :skipif: SKIP_PANDAS_LT_V1
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
     try:
         schema.validate(df, lazy=True)
@@ -129,7 +129,7 @@ catch these errors and inspect the failure cases in a more granular form:
         print(err.data)
 
 .. testoutput:: lazy_validation
-    :skipif: SKIP_PANDAS_LT_V1
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
     Schema errors and failure cases:
         schema_context        column                check check_number  \

--- a/docs/source/pyspark.rst
+++ b/docs/source/pyspark.rst
@@ -24,6 +24,7 @@ below we'll use the :ref:`class-based API <dataframe_models>` to define a
 :py:class:`~pandera.api.pandas.model.DataFrameModel` for validation.
 
 .. testcode:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
     import pyspark.pandas as ps
     import pandas as pd
@@ -57,6 +58,7 @@ below we'll use the :ref:`class-based API <dataframe_models>` to define a
 
 
 .. testoutput:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
       state           city  price
     0    FL        Orlando      8
@@ -72,6 +74,7 @@ pyspark pandas dataframes at runtime:
 
 
 .. testcode:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
     @pa.check_types
     def function(df: DataFrame[Schema]) -> DataFrame[Schema]:
@@ -81,6 +84,7 @@ pyspark pandas dataframes at runtime:
 
 
 .. testoutput:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
       state           city  price
     3    CA  San Francisco     16
@@ -92,6 +96,7 @@ And of course, you can use the object-based API to validate dask dataframes:
 
 
 .. testcode:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
     schema = pa.DataFrameSchema({
         "state": pa.Column(str),
@@ -102,6 +107,7 @@ And of course, you can use the object-based API to validate dask dataframes:
 
 
 .. testoutput:: scaling_pyspark
+    :skipif: SKIP_PANDAS_LT_V1_OR_GT_V2
 
       state           city  price
     0    FL        Orlando      8

--- a/environment.yml
+++ b/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   # testing
   - isort >= 5.7.0
   - mypy <= 0.982
-  - pylint = 2.12.2
+  - pylint = 2.17.3
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   # testing
   - isort >= 5.7.0
   - mypy <= 0.982
-  - pylint = 2.17.3
+  - pylint <= 2.17.3
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ nox.options.sessions = (
 )
 
 DEFAULT_PYTHON = "3.8"
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 PANDAS_VERSIONS = ["1.2.0", "1.3.5", "latest"]
 
 PACKAGE = "pandera"

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,8 +7,10 @@ import sys
 from typing import Dict, List
 
 # setuptools must be imported before distutils !
-import setuptools  # pylint:disable=unused-import  # noqa: F401
-from distutils.core import run_setup  # pylint:disable=wrong-import-order
+import setuptools
+from distutils.core import (
+    run_setup,
+)
 
 import nox
 from nox import Session

--- a/pandera/api/pandas/model_components.py
+++ b/pandera/api/pandas/model_components.py
@@ -221,8 +221,6 @@ def _check_dispatch():
 class CheckInfo(BaseCheckInfo):  # pylint:disable=too-few-public-methods
     """Captures extra information about a Check."""
 
-    ...
-
 
 class FieldCheckInfo(CheckInfo):  # pylint:disable=too-few-public-methods
     """Captures extra information about a Check assigned to a field."""

--- a/pandera/backends/base/__init__.py
+++ b/pandera/backends/base/__init__.py
@@ -29,8 +29,6 @@ class CoreCheckResult(NamedTuple):
 class CoreParserResult(NamedTuple):
     """Namedtuple for holding core parser results."""
 
-    ...
-
 
 class BaseSchemaBackend(ABC):
     """Abstract base class for a schema backend implementation."""
@@ -132,7 +130,6 @@ class BaseCheckBackend(ABC):
 
     def __init__(self, check):  # pylint: disable=unused-argument
         """Initializes a check backend object."""
-        ...
 
     def __call__(self, check_obj, key=None):
         raise NotImplementedError

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -57,7 +57,8 @@ class PandasCheckBackend(BaseCheckBackend):
         # pandas groupby objects instead of dicts.
         if groups is None:
             return {
-                (k[0] if len(k) == 1 else k): v for k, v in groupby_obj  # type: ignore [union-attr]
+                (k if isinstance(k, bool) else k[0] if len(k) == 1 else k): v
+                for k, v in groupby_obj  # type: ignore [union-attr]
             }
         group_keys = set(
             k[0] if len(k) == 1 else k for k, _ in groupby_obj  # type: ignore [union-attr]

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -56,8 +56,12 @@ class PandasCheckBackend(BaseCheckBackend):
         # NOTE: this behavior should be deprecated such that the user deals with
         # pandas groupby objects instead of dicts.
         if groups is None:
-            return dict(list(groupby_obj))  # type: ignore [call-overload]
-        group_keys = set(group_key for group_key, _ in groupby_obj)  # type: ignore [union-attr]
+            return {
+                (k[0] if len(k) == 1 else k): v for k, v in groupby_obj  # type: ignore [union-attr]
+            }
+        group_keys = set(
+            k[0] if len(k) == 1 else k for k, _ in groupby_obj  # type: ignore [union-attr]
+        )
         invalid_groups = [g for g in groups if g not in group_keys]
         if invalid_groups:
             raise KeyError(

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -62,7 +62,7 @@ class Engine(ABCMeta):
     _registered_dtypes: Set[Type[DataType]]
     _base_pandera_dtypes: Tuple[Type[DataType]]
 
-    def __new__(cls, name, bases, namespace, **kwargs):
+    def __new__(mcs, name, bases, namespace, **kwargs):
         base_pandera_dtypes = kwargs.pop("base_pandera_dtypes")
         try:
             namespace["_base_pandera_dtypes"] = tuple(base_pandera_dtypes)
@@ -70,13 +70,13 @@ class Engine(ABCMeta):
             namespace["_base_pandera_dtypes"] = (base_pandera_dtypes,)
 
         namespace["_registered_dtypes"] = set()
-        engine = super().__new__(cls, name, bases, namespace, **kwargs)
+        engine = super().__new__(mcs, name, bases, namespace, **kwargs)
 
         @functools.singledispatch
         def dtype(data_type: Any) -> DataType:
             raise ValueError(f"Data type '{data_type}' not understood")
 
-        cls._registry[engine] = _DtypeRegistry(dispatch=dtype, equivalents={})
+        mcs._registry[engine] = _DtypeRegistry(dispatch=dtype, equivalents={})
         return engine
 
     def _check_source_dtype(cls, data_type: Any) -> None:

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -50,7 +50,7 @@ class DataType(dtypes.DataType):
         coerced = data_container.astype(self.type)
         if type(data_container).__module__.startswith("modin.pandas"):
             # NOTE: this is a hack to enable catching of errors in modin
-            coerced.__str__()
+            str(coerced)
         return coerced
 
     def coerce_value(self, value: Any) -> Any:

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -50,7 +50,7 @@ class DataType(dtypes.DataType):
         coerced = data_container.astype(self.type)
         if type(data_container).__module__.startswith("modin.pandas"):
             # NOTE: this is a hack to enable catching of errors in modin
-            str(coerced)
+            coerced.__str__()
         return coerced
 
     def coerce_value(self, value: Any) -> Any:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -101,7 +101,7 @@ class DataType(dtypes.DataType):
         coerced = data_container.astype(self.type)
         if type(data_container).__module__.startswith("modin.pandas"):
             # NOTE: this is a hack to enable catching of errors in modin
-            coerced.__str__()
+            str(coerced)
         return coerced
 
     def coerce_value(self, value: Any) -> Any:
@@ -115,7 +115,7 @@ class DataType(dtypes.DataType):
             coerced = self.coerce(data_container)
             if type(data_container).__module__.startswith("modin.pandas"):
                 # NOTE: this is a hack to enable catching of errors in modin
-                coerced.__str__()
+                str(coerced)
         except Exception as exc:  # pylint:disable=broad-except
             if isinstance(exc, errors.ParserError):
                 raise

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -825,29 +825,31 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
 
         def _to_datetime(col: PandasObject) -> PandasObject:
             col = to_datetime_fn(col, **self.to_datetime_kwargs)
-            if hasattr(pandas_dtype, "tz") and pandas_dtype.tz is not None:
+            pdtype_tz = getattr(pandas_dtype, "tz", None)
+            coltype_tz = getattr(col.dtype, "tz", None)
+            if pdtype_tz is not None or coltype_tz is not None:
                 if hasattr(col, "dt"):
                     if col.dt.tz is None:
                         # localize datetime column so that it's timezone-aware
                         col = col.dt.tz_localize(
-                            pandas_dtype.tz,
+                            pdtype_tz,
                             **_tz_localize_kwargs,
                         )
                     else:
-                        col = col.dt.tz_convert(pandas_dtype.tz)
+                        col = col.dt.tz_convert(pdtype_tz)
                 elif (
                     hasattr(col, "tz")
-                    and col.tz != pandas_dtype.tz
+                    and col.tz != pdtype_tz
                     and hasattr(col, "tz_localize")
                 ):
                     if col.tz is None:
                         # localize datetime index so that it's timezone-aware
                         col = col.tz_localize(
-                            pandas_dtype.tz,
+                            pdtype_tz,
                             **_tz_localize_kwargs,
                         )
                     else:
-                        col = col.tz_convert(pandas_dtype.tz)
+                        col = col.tz_convert(pdtype_tz)
             return col.astype(pandas_dtype)
 
         if isinstance(data_container, pd.DataFrame):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -101,7 +101,7 @@ class DataType(dtypes.DataType):
         coerced = data_container.astype(self.type)
         if type(data_container).__module__.startswith("modin.pandas"):
             # NOTE: this is a hack to enable catching of errors in modin
-            str(coerced)
+            coerced.__str__()
         return coerced
 
     def coerce_value(self, value: Any) -> Any:
@@ -115,7 +115,7 @@ class DataType(dtypes.DataType):
             coerced = self.coerce(data_container)
             if type(data_container).__module__.startswith("modin.pandas"):
                 # NOTE: this is a hack to enable catching of errors in modin
-                str(coerced)
+                coerced.__str__()
         except Exception as exc:  # pylint:disable=broad-except
             if isinstance(exc, errors.ParserError):
                 raise

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -455,7 +455,9 @@ def _format_checks(checks_dict):
                 "This check will be ignored"
             )
         else:
-            args = ", ".join(f"{k}={v}" for k, v in check_kwargs.items())
+            args = ", ".join(
+                f"{k}={v.__repr__()}" for k, v in check_kwargs.items()
+            )
             checks.append(f"Check.{check_name}({args})")
     return f"[{', '.join(checks)}]"
 
@@ -539,7 +541,7 @@ def to_script(dataframe_schema, path_or_buf=None):
         dtype=dataframe_schema.dtype,
         coerce=dataframe_schema.coerce,
         strict=dataframe_schema.strict,
-        name=dataframe_schema.name,
+        name=dataframe_schema.name.__repr__(),
         ordered=dataframe_schema.ordered,
         unique=dataframe_schema.unique,
         report_duplicates=f'"{dataframe_schema.report_duplicates}"',

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -455,9 +455,7 @@ def _format_checks(checks_dict):
                 "This check will be ignored"
             )
         else:
-            args = ", ".join(
-                f"{k}={v.__repr__()}" for k, v in check_kwargs.items()
-            )
+            args = ", ".join(f"{k}={v}" for k, v in check_kwargs.items())
             checks.append(f"Check.{check_name}({args})")
     return f"[{', '.join(checks)}]"
 
@@ -541,7 +539,7 @@ def to_script(dataframe_schema, path_or_buf=None):
         dtype=dataframe_schema.dtype,
         coerce=dataframe_schema.coerce,
         strict=dataframe_schema.strict,
-        name=dataframe_schema.name.__repr__(),
+        name=dataframe_schema.name,
         ordered=dataframe_schema.ordered,
         unique=dataframe_schema.unique,
         report_duplicates=f'"{dataframe_schema.report_duplicates}"',

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -56,18 +56,17 @@ def _serialize_check_stats(check_stats, dtype=None):
     """Serialize check statistics into json/yaml-compatible format."""
 
     def handle_stat_dtype(stat):
+
         if pandas_engine.Engine.dtype(dtypes.DateTime).check(
             dtype
         ) and hasattr(stat, "strftime"):
             # try serializing stat as a string if it's datetime-like,
             # otherwise return original value
             return stat.strftime(DATETIME_FORMAT)
-        elif pandas_engine.Engine.dtype(dtypes.Timedelta).check(
-            dtype
-        ) and hasattr(stat, "delta"):
+        elif pandas_engine.Engine.dtype(dtypes.Timedelta).check(dtype):
             # try serializing stat into an int in nanoseconds if it's
             # timedelta-like, otherwise return original value
-            return stat.delta
+            return getattr(stat, "value", stat)
 
         return stat
 

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -134,7 +134,7 @@ else:
         ],
     )
 
-DataFrameModel = TypeVar("Schema", bound="DataFrameModel")  # type: ignore
+DataFrameModel = TypeVar("DataFrameModel", bound="DataFrameModel")  # type: ignore
 
 
 # pylint:disable=invalid-name

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ fastapi
 black >= 22.1.0
 isort >= 5.7.0
 mypy <= 0.982
-pylint == 2.12.2
+pylint == 2.17.3
 pytest
 pytest-cov
 pytest-xdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ fastapi
 black >= 22.1.0
 isort >= 5.7.0
 mypy <= 0.982
-pylint == 2.17.3
+pylint <= 2.17.3
 pytest
 pytest-cov
 pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "wrapt",
     ],
     extras_require=extras_require,
-    python_requires=">=3.7",
+    python_requires=">=3.7,<=3.11",
     platforms="any",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import os
 
+from pandera.engines.utils import pandas_version
+
 try:
     # pylint: disable=unused-import
     import hypothesis  # noqa F401
@@ -13,6 +15,14 @@ else:
 
 # ignore test files associated with hypothesis strategies
 collect_ignore = []
+collect_ignore_glob = []
+
+# ignore pyspark, modin and dask tests until these libraries support pandas 2
+if pandas_version().release >= (2, 0, 0):
+    collect_ignore_glob.append("pyspark/**")
+    collect_ignore_glob.append("modin/**")
+    collect_ignore_glob.append("dask/**")
+
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")
 else:

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -495,8 +495,6 @@ def test_check_backend_not_found():
     class CustomDataObject:
         """Custom data object."""
 
-        ...
-
     dummy_check = Check(lambda _: True)
 
     with pytest.raises(KeyError, match="Backend not found for class"):

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -257,7 +257,7 @@ def test_check_instance_method_decorator_error() -> None:
     class TestClass:
         @check_input(DataFrameSchema({"column1": Column(Int)}))
         def test_method(self, df):
-            # pylint: disable=missing-function-docstring,no-self-use
+            # pylint: disable=missing-function-docstring
             return df
 
     with pytest.raises(
@@ -822,7 +822,7 @@ def test_check_types_method_args() -> None:
 
     class SomeClass:
         @check_types
-        def regular_method(  # pylint: disable=no-self-use
+        def regular_method(
             self,
             df1: DataFrame[SchemaIn1],
             df2: DataFrame[SchemaIn2],
@@ -976,7 +976,7 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
         @check_output(Schema.to_schema())
         @check_input(Schema.to_schema(), "df1")
         @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
-        async def regular_meta_coroutine(  # pylint: disable=no-self-use
+        async def regular_meta_coroutine(
             cls,
             df1: DataFrame[Schema],
         ) -> DataFrame[Schema]:
@@ -1007,7 +1007,7 @@ def test_coroutines(event_loop: AbstractEventLoop) -> None:
         @check_output(Schema.to_schema())
         @check_input(Schema.to_schema(), "df1")
         @check_io(df1=Schema.to_schema(), out=Schema.to_schema())
-        async def regular_coroutine(  # pylint: disable=no-self-use
+        async def regular_coroutine(
             self,
             df1: DataFrame[Schema],
         ) -> DataFrame[Schema]:

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -20,6 +20,7 @@ from pandas import DatetimeTZDtype, to_datetime
 
 import pandera as pa
 from pandera.engines import pandas_engine
+from pandera.engines.utils import pandas_version
 from pandera.system import FLOAT_128_AVAILABLE
 
 # List dtype classes and associated pandas alias,
@@ -321,9 +322,12 @@ def test_coerce_no_cast(dtype: Any, pd_dtype: Any, data: List[Any]):
         # handle dtype case
         tz_match = re.match(r"datetime64\[ns, (.+)\]", pd_dtype)
         tz = None if not tz_match else tz_match.group(1)
-        series = pd.Series(data, dtype=pd_dtype).dt.tz_localize(tz)
+        if pandas_version().release >= (2, 0, 0):
+            series = pd.Series(data, dtype=pd_dtype).dt.tz_localize(tz)
+        else:
+            series = pd.Series(data, dtype=pd_dtype)  # type: ignore[assignment]
     else:
-        series = pd.Series(data, dtype=pd_dtype)
+        series = pd.Series(data, dtype=pd_dtype)  # type: ignore[assignment]
 
     coerced_series = expected_dtype.coerce(series)
 

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -97,7 +97,7 @@ def test_register_notclassmethod_from_parametrized_dtype(engine: Engine):
 
         @engine.register_dtype
         class _InvalidDtype(BaseDataType):
-            def from_parametrized_dtype(  # pylint:disable=no-self-argument,no-self-use
+            def from_parametrized_dtype(  # pylint:disable=no-self-argument
                 cls, x: int
             ):
                 return x

--- a/tests/core/test_pandas_engine.py
+++ b/tests/core/test_pandas_engine.py
@@ -69,7 +69,7 @@ def test_pandas_category_dtype(data):
     coerced_data = dtype.coerce(data)
     assert dtype.check(coerced_data.dtype)
 
-    for _, value in data.iteritems():
+    for _, value in data.items():
         coerced_value = dtype.coerce_value(value)
         assert coerced_value in CATEGORIES
 
@@ -83,7 +83,7 @@ def test_pandas_category_dtype_error(data):
     with pytest.raises(TypeError):
         dtype.coerce(data)
 
-    for _, value in data.iteritems():
+    for _, value in data.items():
         with pytest.raises(TypeError):
             dtype.coerce_value(value)
 
@@ -102,7 +102,7 @@ def test_pandas_boolean_native_type(data):
         coerced_data = dtype.coerce(data)
         assert dtype.check(coerced_data.dtype)
 
-    for _, value in data.iteritems():
+    for _, value in data.items():
         dtype.coerce_value(value)
 
 
@@ -115,7 +115,7 @@ def test_pandas_boolean_native_type_error(data):
     with pytest.raises(TypeError):
         dtype.coerce(data)
 
-    for _, value in data.iteritems():
+    for _, value in data.items():
         with pytest.raises(TypeError):
             dtype.coerce_value(value)
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -956,7 +956,6 @@ def test_to_yaml_custom_dataframe_check():
 
 def test_to_yaml_bugfix_warn_unregistered_global_checks():
     """Ensure that unregistered global checks raises a warning."""
-    # pylint: disable=no-self-use
 
     class CheckedDataFrameModel(pandera.DataFrameModel):
         """Schema with a global check"""
@@ -967,7 +966,6 @@ def test_to_yaml_bugfix_warn_unregistered_global_checks():
         @pandera.dataframe_check()
         def unregistered_check(self, _):
             """sample unregistered check"""
-            ...
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
         CheckedDataFrameModel.to_yaml()

--- a/tests/modin/conftest.py
+++ b/tests/modin/conftest.py
@@ -9,7 +9,6 @@ from tests.core.checks_fixtures import custom_check_teardown  # noqa
 
 ENGINES = os.getenv("CI_MODIN_ENGINES", "").split(",")
 if ENGINES == [""]:
-    # ENGINES = ["ray", "dask"]
     ENGINES = ["dask"]
 
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -838,7 +838,6 @@ def test_schema_model_strategy_df_check(data) -> None:
     class SchemaWithDFCheck(Schema):
         """Schema with a custom dataframe-level check with no strategy."""
 
-        # pylint:disable=no-self-use
         @pa.dataframe_check
         @classmethod
         def non_empty(cls, df: pd.DataFrame) -> bool:

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -892,10 +892,10 @@ def test_datetime_example(check_arg, data) -> None:
 @pytest.mark.parametrize(
     "dtype, check_arg",
     [
-        # [
-        #     pd.DatetimeTZDtype(tz="UTC"),
-        #     pd.Timestamp("2006-01-01", tz="UTC"),
-        # ],
+        [
+            pd.DatetimeTZDtype(tz="UTC"),
+            pd.Timestamp("2006-01-01", tz="UTC"),
+        ],
         [
             pd.DatetimeTZDtype(tz="CET"),
             pd.Timestamp("2006-01-01", tz="CET"),
@@ -907,10 +907,10 @@ def test_datetime_tz_example(dtype, check_arg, data) -> None:
     """Test Column schema example method generate examples of
     timezone-aware datetimes that pass."""
     for checks in [
-        # pa.Check.le(check_arg),
-        # pa.Check.ge(check_arg),
+        pa.Check.le(check_arg),
+        pa.Check.ge(check_arg),
         pa.Check.eq(check_arg),
-        # pa.Check.isin([check_arg]),
+        pa.Check.isin([check_arg]),
     ]:
         column_schema = pa.Column(
             dtype,


### PR DESCRIPTION
Add support for pandas 2+. Main changes here are to fix breaking changes that were due to timezone-aware date times. Also update ci tests to use pandas 2.0.1

TODO: need to create a CI matrix of combinations of python versions, pandas versions, and integration support (e.g. dask ,modin, pyspark, etc)