### PR TITLE
Add add_missing_columns DataFrame schema config per enhancement #687

### DIFF
--- a/docs/source/dataframe_models.rst
+++ b/docs/source/dataframe_models.rst
@@ -208,7 +208,8 @@ You can easily convert a :class:`~pandera.api.pandas.model.DataFrameModel` class
         strict=False
         name=InputSchema,
         ordered=False,
-        unique_column_names=False
+        unique_column_names=False,
+        add_missing_columns=False
     )>
 
 You can also use the :meth:`~pandera.api.pandas.model.DataFrameModel.validate` method to

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -813,7 +813,8 @@ data pipeline:
         strict=True
         name=None,
         ordered=False,
-        unique_column_names=False
+        unique_column_names=False,
+        add_missing_columns=False
     )>
 
 If during the course of a data pipeline one of your columns is moved into the
@@ -861,7 +862,8 @@ the pipeline output.
         strict=True
         name=None,
         ordered=False,
-        unique_column_names=False
+        unique_column_names=False,
+        add_missing_columns=False
     )>
 
 

--- a/docs/source/dataframe_schemas.rst
+++ b/docs/source/dataframe_schemas.rst
@@ -542,6 +542,43 @@ To control how unique errors are reported, the `report_duplicates` argument acce
     1      c      1             3
 
 
+Adding missing columns
+~~~~~~~~~~~~~~~~~~~~~~
+
+When loading raw data into a form that's ready for data processing, it's often
+useful to have guarantees that the columns specified in the schema are present,
+even if they're missing from the raw data. This is where it's useful to
+specify ``add_missing_columns=True`` in your schema definition.
+
+When you call ``schema.validate(data)``, the schema will add any missing columns
+to the dataframe, defaulting to the ``default`` value if supplied at the column-level,
+or to ``NaN`` if the column is nullable.
+
+.. testcode:: add_missing_columns
+
+    import pandas as pd
+    import pandera as pa
+
+    schema = pa.DataFrameSchema(
+        columns={
+            "a": pa.Column(int),
+            "b": pa.Column(int, default=1),
+            "c": pa.Column(float, nullable=True),
+        },
+        add_missing_columns=True,
+        coerce=True,
+    )
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    print(schema.validate(df))
+
+.. testoutput:: add_missing_columns
+
+       a  b   c
+    0  1  1 NaN
+    1  2  1 NaN
+    2  3  1 NaN
+
+
 Index Validation
 ----------------
 

--- a/docs/source/schema_inference.rst
+++ b/docs/source/schema_inference.rst
@@ -47,7 +47,8 @@ is a simple example:
         strict=False
         name=None,
         ordered=False,
-        unique_column_names=False
+        unique_column_names=False,
+        add_missing_columns=False
     )>
 
 
@@ -166,6 +167,7 @@ You can also write your schema to a python script with :func:`~pandera.io.to_scr
         unique=None,
         report_duplicates="all",
         unique_column_names=False,
+        add_missing_columns=False,
         title=None,
         description=None,
     )
@@ -250,6 +252,7 @@ is a convenience method for this functionality.
     unique: null
     report_duplicates: all
     unique_column_names: false
+    add_missing_columns: false
     title: null
     description: null
 
@@ -350,6 +353,7 @@ is a convenience method for this functionality.
         "unique": null,
         "report_duplicates": "all",
         "unique_column_names": false,
+        "add_missing_columns": false,
         "title": null,
         "description": null
     }

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -148,9 +148,6 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 "or `'filter'`."
             )
 
-        if add_missing_columns:
-            _validate_add_missing_columns_default(columns)
-
         self.index = index
         self.strict: Union[bool, str] = strict
         self._coerce = coerce
@@ -559,9 +556,6 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         .. seealso:: :func:`remove_columns`
 
         """
-        if self.add_missing_columns:
-            _validate_add_missing_columns_default(extra_schema_cols)
-
         schema_copy = copy.deepcopy(self)
         schema_copy.columns = {
             **schema_copy.columns,
@@ -689,10 +683,6 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         new_column = column_copy.__class__(
             **{**column_copy.properties, **kwargs}
         )
-
-        if self.add_missing_columns:
-            _validate_add_missing_columns_default({column_name: new_column})
-
         schema_copy.columns.update({column_name: new_column})
         return cast(DataFrameSchema, schema_copy)
 
@@ -777,9 +767,6 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 new_columns[col] = new_schema.columns[col].__class__(
                     **original_properties
                 )
-
-        if self.add_missing_columns:
-            _validate_add_missing_columns_default(new_columns)
 
         new_schema.columns = new_columns
 
@@ -1370,17 +1357,6 @@ def _validate_columns(
                     f"Check for Column {column_name} not "
                     "specified in the DataFrameSchema."
                 )
-
-
-def _validate_add_missing_columns_default(
-    column_dict: dict[Any, "pandera.api.pandas.components.Column"],  # type: ignore [name-defined]
-) -> None:
-    for column_name, column in column_dict.items():
-        if pd.isna(column.default) and not column.nullable:
-            raise errors.SchemaInitError(
-                f"column '{column_name}' requires a default value "
-                f"when non-nullable add_missing_columns is enabled"
-            )
 
 
 def _columns_renamed(

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -26,7 +26,9 @@ from pandera.engines import pandas_engine
 N_INDENT_SPACES = 4
 
 
-class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
+class DataFrameSchema(
+    BaseSchema
+):  # pylint: disable=too-many-public-methods,too-many-locals
     """A light-weight pandas DataFrame validator."""
 
     def __init__(

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -44,6 +44,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         unique: Optional[Union[str, List[str]]] = None,
         report_duplicates: UniqueSettings = "all",
         unique_column_names: bool = False,
+        add_missing_columns: bool = False,
         title: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -75,6 +76,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             - `exclude_last`: report all duplicates except last occurence
             - `all`: (default) report all duplicates
         :param unique_column_names: whether or not column names must be unique.
+        :param add_missing_columns: add missing column names with either default
+            value, if specified in column schema, or NaN if column is nullable.
         :param title: A human-readable label for the schema.
         :param description: An arbitrary textual description of the schema.
 
@@ -152,6 +155,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         self._unique = unique
         self.report_duplicates = report_duplicates
         self.unique_column_names = unique_column_names
+        self.add_missing_columns = add_missing_columns
 
         # this attribute is not meant to be accessed by users and is explicitly
         # set to True in the case that a schema is created by infer_schema.
@@ -423,7 +427,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             f"strict={self.strict}, "
             f"name={self.name}, "
             f"ordered={self.ordered}, "
-            f"unique_column_names={self.unique_column_names}"
+            f"unique_column_names={self.unique_column_names}, "
+            f"add_missing_columns={self.add_missing_columns}"
             ")>"
         )
 
@@ -472,7 +477,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             f"{indent}strict={self.strict}\n"
             f"{indent}name={self.name},\n"
             f"{indent}ordered={self.ordered},\n"
-            f"{indent}unique_column_names={self.unique_column_names}\n"
+            f"{indent}unique_column_names={self.unique_column_names},\n"
+            f"{indent}add_missing_columns={self.add_missing_columns}\n"
             ")>"
         )
 
@@ -543,7 +549,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`remove_columns`
@@ -594,7 +601,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`add_columns`
@@ -656,7 +664,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`rename_columns`
@@ -719,7 +728,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         """
@@ -801,7 +811,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`update_column`
@@ -879,7 +890,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. note:: If an index is present in the schema, it will also be
@@ -945,7 +957,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         If you have an existing index in your schema, and you would like to
@@ -981,7 +994,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`reset_index`
@@ -1078,7 +1092,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         This reclassifies an index (or indices) as a column (or columns).
@@ -1108,7 +1123,8 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             strict=False
             name=None,
             ordered=False,
-            unique_column_names=False
+            unique_column_names=False,
+            add_missing_columns=False
         )>
 
         .. seealso:: :func:`set_index`

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -148,6 +148,9 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 "or `'filter'`."
             )
 
+        if add_missing_columns:
+            _validate_add_missing_columns_default(columns)
+
         self.index = index
         self.strict: Union[bool, str] = strict
         self._coerce = coerce
@@ -556,6 +559,9 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         .. seealso:: :func:`remove_columns`
 
         """
+        if self.add_missing_columns:
+            _validate_add_missing_columns_default(extra_schema_cols)
+
         schema_copy = copy.deepcopy(self)
         schema_copy.columns = {
             **schema_copy.columns,
@@ -683,6 +689,10 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         new_column = column_copy.__class__(
             **{**column_copy.properties, **kwargs}
         )
+
+        if self.add_missing_columns:
+            _validate_add_missing_columns_default({column_name: new_column})
+
         schema_copy.columns.update({column_name: new_column})
         return cast(DataFrameSchema, schema_copy)
 
@@ -767,6 +777,9 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
                 new_columns[col] = new_schema.columns[col].__class__(
                     **original_properties
                 )
+
+        if self.add_missing_columns:
+            _validate_add_missing_columns_default(new_columns)
 
         new_schema.columns = new_columns
 
@@ -1357,6 +1370,17 @@ def _validate_columns(
                     f"Check for Column {column_name} not "
                     "specified in the DataFrameSchema."
                 )
+
+
+def _validate_add_missing_columns_default(
+    column_dict: dict[Any, "pandera.api.pandas.components.Column"],  # type: ignore [name-defined]
+) -> None:
+    for column_name, column in column_dict.items():
+        if pd.isna(column.default) and not column.nullable:
+            raise errors.SchemaInitError(
+                f"column '{column_name}' requires a default value "
+                f"when non-nullable add_missing_columns is enabled"
+            )
 
 
 def _columns_renamed(

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -270,7 +270,6 @@ class DataFrameModel(BaseModel):
                 "unique_column_names": cls.__config__.unique_column_names,
                 "add_missing_columns": cls.__config__.add_missing_columns,
                 "drop_invalid_rows": cls.__config__.drop_invalid_rows,
-
             }
         cls.__schema__ = DataFrameSchema(
             columns,

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -268,6 +268,7 @@ class DataFrameModel(BaseModel):
                 "title": cls.__config__.title,
                 "description": cls.__config__.description or cls.__doc__,
                 "unique_column_names": cls.__config__.unique_column_names,
+                "add_missing_columns": cls.__config__.add_missing_columns,
             }
         cls.__schema__ = DataFrameSchema(
             columns,

--- a/pandera/api/pandas/model_config.py
+++ b/pandera/api/pandas/model_config.py
@@ -47,6 +47,9 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: make sure dataframe column names are unique
     unique_column_names: bool = False
 
+    #: add columns to dataframe if they are missing
+    add_missing_columns: bool = False
+
     #: data format before validation. This option only applies to
     #: schemas used in the context of the pandera type constructor
     #: ``pa.typing.DataFrame[Schema](data)``. If None, assumes a data structure

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -33,7 +33,6 @@ class ColumnInfo(NamedTuple):
     expanded_column_names: FrozenSet
     destuttered_column_names: List
     absent_column_names: List
-    lazy_exclude_column_names: List
 
 
 FieldCheckObj = Union[pd.Series, pd.DataFrame]

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -62,12 +62,8 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
         if hasattr(check_obj, "pandera"):
             check_obj = check_obj.pandera.add_schema(schema)
 
+        # Collect status of columns against schema
         column_info = self.collect_column_info(check_obj, schema)
-
-        # collect schema components
-        components = self.collect_schema_components(
-            check_obj, schema, column_info
-        )
 
         core_parsers: List[Tuple[Callable[..., Any], Tuple[Any, ...]]] = [
             (self.add_missing_columns, (schema, column_info)),
@@ -82,6 +78,15 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 error_handler.collect_error(exc.reason_code, exc)
             except SchemaErrors as exc:
                 error_handler.collect_errors(exc)
+
+        # We may have modified columns, for example by
+        # add_missing_columns, so regenerate column info
+        column_info = self.collect_column_info(check_obj, schema)
+
+        # collect schema components
+        components = self.collect_schema_components(
+            check_obj, schema, column_info
+        )
 
         # subsample the check object if head, tail, or sample are specified
         sample = self.subsample(check_obj, head, tail, sample, random_state)

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -153,6 +153,7 @@ class SchemaErrorReason(Enum):
     SERIES_CHECK = "series_check"
     WRONG_DATATYPE = "wrong_dtype"
     INDEX_CHECK = "index_check"
+    ADD_MISSING_COLUMN_NO_DEFAULT = "add_missing_column_no_default"
 
 
 class SchemaErrors(ReducedPickleExceptionBase):

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -173,6 +173,7 @@ def serialize_schema(dataframe_schema):
         "unique": dataframe_schema.unique,
         "report_duplicates": dataframe_schema.report_duplicates,
         "unique_column_names": dataframe_schema.unique_column_names,
+        "add_missing_columns": dataframe_schema.add_missing_columns,
         "title": dataframe_schema.title,
         "description": dataframe_schema.description,
     }
@@ -301,6 +302,9 @@ def deserialize_schema(serialized_schema):
         unique_column_names=serialized_schema.get(
             "unique_column_names", False
         ),
+        add_missing_columns=serialized_schema.get(
+            "add_missing_columns", False
+        ),
         title=serialized_schema.get("title", None),
         description=serialized_schema.get("description", None),
     )
@@ -407,6 +411,7 @@ schema = DataFrameSchema(
     unique={unique},
     report_duplicates={report_duplicates},
     unique_column_names={unique_column_names},
+    add_missing_columns={add_missing_columns},
     title={title},
     description={description},
 )
@@ -546,6 +551,7 @@ def to_script(dataframe_schema, path_or_buf=None):
         unique=dataframe_schema.unique,
         report_duplicates=f'"{dataframe_schema.report_duplicates}"',
         unique_column_names=dataframe_schema.unique_column_names,
+        add_missing_columns=dataframe_schema.add_missing_columns,
         title=dataframe_schema.title,
         description=dataframe_schema.description,
     ).strip()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -724,7 +724,7 @@ def test_config() -> None:
     """Test that Config can be inherited and translate into DataFrameSchema options."""
 
     class Base(pa.DataFrameModel):
-        a: Series[int] = pa.Field(default=0)
+        a: Series[int]
         idx_1: Index[str]
         idx_2: Index[str]
 
@@ -739,7 +739,7 @@ def test_config() -> None:
             add_missing_columns = True
 
     class Child(Base):
-        b: Series[int] = pa.Field(default=0)
+        b: Series[int]
 
         class Config:
             name = "Child schema"
@@ -749,10 +749,7 @@ def test_config() -> None:
             title = "bar"
 
     expected = pa.DataFrameSchema(
-        columns={
-            "a": pa.Column(int, default=0),
-            "b": pa.Column(int, default=0),
-        },
+        columns={"a": pa.Column(int), "b": pa.Column(int)},
         index=pa.MultiIndex(
             [pa.Index(str, name="idx_1"), pa.Index(str, name="idx_2")],
             coerce=True,
@@ -774,7 +771,7 @@ def test_config() -> None:
 
 def test_multiindex_unique() -> None:
     class Base(pa.DataFrameModel):
-        a: Series[int] = pa.Field(default=0)
+        a: Series[int]
         idx_1: Index[str]
         idx_2: Index[str]
 
@@ -790,7 +787,7 @@ def test_multiindex_unique() -> None:
             add_missing_columns = True
 
     expected = pa.DataFrameSchema(
-        columns={"a": pa.Column(int, default=0)},
+        columns={"a": pa.Column(int)},
         index=pa.MultiIndex(
             [pa.Index(str, name="idx_1"), pa.Index(str, name="idx_2")],
             coerce=True,

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -736,6 +736,7 @@ def test_config() -> None:
             multiindex_strict = True
             multiindex_name: Optional[str] = "mi"
             unique_column_names = True
+            add_missing_columns = True
 
     class Child(Base):
         b: Series[int]
@@ -760,6 +761,7 @@ def test_config() -> None:
         strict=True,
         ordered=True,
         unique_column_names=True,
+        add_missing_columns=True,
         description="foo",
         title="bar",
     )
@@ -782,6 +784,7 @@ def test_multiindex_unique() -> None:
             multiindex_unique = ["idx_1", "idx_2"]
             multiindex_name: Optional[str] = "mi"
             unique_column_names = True
+            add_missing_columns = True
 
     expected = pa.DataFrameSchema(
         columns={"a": pa.Column(int)},
@@ -796,6 +799,7 @@ def test_multiindex_unique() -> None:
         coerce=True,
         ordered=True,
         unique_column_names=True,
+        add_missing_columns=True,
     )
 
     assert expected == Base.to_schema()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -724,7 +724,7 @@ def test_config() -> None:
     """Test that Config can be inherited and translate into DataFrameSchema options."""
 
     class Base(pa.DataFrameModel):
-        a: Series[int]
+        a: Series[int] = pa.Field(default=0)
         idx_1: Index[str]
         idx_2: Index[str]
 
@@ -739,7 +739,7 @@ def test_config() -> None:
             add_missing_columns = True
 
     class Child(Base):
-        b: Series[int]
+        b: Series[int] = pa.Field(default=0)
 
         class Config:
             name = "Child schema"
@@ -749,7 +749,10 @@ def test_config() -> None:
             title = "bar"
 
     expected = pa.DataFrameSchema(
-        columns={"a": pa.Column(int), "b": pa.Column(int)},
+        columns={
+            "a": pa.Column(int, default=0),
+            "b": pa.Column(int, default=0),
+        },
         index=pa.MultiIndex(
             [pa.Index(str, name="idx_1"), pa.Index(str, name="idx_2")],
             coerce=True,
@@ -771,7 +774,7 @@ def test_config() -> None:
 
 def test_multiindex_unique() -> None:
     class Base(pa.DataFrameModel):
-        a: Series[int]
+        a: Series[int] = pa.Field(default=0)
         idx_1: Index[str]
         idx_2: Index[str]
 
@@ -787,7 +790,7 @@ def test_multiindex_unique() -> None:
             add_missing_columns = True
 
     expected = pa.DataFrameSchema(
-        columns={"a": pa.Column(int)},
+        columns={"a": pa.Column(int, default=0)},
         index=pa.MultiIndex(
             [pa.Index(str, name="idx_1"), pa.Index(str, name="idx_2")],
             coerce=True,

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -44,6 +44,15 @@ def test_column() -> None:
         Column(Int)(data)
 
 
+def test_column_coerce() -> None:
+    """Test that the Column object can be used to coerce dataframe types."""
+    data = pd.DataFrame({"a": [1, 2, 3]})
+    column_schema = Column(Int, name="a", coerce=True)
+    validated = column_schema.validate(data)
+    assert isinstance(validated, pd.DataFrame)
+    assert Engine.dtype(validated.a.dtype) == Engine.dtype(int)
+
+
 def test_column_in_dataframe_schema():
     """Test that a Column check returns a dataframe."""
     schema = DataFrameSchema(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -431,58 +431,6 @@ def test_add_missing_columns():
     ]
     assert validated_frame_unknown["b"].eq(9).all()
 
-    # Add nullable column without a default value
-    schema_no_default_nullable = DataFrameSchema(
-        columns={
-            i: Column(int, default=None, nullable=True) for i in col_labels
-        },
-        strict=True,
-        add_missing_columns=True,
-    )
-    validated_frame_nullable = schema_no_default_nullable.validate(
-        frame_missing_first
-    )
-    assert validated_frame_nullable[["a"]].isna().all(axis=None)
-
-    # Try to add a non-nullable column without a default value to existing schema
-    with pytest.raises(
-        errors.SchemaInitError,
-        match="column 'missing' requires a default value when non-nullable add_missing_columns is enabled",
-    ):
-        schema_no_default_nullable.add_columns({"missing": Column()})
-
-    # Try to update a non-nullable column with a default to one without
-    with pytest.raises(
-        errors.SchemaInitError,
-        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
-    ):
-        schema_no_default_nullable.update_column(
-            "a", default=np.nan, nullable=False
-        )
-
-    # Try to update a non-nullable column with a default to one without
-    with pytest.raises(
-        errors.SchemaInitError,
-        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
-    ):
-        schema_no_default_nullable.update_columns(
-            {"a": {"default": np.nan, "nullable": False}}
-        )
-
-    # Create schema containing non-nullable columns without a default value
-    with pytest.raises(
-        errors.SchemaInitError,
-        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
-    ):
-        DataFrameSchema(
-            columns={
-                i: Column(int, default=None, nullable=False)
-                for i in col_labels
-            },
-            strict=True,
-            add_missing_columns=True,
-        )
-
 
 def test_series_schema() -> None:
     """Tests that a SeriesSchema Check behaves as expected for integers and

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -431,6 +431,18 @@ def test_add_missing_columns():
     ]
     assert validated_frame_unknown["b"].eq(9).all()
 
+    # Validate schema containing non-nullable column without a default value
+    schema_no_default_not_nullable = DataFrameSchema(
+        columns={i: Column(int, nullable=False) for i in ["a", "b", "c"]},
+        strict=True,
+        add_missing_columns=True,
+    )
+    with pytest.raises(
+        errors.SchemaError,
+        match="column 'a' in .* requires a default value when non-nullable add_missing_columns is enabled",
+    ):
+        schema_no_default_not_nullable.validate(frame_missing_first)
+
 
 def test_series_schema() -> None:
     """Tests that a SeriesSchema Check behaves as expected for integers and

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -2106,7 +2106,7 @@ def test_missing_columns():
         ),
     ],
 )
-def test_default_with_correct_dtype(
+def test_series_default_with_correct_dtype(
     series_schema: SeriesSchema, series: pd.Series, expected_values: list
 ):
     """Test that missing rows are backfilled with the default if missing"""
@@ -2114,13 +2114,38 @@ def test_default_with_correct_dtype(
     assert set(validated_series.values) == set(expected_values)
 
 
-def test_default_with_incorrect_dtype_raises_error():
+def test_series_default_with_incorrect_dtype_raises_error():
     """Test that if a default with the incorrect dtype is passed, a SchemaError is raised"""
     series_schema = SeriesSchema(str, default=1)
 
     series = pd.Series(["the first", None])
     with pytest.raises(errors.SchemaError):
         series_schema.validate(series)
+
+
+@pytest.mark.parametrize(
+    "dataframe_schema,dataframe,expected_dataframe",
+    [
+        (
+            DataFrameSchema(
+                columns={
+                    "a": Column(pd.Int64Dtype(), default=9),
+                    "b": Column(pd.Int64Dtype(), nullable=True),
+                },
+            ),
+            pd.DataFrame({"a": [0, None], "b": [None, 5]}, dtype="Int64"),
+            pd.DataFrame({"a": [0, 9], "b": [None, 5]}, dtype="Int64"),
+        ),
+    ],
+)
+def test_dataframe_default_with_correct_dtype(
+    dataframe_schema: DataFrameSchema,
+    dataframe: pd.DataFrame,
+    expected_dataframe: pd.DataFrame,
+):
+    """Test that missing rows are backfilled with the default if missing"""
+    validated_dataframe = dataframe_schema.validate(dataframe)
+    pd.testing.assert_frame_equal(validated_dataframe, expected_dataframe)
 
 
 def test_pandas_dataframe_subclass_validation():

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -431,6 +431,58 @@ def test_add_missing_columns():
     ]
     assert validated_frame_unknown["b"].eq(9).all()
 
+    # Add nullable column without a default value
+    schema_no_default_nullable = DataFrameSchema(
+        columns={
+            i: Column(int, default=None, nullable=True) for i in col_labels
+        },
+        strict=True,
+        add_missing_columns=True,
+    )
+    validated_frame_nullable = schema_no_default_nullable.validate(
+        frame_missing_first
+    )
+    assert validated_frame_nullable[["a"]].isna().all(axis=None)
+
+    # Try to add a non-nullable column without a default value to existing schema
+    with pytest.raises(
+        errors.SchemaInitError,
+        match="column 'missing' requires a default value when non-nullable add_missing_columns is enabled",
+    ):
+        schema_no_default_nullable.add_columns({"missing": Column()})
+
+    # Try to update a non-nullable column with a default to one without
+    with pytest.raises(
+        errors.SchemaInitError,
+        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
+    ):
+        schema_no_default_nullable.update_column(
+            "a", default=np.nan, nullable=False
+        )
+
+    # Try to update a non-nullable column with a default to one without
+    with pytest.raises(
+        errors.SchemaInitError,
+        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
+    ):
+        schema_no_default_nullable.update_columns(
+            {"a": {"default": np.nan, "nullable": False}}
+        )
+
+    # Create schema containing non-nullable columns without a default value
+    with pytest.raises(
+        errors.SchemaInitError,
+        match="column 'a' requires a default value when non-nullable add_missing_columns is enabled",
+    ):
+        DataFrameSchema(
+            columns={
+                i: Column(int, default=None, nullable=False)
+                for i in col_labels
+            },
+            strict=True,
+            add_missing_columns=True,
+        )
+
 
 def test_series_schema() -> None:
     """Tests that a SeriesSchema Check behaves as expected for integers and

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -244,6 +244,7 @@ ordered: false
 unique: null
 report_duplicates: all
 unique_column_names: false
+add_missing_columns: false
 title: null
 description: null
 """
@@ -505,6 +506,7 @@ ordered: false
 unique: null
 report_duplicates: all
 unique_column_names: false
+add_missing_columns: false
 title: null
 description: null
 """
@@ -1251,6 +1253,7 @@ ordered: false
 unique: null
 report_duplicates: all
 unique_column_names: false
+add_missing_columns: false
 title: null
 description: null
 """


### PR DESCRIPTION
I took a crack at adding the 'add_missing_columns' DataFrame schema config, including tests. One thing I could use some advice on is that I got missing attribute pylint issues in file pandera/backends/pandas/container.py before I even changed anything. They look related to the 'schema' method argument variable not having any typing annotation such that the referenced column schema attributes for 'required', 'dtype', and 'coerce' are unknown. The typing annotation surrounding this variable looks rather complicated and I was afraid to make changes, so I marked as "# type: ignore[union-attr]" in this pull request.

```python
import pandas as pd
from pandera import Column, DataFrameSchema

schema = DataFrameSchema(
    columns={i: Column(int, default=9) for i in ["a", "b", "c"]},
    strict=True,
    add_missing_columns=True,
)

print(schema.validate(pd.DataFrame(data=[[1, 3]], columns=["a", "c"])))

# Output:
#    a  b  c
# 0  1  9  3
```