### PR TITLE
Bugfix: check for presence of default attribute before calling

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -46,7 +46,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
         check_obj = self.preprocess(check_obj, inplace)
 
         # fill nans with `default` if it's present
-        if pd.notna(schema.default):
+        if hasattr(schema, "default") and pd.notna(schema.default):
             check_obj.fillna(schema.default, inplace=True)
 
         if schema.coerce:


### PR DESCRIPTION
**Fixes issue:** [1188](https://github.com/unionai-oss/pandera/issues/1188) by ensuring the `.default` attributes exists on the `schema` object before calling it.