### PR TITLE
Use custom check strategies

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -103,7 +103,8 @@ class Check(BaseCheck):
         :param statistics: kwargs to pass into the check function. These values
             are serialized and represent the constraints of the checks.
         :param strategy: A hypothesis strategy, used for implementing data
-            synthesis strategies for this check.
+            synthesis strategies for this check. See the
+            :ref:`User Guide <custom_strategies>` for more details.
         :param check_kwargs: key-word arguments to pass into ``check_fn``
 
         :example:

--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -195,7 +195,7 @@ class Check(BaseCheck):
             groups = [groups]
         self.groups: Optional[List[str]] = groups
 
-        self.statistics = statistics or {}
+        self.statistics = statistics or check_kwargs or {}
         self.statistics_args = [*self.statistics.keys()]
         self.strategy = strategy
 

--- a/pandera/api/extensions.py
+++ b/pandera/api/extensions.py
@@ -288,5 +288,6 @@ def register_check_method(
         Check.REGISTERED_CUSTOM_CHECKS[check_fn.__name__] = partial(
             check_method, Check
         )
+        return check_fn
 
     return register_check_wrapper(check_fn)

--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -1073,11 +1073,8 @@ def dataframe_strategy(
         undefined_strat_df_checks = []
         for check in checks:
             if (
-                getattr(
-                    check,
-                    "strategy",
-                    STRATEGY_DISPATCHER.get((check.name, pd.DataFrame), None),
-                )
+                check.strategy
+                or STRATEGY_DISPATCHER.get((check.name, pd.DataFrame), None)
                 or check.element_wise
             ):
                 # we can apply element-wise checks defined at the dataframe

--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -828,7 +828,7 @@ def series_strategy(
     unique: bool = False,
     name: Optional[str] = None,
     size: Optional[int] = None,
-):
+) -> SearchStrategy[pd.Series]:
     """Strategy to generate a pandas Series.
 
     :param pandera_dtype: :class:`pandera.dtypes.DataType` instance.
@@ -882,9 +882,14 @@ def series_strategy(
         return strategy.filter(_check_fn)
 
     for check in checks if checks is not None else []:
-        check_strategy = STRATEGY_DISPATCHER.get((check.name, pd.Series), None)
-        if check_strategy is None and not check.element_wise:
-            strategy = undefined_check_strategy(strategy, check)
+        if check.strategy is not None:
+            strategy = check.strategy
+        else:
+            check_strategy = STRATEGY_DISPATCHER.get(
+                (check.name, pd.Series), None
+            )
+            if check_strategy is None and not check.element_wise:
+                strategy = undefined_check_strategy(strategy, check)
 
     return strategy
 

--- a/tests/core/test_extensions.py
+++ b/tests/core/test_extensions.py
@@ -226,7 +226,7 @@ def test_register_check_with_strategy(custom_check_teardown: None) -> None:
         return pandas_obj >= min_value
 
     check = Check.custom_ge_check(min_value=0)
-    strat = check.strategy(pa.Int)
+    strat = check.strategy(pa.Int, **check.statistics)
     with pytest.warns(hypothesis.errors.NonInteractiveExampleWarning):
         assert strat.example() >= 0
 

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -484,6 +484,25 @@ def test_dataframe_strategy(data_type, size, data):
         )
 
 
+@pytest.mark.parametrize("size", [None, 0, 1, 3, 5])
+@hypothesis.given(st.data())
+def test_dataframe_strategy_with_check(size, data):
+    """Test DataFrameSchema strategy with dataframe-level check."""
+    dataframe_schema = pa.DataFrameSchema(
+        {"col": pa.Column(float)},
+        checks=pa.Check.in_range(5, 10),
+    )
+    df_sample = data.draw(dataframe_schema.strategy(size=size))
+    if size == 0:
+        assert df_sample.empty
+    elif size is None:
+        assert df_sample.empty or isinstance(
+            dataframe_schema(df_sample), pd.DataFrame
+        )
+    else:
+        assert isinstance(dataframe_schema(df_sample), pd.DataFrame)
+
+
 @hypothesis.given(st.data())
 def test_dataframe_example(data) -> None:
     """Test DataFrameSchema example method generate examples that pass."""

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -805,7 +805,7 @@ def test_dataframe_strategy_undefined_check_strategy(
     schema(example)
 
 
-@pytest.mark.xfail(reason="https://github.com/unionai-oss/pandera/issues/1173")
+@pytest.mark.xfail(reason="no mechanism to specify strategy size")
 @hypothesis.given(st.data())
 def test_defined_check_strategy(data: st.DataObject):
     """


### PR DESCRIPTION
Resolves https://github.com/unionai-oss/pandera/issues/1173... somewhat. Adds the xfailed `tests/strategies/test_strategies.py::test_defined_check_strategy`, which fails because `size` arguments aren't respected in this PR.

Concerns regarding `series_strategy()`:

* It'd require some significant re-working for `size` to be respected by custom strategies, unless I'm missing something. Maybe we need something like

  ```python
  # in the pandera.strategies namespace
  class VectorizedPanderaStrategy(Protocol):
      def __call__(self, size: None | int, **kwargs) -> st.SearchStrategy[pd.Series]:
          ...
  ```
  
  which would be the type hint for all relevant `strategy=` keywords and used accordingly.

* Only one check strategy would end up getting used, even if there are multiple checks. IMO it'd be best to warn at least here, as I can see "merging" the built-in check strategies is difficult, and custom strategies would be impossible. I think at least these strategies could all be sampled via `st.one_of()`.

  FWIW I've had [some success "merging" strategies](https://github.com/data-apis/array-api-tests/blob/fb498029319212bd9248c05fd8dee4213efee371/array_api_tests/test_special_cases.py#L191) before. I could certainly see it possible for the builtin check strategies... just a fair bit of effort.