### PR TITLE
Relax python_requires constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "wrapt",
     ],
     extras_require=extras_require,
-    python_requires=">=3.7,<3.12",
+    python_requires=">=3.7",
     platforms="any",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Limiting supported Python versions to < 3.12 has unforeseen knock-on effects, as described in #1206.

Closes #1206