### PR TITLE
Add a Dependabot config to update GitHub workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Several of the actions used in the GitHub workflows are older versions which are throwing deprecation warnings on each run. [[example from a recent CI run](https://github.com/unionai-oss/pandera/actions/runs/5247527340)]

Rather than submit a PR to update the versions, this PR adds a Dependabot configuration that, once merged, will trigger ongoing automatic update PRs from Dependabot. This will keep the action versions updated in perpetuity.

I've read through the contributing document and signed off on the commit, but I may have missed something. Please let me know if anything else is required.

Thanks! Hopefully we'll have a chance to talk at SciPy 2023!