### PR TITLE
Bug fix while ordering optional keys from schema in static method from_records from pandera df

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -14,6 +14,7 @@ from typing import (  # type: ignore[attr-defined]
     Union,
     _type_check,
 )
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -231,8 +232,15 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         schema_index = schema.index.names if schema.index is not None else None
         if "index" not in kwargs:
             kwargs["index"] = schema_index
+        data_df = pd.DataFrame.from_records(data=data, **kwargs)
         return DataFrame[schema](  # type: ignore
-            pd.DataFrame.from_records(data=data, **kwargs,)[
-                schema.columns.keys()
-            ]  # set the column order according to schema
+            # set the column order according to schema
+            data_df[
+                list(
+                    filter(
+                        lambda column: column in data_df.columns,
+                        OrderedDict.fromkeys(schema.columns),
+                    )
+                )
+            ]
         )

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -14,7 +14,6 @@ from typing import (  # type: ignore[attr-defined]
     Union,
     _type_check,
 )
-from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -235,12 +234,5 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         data_df = pd.DataFrame.from_records(data=data, **kwargs)
         return DataFrame[schema](  # type: ignore
             # set the column order according to schema
-            data_df[
-                list(
-                    filter(
-                        lambda column: column in data_df.columns,
-                        OrderedDict.fromkeys(schema.columns),
-                    )
-                )
-            ]
+            data_df[[c for c in schema.columns if c in data_df.columns]]
         )

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1090,6 +1090,7 @@ def test_from_records_validates_the_schema():
         state: Series[str]
         city: Series[str]
         price: Series[float]
+        postal_code: Optional[Series[int]] = pa.Field(nullable=True)
 
     raw_data = [
         {


### PR DESCRIPTION
I saw a bug on from_records static method from pandera DataFrame when trying to sort columns that may be not required in the schema but are trying to be sorted:
```python
from typing import Optional
from pandera import Field, SchemaModel
from pandera.typing import Series, DataFrame
class Schema(SchemaModel):
    state: Series[str]
    city: Series[str]
    price: Series[float]
    postal_code: Optional[Series[int]] = Field(nullable=True)

raw_data = [
    {
        "state": "NY",
        "city": "New York",
        "price": 8.0,
    },
    {
        "state": "FL",
        "city": "Miami",
        "price": 12.0,
    },
]
DataFrame.from_records(Schema, raw_data)
```
and raises the following error: KeyError: "['postal_code'] not in index".
Also, as is currently implemented, the keys may not be sorted as schema says.
