### PR TITLE
Bugfix: Ensure defaults are correctly applied

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -53,7 +53,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
 
         # fill nans with `default` if it's present
         if hasattr(schema, "default") and pd.notna(schema.default):
-            check_obj.fillna(schema.default, inplace=True)
+            check_obj = self.set_default(check_obj, schema)
 
         if schema.coerce:
             try:
@@ -318,6 +318,15 @@ class ArraySchemaBackend(PandasSchemaBackend):
                     )
                 )
         return check_results
+
+    def set_default(self, check_obj, schema):
+        """Sets the ``schema.default`` value on the ``check_obj``"""
+        if is_field(check_obj):
+            check_obj.fillna(schema.default, inplace=True)
+        else:
+            check_obj[schema.name].fillna(schema.default, inplace=True)
+
+        return check_obj
 
 
 class SeriesSchemaBackend(ArraySchemaBackend):

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -2043,6 +2043,30 @@ def test_default_with_incorrect_dtype_raises_error():
         series_schema.validate(series)
 
 
+def test_default_works_correctly_on_schemas_with_multiple_colummns():
+    """Test that each column defaults to the correct value"""
+
+    df = pd.DataFrame(
+        {"x": [1, 2, 3], "y": [None, None, None], "z": [None, None, None]}
+    ).astype("Int64")
+
+    schema = DataFrameSchema(
+        columns={
+            "x": Column("Int64", nullable=True, default=-999),
+            "y": Column("Int64", nullable=True, default=123),
+            "z": Column("Int64", nullable=True, default=1000),
+        }
+    )
+
+    schema.validate(df, inplace=True)
+
+    expected_df = pd.DataFrame(
+        {"x": [1, 2, 3], "y": [123, 123, 123], "z": [1000, 1000, 1000]}
+    ).astype("Int64")
+
+    pd.testing.assert_frame_equal(df, expected_df)
+
+
 def test_pandas_dataframe_subclass_validation():
     """Test that DataFrame subclasses can be validated by pandera."""
 


### PR DESCRIPTION
Fixing: https://github.com/unionai-oss/pandera/issues/1193

The default values is currently incorrectly applied to `check_obj`, meaning that the `NaN` values are filled with the first columns default value 🥴 

This PR fixes this bug, ensuring that only the column/series/field's `NaN` values are filled, not the entire dataframe!