### PR TITLE
fix issue for optional fields

### DIFF
--- a/pandera/mypy.py
+++ b/pandera/mypy.py
@@ -133,7 +133,13 @@ class DataFrameModelTransformer:
             x: pa.typing.Series[str]  # mypy assignment error, cannot override types
         """
         for def_ in self.ctx.cls.defs.body:
-            if not hasattr(def_, "type") or def_.type is None:
+            if (
+                not hasattr(def_, "type")
+                or def_.type is None
+                # e.g. UnionType does not have module_name or name
+                or not hasattr(def_.type, "module_name")
+                or not hasattr(def_.type, "name")
+            ):
                 continue
             type_ = def_.type
             if get_typename(def_.type) in FIELD_GENERICS_FULLNAMES:

--- a/tests/mypy/modules/pandas_dataframe.py
+++ b/tests/mypy/modules/pandas_dataframe.py
@@ -5,7 +5,7 @@ This test module uses https://github.com/davidfritzsche/pytest-mypy-testing to
 run statically check the functions marked pytest.mark.mypy_testing
 """
 
-from typing import cast
+from typing import Optional, cast
 
 import pandas as pd
 
@@ -24,7 +24,7 @@ class SchemaOut(pa.DataFrameModel):
 
 class AnotherSchema(pa.DataFrameModel):
     id: Series[int]
-    first_name: Series[str]
+    first_name: Optional[Series[str]]
 
 
 def fn(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -54,7 +54,11 @@ PANDAS_DATAFRAME_ERRORS = [
 ]
 
 
-def test_mypy_pandas_dataframe(capfd) -> None:
+@pytest.mark.parametrize(
+    ["config_file", "expected_errors"],
+    [("no_plugin.ini", PANDAS_DATAFRAME_ERRORS), ("plugin_mypy.ini", [])],
+)
+def test_mypy_pandas_dataframe(capfd, config_file, expected_errors) -> None:
     """Test that mypy raises expected errors on pandera-decorated functions."""
     # pylint: disable=subprocess-run-check
     cache_dir = str(test_module_dir / ".mypy_cache" / "test-mypy-default")
@@ -67,13 +71,13 @@ def test_mypy_pandas_dataframe(capfd) -> None:
             "--cache-dir",
             cache_dir,
             "--config-file",
-            str(test_module_dir / "config" / "no_plugin.ini"),
+            str(test_module_dir / "config" / config_file),
         ],
         text=True,
     )
     errors = _get_mypy_errors("pandas_dataframe.py", capfd.readouterr().out)
-    assert len(PANDAS_DATAFRAME_ERRORS) == len(errors)
-    for expected, error in zip(PANDAS_DATAFRAME_ERRORS, errors):
+    assert len(expected_errors) == len(errors)
+    for expected, error in zip(expected_errors, errors):
         assert error["errcode"] == expected["errcode"]
         assert expected["msg"] == error["msg"] or re.match(
             expected["msg"], error["msg"]


### PR DESCRIPTION
This is an new contributor's attempt to address an issue with optional fields in Pandera Models. Already reported in https://github.com/unionai-oss/pandera/issues/1204.

I'm not sure this is the right proper way. The whole `DataFrameModelTransformer` seems not to be picked mypy tests. I'd be grateful for a hint on creating a better test for this.