### PR TITLE
Use pandera-dev in envrc to match the environment.yml

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-source activate pandera
+source activate pandera-dev


### PR DESCRIPTION
This PR updates the `.envrc` file to match the name with the one in `environment.yml`:

https://github.com/unionai-oss/pandera/blob/62bc4840508ff1ac0df595b57b2152737a1228a2/environment.yml#L1

The alternative is to remove `.envrc` if it is not actually used.