### PR TITLE
Use mirrors-mypy for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,9 @@ repos:
         args: ["--line-length=79", "--skip=docs/source/conf.py", "--diff"]
 
   - repo: https://github.com/ikamensh/flynt
-    rev: '0.76'
+    rev: "0.76"
     hooks:
-        - id: flynt
+      - id: flynt
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -45,15 +45,19 @@ repos:
         args: ["--disable=import-error"]
         exclude: (^docs/|^scripts)
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
     hooks:
       - id: mypy
-        name: mypy
-        entry: mypy
-        language: python
-        types: [python]
-        pass_filenames: false
-        exclude: (^docs/|^tests/mypy/modules/)
-        require_serial: true
+        additional_dependencies:
+          - pandas-stubs
+          - types-click
+          - types-pkg_resources
+          - types-pytz
+          - types-pyyaml
+          - types-requests
         args: ["pandera", "tests", "scripts"]
+        exclude: (^docs/|^tests/mypy/modules/)
+        pass_filenames: false
+        require_serial: true
         verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - numpy
           - pandas-stubs
           - types-click
           - types-pkg_resources

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -19,7 +19,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints,
 )
 
 import pandas as pd
@@ -42,6 +41,11 @@ from pandera.errors import SchemaInitError
 from pandera.strategies import pandas_strategies as st
 from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo
 from pandera.typing.common import DataFrameBase
+
+try:
+    from typing_extensions import get_type_hints
+except ImportError:  # pragma: no cover
+    from typing import get_type_hints  # type: ignore
 
 try:
     from pydantic.fields import ModelField  # pylint:disable=unused-import

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -19,6 +19,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_type_hints,
 )
 
 import pandas as pd
@@ -40,11 +41,6 @@ from pandera.errors import SchemaInitError
 from pandera.strategies import pandas_strategies as st
 from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo
 from pandera.typing.common import DataFrameBase
-
-try:
-    from typing_extensions import get_type_hints
-except ImportError:
-    from typing import get_type_hints  # type: ignore
 
 try:
     from pydantic.fields import ModelField  # pylint:disable=unused-import
@@ -424,9 +420,12 @@ class DataFrameModel(BaseModel):
     @classmethod
     def _collect_fields(cls) -> Dict[str, Tuple[AnnotationInfo, FieldInfo]]:
         """Centralize publicly named fields and their corresponding annotations."""
-        annotations = get_type_hints(  # pylint:disable=unexpected-keyword-arg
-            cls, include_extras=True  # type: ignore [call-arg]
+        # pylint: disable=unexpected-keyword-arg
+        annotations = get_type_hints(  # type: ignore[call-arg]
+            cls,
+            include_extras=True,
         )
+        # pylint: enable=unexpected-keyword-arg
         attrs = cls._get_model_attrs()
 
         missing = []

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 import pandas as pd
+import pandas.util
 
 from pandera.api.base.model import BaseModel
 from pandera.api.checks import Check
@@ -65,10 +66,11 @@ TDataFrameModel = TypeVar("TDataFrameModel", bound="DataFrameModel")
 
 
 def docstring_substitution(*args: Any, **kwargs: Any) -> Callable[[F], F]:
-    """Typed wrapper around pd.util.Substitution."""
+    """Typed wrapper around pandas.util.Substitution."""
 
     def decorator(func: F) -> F:
-        return cast(F, pd.util.Substitution(*args, **kwargs)(func))
+        substitutor = pandas.util.Substitution(*args, **kwargs)  # type: ignore[attr-defined]
+        return cast(F, substitutor(func))
 
     return decorator
 

--- a/pandera/api/pandas/types.py
+++ b/pandera/api/pandas/types.py
@@ -11,9 +11,10 @@ from pandera.api.hypotheses import Hypothesis
 from pandera.dtypes import DataType
 
 try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore [misc]
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore[misc]
 
 
 CheckList = Union[Check, List[Union[Check, Hypothesis]]]

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -19,7 +19,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints,
 )
 
 import pyspark.sql as ps
@@ -40,6 +39,11 @@ from pandera.api.pyspark.model_config import BaseConfig
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
 from pandera.typing.common import DataFrameBase
+
+try:
+    from typing_extensions import get_type_hints
+except ImportError:  # pragma: no cover
+    from typing import get_type_hints  # type: ignore
 
 try:
     from pydantic.fields import ModelField  # pylint:disable=unused-import

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -19,6 +19,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_type_hints,
 )
 
 import pyspark.sql as ps
@@ -39,11 +40,6 @@ from pandera.api.pyspark.model_config import BaseConfig
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
 from pandera.typing.common import DataFrameBase
-
-try:
-    from typing_extensions import get_type_hints
-except ImportError:  # pragma: no cover
-    from typing import get_type_hints  # type: ignore
 
 try:
     from pydantic.fields import ModelField  # pylint:disable=unused-import

--- a/pandera/api/pyspark/types.py
+++ b/pandera/api/pyspark/types.py
@@ -10,9 +10,10 @@ from pandera.api.checks import Check
 from pandera.dtypes import DataType
 
 try:
-    from typing import Literal
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore [misc]
+    from typing_extensions import Literal  # type: ignore[misc]
 
 
 CheckList = Union[Check, List[Check]]

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -56,12 +56,12 @@ class PandasCheckBackend(BaseCheckBackend):
         # NOTE: this behavior should be deprecated such that the user deals with
         # pandas groupby objects instead of dicts.
         if groups is None:
-            return {
+            return {  # type: ignore[return-value]
                 (k if isinstance(k, bool) else k[0] if len(k) == 1 else k): v
-                for k, v in groupby_obj  # type: ignore [union-attr]
+                for k, v in groupby_obj  # type: ignore[union-attr]
             }
         group_keys = set(
-            k[0] if len(k) == 1 else k for k, _ in groupby_obj  # type: ignore [union-attr]
+            k[0] if len(k) == 1 else k for k, _ in groupby_obj  # type: ignore[union-attr]
         )
         invalid_groups = [g for g in groups if g not in group_keys]
         if invalid_groups:
@@ -69,7 +69,7 @@ class PandasCheckBackend(BaseCheckBackend):
                 f"groups {invalid_groups} provided in `groups` argument not a "
                 f"valid group key. Valid group keys: {group_keys}"
             )
-        return {
+        return {  # type: ignore[return-value]
             group_key: group
             for group_key, group in groupby_obj  # type: ignore [union-attr]
             if group_key in groups

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -357,7 +357,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
                     )
 
         if schema.strict == "filter":
-            check_obj = check_obj.drop(*filter_out_columns)
+            check_obj = check_obj.drop(columns=filter_out_columns)
 
         return check_obj
 

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -3,7 +3,7 @@
 import copy
 import traceback
 import warnings
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
 
 from pyspark.sql import DataFrame
 from pyspark.sql.functions import col
@@ -11,7 +11,7 @@ from pyspark.sql.functions import col
 from pandera.api.pyspark.error_handler import ErrorCategory, ErrorHandler
 from pandera.api.pyspark.types import is_table
 from pandera.backends.pyspark.base import ColumnInfo, PysparkSchemaBackend
-from pandera.backends.pyspark.decorators import validate_scope, ValidationScope
+from pandera.backends.pyspark.decorators import ValidationScope, validate_scope
 from pandera.backends.pyspark.error_formatters import scalar_failure_case
 from pandera.config import CONFIG
 from pandera.errors import (
@@ -357,7 +357,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
                     )
 
         if schema.strict == "filter":
-            check_obj = check_obj.drop(columns=filter_out_columns)
+            check_obj = check_obj.drop(cols=filter_out_columns)
 
         return check_obj
 

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -357,7 +357,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
                     )
 
         if schema.strict == "filter":
-            check_obj = check_obj.drop(cols=filter_out_columns)
+            check_obj = check_obj.drop(*filter_out_columns)
 
         return check_obj
 

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -18,8 +18,9 @@ from typing import (
 )
 
 try:
-    from typing import Literal
-except ImportError:
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
     from typing_extensions import Literal  # type: ignore[misc]
 
 

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import numpy as np
+from numpy.typing import DTypeLike
 
 from pandera import dtypes, errors
 from pandera.dtypes import immutable
@@ -21,7 +22,7 @@ from pandera.system import FLOAT_128_AVAILABLE
 class DataType(dtypes.DataType):
     """Base `DataType` for boxing Numpy data types."""
 
-    type: np.dtype = dataclasses.field(
+    type: DTypeLike = dataclasses.field(
         default=np.dtype("object"), repr=False, init=False
     )
     """Native numpy dtype boxed by the data type."""

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -655,9 +655,9 @@ else:
 
     @Engine.register_dtype(
         equivalents=["string", pd.StringDtype, pd.StringDtype()]  # type: ignore
-    )  # type: ignore[no-redef]
+    )  # type: ignore[no-redef] # python 3.7
     @immutable
-    class STRING(DataType, dtypes.String):
+    class STRING(DataType, dtypes.String):  # type: ignore[no-redef] # python 3.8+
         """Semantic representation of a :class:`pandas.StringDtype`."""
 
         type = pd.StringDtype()  # type: ignore

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -62,9 +62,10 @@ else:
 
 
 try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore[misc]
 
 
 def is_extension_dtype(
@@ -656,7 +657,7 @@ else:
         equivalents=["string", pd.StringDtype, pd.StringDtype()]  # type: ignore
     )
     @immutable
-    class STRING(DataType, dtypes.String):  # type: ignore
+    class STRING(DataType, dtypes.String):  # type: ignore[no-redef]
         """Semantic representation of a :class:`pandas.StringDtype`."""
 
         type = pd.StringDtype()  # type: ignore
@@ -1024,7 +1025,8 @@ class Sparse(DataType):
         """Convert a :class:`pandas.SparseDtype` to
         a Pandera :class:`pandera.engines.pandas_engine.Sparse`."""
         return cls(
-            dtype=pd_dtype.subtype, fill_value=pd_dtype.fill_value  # type: ignore
+            dtype=pd_dtype.subtype,  # type: ignore[call-arg, attr-defined]
+            fill_value=pd_dtype.fill_value,
         )
 
 
@@ -1127,7 +1129,7 @@ class PydanticModel(DataType):
                     failure_cases, ignore_na=False
                 ),
             )
-        return coerced_df.drop(["failure_cases"], axis="columns")
+        return coerced_df.drop(columns="failure_cases")
 
 
 ###############################################################################

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -655,9 +655,9 @@ else:
 
     @Engine.register_dtype(
         equivalents=["string", pd.StringDtype, pd.StringDtype()]  # type: ignore
-    )
+    )  # type: ignore[no-redef]
     @immutable
-    class STRING(DataType, dtypes.String):  # type: ignore[no-redef]
+    class STRING(DataType, dtypes.String):
         """Semantic representation of a :class:`pandas.StringDtype`."""
 
         type = pd.StringDtype()  # type: ignore
@@ -1024,8 +1024,8 @@ class Sparse(DataType):
     def from_parametrized_dtype(cls, pd_dtype: pd.SparseDtype):
         """Convert a :class:`pandas.SparseDtype` to
         a Pandera :class:`pandera.engines.pandas_engine.Sparse`."""
-        return cls(
-            dtype=pd_dtype.subtype,  # type: ignore[call-arg, attr-defined]
+        return cls(  # type: ignore[call-arg]
+            dtype=pd_dtype.subtype,  # type: ignore[attr-defined]
             fill_value=pd_dtype.fill_value,
         )
 

--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -51,7 +51,6 @@ try:
     import hypothesis.strategies as st
     from hypothesis.strategies import SearchStrategy, composite
 except ImportError:  # pragma: no cover
-
     T = TypeVar("T")
 
     # pylint: disable=too-few-public-methods
@@ -284,8 +283,8 @@ def numpy_time_dtypes(
 
     def _to_unix(value: Any) -> int:
         if dtype.type is np.timedelta64:
-            return pd.Timedelta(value).value
-        return pd.Timestamp(value).value
+            return pd.Timedelta(value).value  # type: ignore[attr-defined]
+        return pd.Timestamp(value).value  # type: ignore[attr-defined]
 
     min_value = MIN_DT_VALUE if min_value is None else _to_unix(min_value)
     max_value = MAX_DT_VALUE if max_value is None else _to_unix(max_value)

--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -265,7 +265,8 @@ def convert_dtypes(df: pd.DataFrame, col_dtypes: Dict[str, Any]):
         return df
 
     for col_name, col_dtype in col_dtypes.items():
-        df[col_name] = convert_dtype(df[col_name], col_dtype)
+        array: pd.Series = df[col_name]  # type: ignore[assignment]
+        df[col_name] = convert_dtype(array, col_dtype)
 
     return df
 

--- a/pandera/typing/formats.py
+++ b/pandera/typing/formats.py
@@ -4,9 +4,10 @@ from enum import Enum
 from typing import Union
 
 try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore[misc]
 
 
 class Formats(Enum):

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -26,10 +26,10 @@ from pandera.engines.pandas_engine import Engine
 from pandera.typing import DataFrame, Index, Series
 
 try:
-    from typing import Literal  # type: ignore
-except ImportError:
-    # Remove this after dropping python 3.6
-    from typing_extensions import Literal  # type: ignore
+    # python 3.8+
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore[misc]
 
 
 def test_check_function_decorators() -> None:

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -835,8 +835,8 @@ def test_check_types() -> None:
     assert isinstance(transform(data), pd.DataFrame)  # type: ignore
 
     for invalid_data in [
-        data.drop("a", axis="columns"),
-        data.drop("b", axis="columns"),
+        data.drop(columns="a"),
+        data.drop(columns="b"),
         data.assign(a=["a", "b", "c"]),
         data.assign(b=["a", "b", "c"]),
         data.reset_index(drop=True),

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -85,7 +85,7 @@ def test_dataframe_schema() -> None:
 
     # error case
     with pytest.raises(errors.SchemaError):
-        schema.validate(df.drop("a", axis=1))
+        schema.validate(df.drop(columns="a"))
 
     with pytest.raises(errors.SchemaError):
         schema.validate(df.assign(a=[-1, -2, -1]))

--- a/tests/mypy/modules/pandas_dataframe.py
+++ b/tests/mypy/modules/pandas_dataframe.py
@@ -71,7 +71,7 @@ def fn_cast_dataframe(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
 @pa.check_types
 def fn_mutate_inplace(df: DataFrame[Schema]) -> DataFrame[SchemaOut]:
     out = df.assign(age=30).pipe(DataFrame[SchemaOut])
-    out.drop(["age"], axis=1, inplace=True)
+    out.drop(columns="age", inplace=True)
     return out  # okay for mypy, pandera raises error
 
 


### PR DESCRIPTION
I was having issues with the local hook for `mypy`.

Specifically, was getting inconsistent results between running `pre-commit run --all-files` versus `pre-commit install` and then `git commit` etc.

I changed this configuration to use https://github.com/pre-commit/mirrors-mypy, and once ensuring compliance across the codebase, I could get consistent results. I'm not sure of the motivation for using a local hook - if we need to stick with it, then I think there might need to be some more configuration to get ensure consistency.

For calls to `pd.DataFrame.drop`, I've preferentially used the `columns` argument since in some cases this was causing mypy issues.

Some formatting changes via black.

I also had some trouble considering how to test mypy compliance against different versions of python without creating separate environments for each version and switching between them. I don't know if you have any advice about this for contributors?