### PR TITLE
Move black config to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,15 +28,14 @@ repos:
         args: ["--line-length=79", "--skip=docs/source/conf.py", "--diff"]
 
   - repo: https://github.com/ikamensh/flynt
-    rev: '0.76'
+    rev: "0.76"
     hooks:
-        - id: flynt
+      - id: flynt
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: ["--line-length=79"]
 
   - repo: https://github.com/pycqa/pylint
     rev: v2.17.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,27 @@
 [tool.pyright]
-include = [ "pandera", "tests" ]
+include = ["pandera", "tests"]
 exclude = [".nox/**", ".nox-*/**"]
 
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = 20
+
+[tool.black]
+line-length = 79
+target-version = [
+  'py37',
+  'py38',
+  'py39',
+  'py310',
+  # 'py311' Disabled until black>=23.7.0
+]
+include = '^(\.py)|(\.pyi)$'
+exclude = '''
+(
+  \.git
+  | \.venv
+  | \.nox
+  | setup.py
+  | asv_bench
+)
+'''


### PR DESCRIPTION
Since black's line length of 79 is configured in pre-commit-config, this is somewhat inconvenient when using black directly from the command line (rather than using pre-commit).

Personally, I use VS Code, and the [`ms-python.black-formatter`](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) extension is not configured to use pre-commit. I like to run the formatter on-save, but at the moment it is assuming the black default line length of 88.

So, I propose moving the configuration into its own dedicated space in pyproject.toml.