### PR TITLE
raise_warning -> new SchemaWarning not UserWarning

### DIFF
--- a/docs/source/checks.rst
+++ b/docs/source/checks.rst
@@ -250,13 +250,13 @@ should return a ``bool``, a ``Series`` of booleans, or a ``DataFrame`` of
 boolean values.
 
 
-Raise UserWarning on Check Failure
-----------------------------------
+Raise Warning Instead of Error on Check Failure
+-----------------------------------------------
 
-In some cases, you might want to raise a ``UserWarning`` and continue execution
+In some cases, you might want to raise a warning and continue execution
 of your program. The ``Check`` and ``Hypothesis`` classes and their built-in
 methods support the keyword argument ``raise_warning``, which is ``False``
-by default. If set to ``True``, the check will raise a ``UserWarning`` instead
+by default. If set to ``True``, the check will warn with a ``SchemaWarning`` instead
 of raising a ``SchemaError`` exception.
 
 .. note::

--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -89,7 +89,7 @@ class Check(BaseCheck):
         :param name: optional name for the check.
         :param error: custom error message if series fails validation
             check.
-        :param raise_warning: if True, raise a UserWarning and do not throw
+        :param raise_warning: if True, raise a SchemaWarning and do not throw
             exception instead of raising a SchemaError for a specific check.
             This option should be used carefully in cases where a failing
             check is informational and shouldn't stop execution of the program.
@@ -408,7 +408,7 @@ class Check(BaseCheck):
 
         :param forbidden_values: The set of values which should not occur. May
             be any iterable.
-        :param raise_warning: if True, check raises UserWarning instead of
+        :param raise_warning: if True, check raises SchemaWarning instead of
             SchemaError on validation.
         """
         try:

--- a/pandera/api/hypotheses.py
+++ b/pandera/api/hypotheses.py
@@ -85,7 +85,7 @@ class Hypothesis(Check):
             threshold in a t-test.
         :param name: optional name of hypothesis test
         :param error: error message to show
-        :param raise_warning: if True, raise a UserWarning and do not throw
+        :param raise_warning: if True, raise a SchemaWarning and do not throw
             exception instead of raising a SchemaError for a specific check.
             This option should be used carefully in cases where a failing
             check is informational and shouldn't stop execution of the program.
@@ -331,7 +331,7 @@ class Hypothesis(Check):
             example, a significance level of 0.01 indicates a 1% risk of
             concluding that a difference exists when there is no actual
             difference.
-        :param raise_warning: if True, check raises UserWarning instead of
+        :param raise_warning: if True, check raises SchemaWarning instead of
             SchemaError on validation.
 
         :example:

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -123,7 +123,19 @@ class PandasSchemaBackend(BaseSchemaBackend):
             # raise a warning without exiting if the check is specified to do so
             # but make sure the check passes
             if check.raise_warning:
-                warnings.warn(message, SchemaWarning)
+                warnings.warn(
+                    message,
+                    SchemaWarning(
+                        schema=schema,
+                        data=check_obj,
+                        message=message,
+                        failure_cases=failure_cases,
+                        check=check,
+                        check_index=check_index,
+                        check_output=check_result.check_output,
+                        reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+                    ),
+                )
                 return CoreCheckResult(
                     passed=True,
                     check=check,

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -23,8 +23,13 @@ from pandera.backends.pandas.error_formatters import (
     scalar_failure_case,
     summarize_failure_cases,
 )
-from pandera.errors import FailureCaseMetadata, SchemaError, SchemaErrorReason
 from pandera.error_handlers import SchemaErrorHandler
+from pandera.errors import (
+    FailureCaseMetadata,
+    SchemaError,
+    SchemaErrorReason,
+    SchemaWarning,
+)
 
 
 class ColumnInfo(NamedTuple):
@@ -118,7 +123,7 @@ class PandasSchemaBackend(BaseSchemaBackend):
             # raise a warning without exiting if the check is specified to do so
             # but make sure the check passes
             if check.raise_warning:
-                warnings.warn(message, UserWarning)
+                warnings.warn(message, SchemaWarning)
                 return CoreCheckResult(
                     passed=True,
                     check=check,

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -125,16 +125,7 @@ class PandasSchemaBackend(BaseSchemaBackend):
             if check.raise_warning:
                 warnings.warn(
                     message,
-                    SchemaWarning(
-                        schema=schema,
-                        data=check_obj,
-                        message=message,
-                        failure_cases=failure_cases,
-                        check=check,
-                        check_index=check_index,
-                        check_output=check_result.check_output,
-                        reason_code=SchemaErrorReason.DATAFRAME_CHECK,
-                    ),
+                    SchemaWarning,
                 )
                 return CoreCheckResult(
                     passed=True,

--- a/pandera/backends/pandas/builtin_checks.py
+++ b/pandera/backends/pandas/builtin_checks.py
@@ -200,7 +200,7 @@ def notin(data: PandasData, forbidden_values: Iterable) -> PandasData:
 
     :param forbidden_values: The set of values which should not occur. May
         be any iterable.
-    :param raise_warning: if True, check raises UserWarning instead of
+    :param raise_warning: if True, check raises SchemaWarning instead of
         SchemaError on validation.
     """
     return ~data.isin(forbidden_values)

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -100,7 +100,19 @@ class PysparkSchemaBackend(BaseSchemaBackend):
 
             # raise a warning without exiting if the check is specified to do so
             if check.raise_warning:  # pragma: no cover
-                warnings.warn(error_msg, SchemaWarning._from_error(error))
+                warnings.warn(
+                    error_msg,
+                    SchemaWarning(
+                        schema=error.schema,
+                        data=error.data,
+                        message=error_msg,
+                        failure_cases=error.failure_cases,
+                        check=error.check,
+                        check_index=error.check_index,
+                        check_output=error.check_output,
+                        reason_code=error.reason_code,
+                    ),
+                )
                 return True
 
             raise error

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -88,7 +88,15 @@ class PysparkSchemaBackend(BaseSchemaBackend):
             failure_cases = scalar_failure_case(check_result.check_passed)
             error_msg = format_generic_error_message(schema, check)
 
-            error = SchemaError(
+            # raise a warning without exiting if the check is specified to do so
+            if check.raise_warning:  # pragma: no cover
+                warnings.warn(
+                    message=error_msg,
+                    category=SchemaWarning,
+                )
+                return True
+
+            raise SchemaError(
                 schema,
                 check_obj,
                 error_msg,
@@ -97,25 +105,6 @@ class PysparkSchemaBackend(BaseSchemaBackend):
                 check_index=check_index,
                 check_output=check_result.check_output,
             )
-
-            # raise a warning without exiting if the check is specified to do so
-            if check.raise_warning:  # pragma: no cover
-                warnings.warn(
-                    error_msg,
-                    SchemaWarning(
-                        schema=error.schema,
-                        data=error.data,
-                        message=error_msg,
-                        failure_cases=error.failure_cases,
-                        check=error.check,
-                        check_index=error.check_index,
-                        check_output=error.check_output,
-                        reason_code=error.reason_code,
-                    ),
-                )
-                return True
-
-            raise error
         return check_result.check_passed
 
     def failure_cases_metadata(

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -21,7 +21,7 @@ from pandera.backends.pyspark.error_formatters import (
     format_generic_error_message,
     scalar_failure_case,
 )
-from pandera.errors import FailureCaseMetadata, SchemaError
+from pandera.errors import FailureCaseMetadata, SchemaError, SchemaWarning
 
 
 class ColumnInfo(NamedTuple):
@@ -90,7 +90,7 @@ class PysparkSchemaBackend(BaseSchemaBackend):
 
             # raise a warning without exiting if the check is specified to do so
             if check.raise_warning:  # pragma: no cover
-                warnings.warn(error_msg, UserWarning)
+                warnings.warn(error_msg, SchemaWarning)
                 return True
 
             raise SchemaError(

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -88,12 +88,7 @@ class PysparkSchemaBackend(BaseSchemaBackend):
             failure_cases = scalar_failure_case(check_result.check_passed)
             error_msg = format_generic_error_message(schema, check)
 
-            # raise a warning without exiting if the check is specified to do so
-            if check.raise_warning:  # pragma: no cover
-                warnings.warn(error_msg, SchemaWarning)
-                return True
-
-            raise SchemaError(
+            error = SchemaError(
                 schema,
                 check_obj,
                 error_msg,
@@ -102,6 +97,13 @@ class PysparkSchemaBackend(BaseSchemaBackend):
                 check_index=check_index,
                 check_output=check_result.check_output,
             )
+
+            # raise a warning without exiting if the check is specified to do so
+            if check.raise_warning:  # pragma: no cover
+                warnings.warn(error_msg, SchemaWarning._from_error(error))
+                return True
+
+            raise error
         return check_result.check_passed
 
     def failure_cases_metadata(

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -111,19 +111,6 @@ _T = TypeVar("_T", bound="SchemaWarning")
 class SchemaWarning(SchemaError, UserWarning):
     """Warning when object does not pass schema validation constraints."""
 
-    @classmethod
-    def _from_error(cls: _T, error: SchemaError) -> _T:
-        return cls(
-            schema=error.schema,
-            data=error.data,
-            message=error.args[0],
-            failure_cases=error.failure_cases,
-            check=error.check,
-            check_index=error.check_index,
-            check_output=error.check_output,
-            reason_code=error.reason_code,
-        )
-
 
 class BaseStrategyOnlyError(Exception):
     """Custom error for reporting strategies that must be base strategies."""

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -108,7 +108,7 @@ class SchemaError(ReducedPickleExceptionBase):
 _T = TypeVar("_T", bound="SchemaWarning")
 
 
-class SchemaWarning(SchemaError, UserWarning):
+class SchemaWarning(UserWarning, SchemaError):
     """Warning when object does not pass schema validation constraints."""
 
 

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -2,7 +2,7 @@
 
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, TypeVar
 
 
 class BackendNotFoundError(Exception):
@@ -105,8 +105,24 @@ class SchemaError(ReducedPickleExceptionBase):
         self.reason_code = reason_code
 
 
+_T = TypeVar("_T", bound="SchemaWarning")
+
+
 class SchemaWarning(SchemaError, UserWarning):
     """Warning when object does not pass schema validation constraints."""
+
+    @classmethod
+    def _from_error(cls: _T, error: SchemaError) -> _T:
+        return cls(
+            schema=error.schema,
+            data=error.data,
+            message=error.args[0],
+            failure_cases=error.failure_cases,
+            check=error.check,
+            check_index=error.check_index,
+            check_output=error.check_output,
+            reason_code=error.reason_code,
+        )
 
 
 class BaseStrategyOnlyError(Exception):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -2,7 +2,7 @@
 
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, TypeVar
+from typing import Any, Dict, List, NamedTuple
 
 
 class BackendNotFoundError(Exception):
@@ -105,10 +105,7 @@ class SchemaError(ReducedPickleExceptionBase):
         self.reason_code = reason_code
 
 
-_T = TypeVar("_T", bound="SchemaWarning")
-
-
-class SchemaWarning(UserWarning, SchemaError):
+class SchemaWarning(UserWarning):
     """Warning when object does not pass schema validation constraints."""
 
 

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -105,6 +105,10 @@ class SchemaError(ReducedPickleExceptionBase):
         self.reason_code = reason_code
 
 
+class SchemaWarning(SchemaError, UserWarning):
+    """Warning when object does not pass schema validation constraints."""
+
+
 class BaseStrategyOnlyError(Exception):
     """Custom error for reporting strategies that must be base strategies."""
 

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -388,6 +388,10 @@ def test_raise_warning_series() -> None:
     with pytest.warns(errors.SchemaWarning):
         warning_schema(data)
 
+    # For compatibility with old behaviour of raise_warning to give UserWarning
+    with pytest.warns(UserWarning):
+        warning_schema(data)
+
 
 def test_raise_warning_dataframe() -> None:
     """Test that checks with raise_warning=True raise a warning."""

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -385,7 +385,7 @@ def test_raise_warning_series() -> None:
     with pytest.raises(errors.SchemaError):
         error_schema(data)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(errors.SchemaWarning):
         warning_schema(data)
 
 
@@ -408,7 +408,7 @@ def test_raise_warning_dataframe() -> None:
     with pytest.raises(errors.SchemaError):
         error_schema(data)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(errors.SchemaWarning):
         warning_schema(data)
 
 

--- a/tests/core/test_checks_builtin.py
+++ b/tests/core/test_checks_builtin.py
@@ -11,7 +11,7 @@ from pandera.api.checks import Check
 from pandera.api.pandas.array import SeriesSchema
 from pandera.api.pandas.components import Column
 from pandera.api.pandas.container import DataFrameSchema
-from pandera.errors import SchemaError
+from pandera.errors import SchemaError, SchemaWarning
 
 
 def check_values(
@@ -69,7 +69,7 @@ def check_raise_error_or_warning(failure_values, check) -> None:
     """
     Check that Series and DataFrameSchemas raise warnings instead of exceptions
 
-    NOTE: it's not ideal that we have to import schema and schemaa_components
+    NOTE: it's not ideal that we have to import schema and schema_components
     modules into this test module to test this functionality, this doesn't
     separate the units under test very well.
     """
@@ -82,7 +82,7 @@ def check_raise_error_or_warning(failure_values, check) -> None:
         DataFrameSchema({"failure_column": Column(checks=check)})(failure_df)
 
     check.raise_warning = True
-    with pytest.warns(UserWarning):
+    with pytest.warns(SchemaWarning):
         SeriesSchema(checks=check)(failure_series)
         DataFrameSchema({"failure_column": Column(checks=check)})(failure_df)
 

--- a/tests/core/test_checks_builtin.py
+++ b/tests/core/test_checks_builtin.py
@@ -86,6 +86,11 @@ def check_raise_error_or_warning(failure_values, check) -> None:
         SeriesSchema(checks=check)(failure_series)
         DataFrameSchema({"failure_column": Column(checks=check)})(failure_df)
 
+    # For compatibility with old behaviour of raise_warning to give UserWarning
+    with pytest.warns(UserWarning):
+        SeriesSchema(checks=check)(failure_series)
+        DataFrameSchema({"failure_column": Column(checks=check)})(failure_df)
+
 
 class TestGreaterThan:
     """Tests for Check.greater_than"""


### PR DESCRIPTION
#1297 

The new `SchemaWarning` is a subclass of `UserWarning`, so I think this means it shouldn't cause too many backward compatibility issues. I have added some tests that check the old behaviour still works.