### PR TITLE
Fix typo in docs

### DIFF
--- a/pandera/backends/pandas/builtin_checks.py
+++ b/pandera/backends/pandas/builtin_checks.py
@@ -297,7 +297,7 @@ def unique_values_eq(data: PandasData, values: Iterable):
     """Ensure that unique values in the data object contain all values.
 
     .. note::
-        In constrast with :func:`isin`, this check makes sure that all the items
+        In contrast with :func:`isin`, this check makes sure that all the items
         in the ``values`` iterable are contained within the series.
 
     :param values: The set of values that must be present. Maybe any iterable.


### PR DESCRIPTION
At the moment, I suspect the CI isn't passing, since even changes which are purely cosmetic are failing on the ray modin tests.

This is a single character typo fix in source code which should hopefully trigger the CI and prove it is failing, so that it can be fixed.