### PR TITLE
Use generic types for config objects.

### DIFF
--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -6,7 +6,7 @@ import copy
 import os
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast, overload
+from typing import Any, Dict, List, Optional, Sequence, Union, cast, overload
 
 import pandas as pd
 
@@ -47,7 +47,7 @@ class DataFrameSchema(
         strict: StrictType = False,
         name: Optional[str] = None,
         ordered: bool = False,
-        unique: Optional[Union[str, List[str]]] = None,
+        unique: Optional[Union[str, Sequence[str]]] = None,
         report_duplicates: UniqueSettings = "all",
         unique_column_names: bool = False,
         add_missing_columns: bool = False,
@@ -188,12 +188,12 @@ class DataFrameSchema(
         self._coerce = value
 
     @property
-    def unique(self):
+    def unique(self) -> Optional[Sequence[str]]:
         """List of columns that should be jointly unique."""
         return self._unique
 
     @unique.setter
-    def unique(self, value: Optional[Union[str, List[str]]]) -> None:
+    def unique(self, value: Optional[Union[str, Sequence[str]]]) -> None:
         """Set unique attribute."""
         self._unique = [value] if isinstance(value, str) else value
 

--- a/pandera/api/pandas/model_config.py
+++ b/pandera/api/pandas/model_config.py
@@ -1,6 +1,6 @@
 """Class-based dataframe model API configuration for pandas."""
 
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 from pandera.api.base.model_config import BaseModelConfig
 from pandera.api.pandas.types import PandasDtypeInputTypes, StrictType
@@ -24,7 +24,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     drop_invalid_rows: bool = False  #: drop invalid rows on validation
 
     #: make sure certain column combinations are unique
-    unique: Optional[Union[str, List[str]]] = None
+    unique: Optional[Union[str, Sequence[str]]] = None
 
     #: make sure all specified columns are in the validated dataframe -
     #: if ``"filter"``, removes columns not specified in the schema
@@ -61,7 +61,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: converts the object of type ``from_format`` to a pandera-validate-able
     #: data structure. The reader function is implemented in the pandera.typing
     #: generic types via the ``from_format`` and ``to_format`` methods.
-    from_format_kwargs: Optional[Dict[str, Any]] = None
+    from_format_kwargs: Optional[Mapping[str, Any]] = None
 
     #: data format to serialize into after validation. This option only applies
     #: to  schemas used in the context of the pandera type constructor
@@ -76,7 +76,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: converts the pandera-validate-able object to type ``to_format``.
     #: The writer function is implemented in the pandera.typing
     #: generic types via the ``from_format`` and ``to_format`` methods.
-    to_format_kwargs: Optional[Dict[str, Any]] = None
+    to_format_kwargs: Optional[Mapping[str, Any]] = None
 
     #: a dictionary object to store key-value data at schema level
     metadata: Optional[dict] = None

--- a/pandera/api/pyspark/container.py
+++ b/pandera/api/pyspark/container.py
@@ -6,7 +6,7 @@ import copy
 import os
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast, overload
+from typing import Any, Dict, List, Optional, Sequence, Union, cast, overload
 
 from pyspark.sql import DataFrame
 
@@ -40,7 +40,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         strict: StrictType = False,
         name: Optional[str] = None,
         ordered: bool = False,
-        unique: Optional[Union[str, List[str]]] = None,
+        unique: Optional[Union[str, Sequence[str]]] = None,
         report_duplicates: UniqueSettings = "all",
         unique_column_names: bool = False,
         title: Optional[str] = None,
@@ -169,12 +169,12 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         self._coerce = value
 
     @property
-    def unique(self):
+    def unique(self) -> Optional[Sequence[str]]:
         """List of columns that should be jointly unique."""
         return self._unique
 
     @unique.setter
-    def unique(self, value: Optional[Union[str, List[str]]]) -> None:
+    def unique(self, value: Optional[Union[str, Sequence[str]]]) -> None:
         """Set unique attribute."""
         self._unique = [value] if isinstance(value, str) else value
 

--- a/pandera/api/pyspark/model_config.py
+++ b/pandera/api/pyspark/model_config.py
@@ -1,6 +1,6 @@
 """Class-based dataframe model API configuration for pyspark."""
 
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 from pandera.api.base.model_config import BaseModelConfig
 from pandera.api.pyspark.types import PySparkDtypeInputTypes, StrictType
@@ -23,7 +23,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     coerce: bool = False  #: coerce types of all schema components
 
     #: make sure certain column combinations are unique
-    unique: Optional[Union[str, List[str]]] = None
+    unique: Optional[Union[str, Sequence[str]]] = None
 
     #: make sure all specified columns are in the validated dataframe -
     #: if ``"filter"``, removes columns not specified in the schema
@@ -44,7 +44,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: converts the object of type ``from_format`` to a pandera-validate-able
     #: data structure. The reader function is implemented in the pandera.typing
     #: generic types via the ``from_format`` and ``to_format`` methods.
-    from_format_kwargs: Optional[Dict[str, Any]] = None
+    from_format_kwargs: Optional[Mapping[str, Any]] = None
 
     #: data format to serialize into after validation. This option only applies
     #: to  schemas used in the context of the pandera type constructor
@@ -59,7 +59,7 @@ class BaseConfig(BaseModelConfig):  # pylint:disable=R0903
     #: converts the pandera-validate-able object to type ``to_format``.
     #: The writer function is implemented in the pandera.typing
     #: generic types via the ``from_format`` and ``to_format`` methods.
-    to_format_kwargs: Optional[Dict[str, Any]] = None
+    to_format_kwargs: Optional[Mapping[str, Any]] = None
 
     #: a dictionary object to store key-value data at schema level
     metadata: Optional[dict] = None


### PR DESCRIPTION
This is made to be consistent with typeshed best practices:

> avoid invariant collection types (list, dict) in argument positions, in favor of covariant types like Mapping or Sequence

Specifically, we have a linter in house that complains about mutable defaults on class members:

```py
class MySchema(pandera.SchemaModel):
    a: ...
    b: ...

    class Config:
        unique: List[str] = ["a", "b"]  # <- violation
```

I can't see any reason that `unique` _must_ be a `list` rather than a `tuple` (why would we ever need to mutate this object?).  I haven't looked hard enough to determine if I think that there is a "danger" if someone goes and `MySchema.Config.unique.append("c")` or accidentally mutates this via some oddball path of references at some other place in the code.