### PR TITLE
improve pydantic model efficiency

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -476,9 +476,9 @@ def _check_decimal(
     decimals = pandas_obj[is_decimal]
     # fix for modin unamed series raises KeyError
     # https://github.com/modin-project/modin/issues/4317
-    decimals.name = "decimals"
+    decimals.name = "decimals"  # type: ignore
 
-    splitted = decimals.astype("string").str.split(".", n=1, expand=True)
+    splitted = decimals.astype("string").str.split(".", n=1, expand=True)  # type: ignore
     if splitted.shape[1] < 2:
         splitted[1] = ""
     len_left = splitted[0].str.len().fillna(0)
@@ -486,7 +486,7 @@ def _check_decimal(
     precisions = len_left + len_right
 
     scales = series_cls(
-        np.full_like(decimals, np.nan), dtype=np.object_, index=decimals.index
+        np.full_like(decimals, np.nan), dtype=np.object_, index=decimals.index  # type: ignore
     )
     pos_left = len_left > 0
     scales[pos_left] = len_right[pos_left]


### PR DESCRIPTION
This PR makes `PydanticModel` more efficient by first converting the dataframe to a list of records before coercing them all using the Model class.