### PR TITLE
Avoid throwing exception for Union type

### DIFF
--- a/pandera/mypy.py
+++ b/pandera/mypy.py
@@ -136,7 +136,7 @@ class DataFrameModelTransformer:
             if not hasattr(def_, "type") or def_.type is None:
                 continue
             type_ = def_.type
-            if get_typename(def_.type) in FIELD_GENERICS_FULLNAMES:
+            if str(def_.type) in FIELD_GENERICS_FULLNAMES:
                 type_.args = ()  # erase generic type arg
 
 
@@ -154,7 +154,3 @@ def get_fullname(x: Union[FuncBase, SymbolNode]) -> str:
     if callable(fn):  # pragma: no cover
         return fn()
     return fn
-
-
-def get_typename(x) -> str:
-    return f"{x.type.module_name}.{x.type.name}"


### PR DESCRIPTION
The current implementation does not work for Union types, as they have no `type` attribute.

Also, the implementation can be simplified by simply stringifying the type rather than having a custom implementation.