### PR TITLE
Fix lack of support for new TimestampNTZType in Spark 3.4 datatypes

### DIFF
--- a/pandera/engines/pyspark_engine.py
+++ b/pandera/engines/pyspark_engine.py
@@ -13,6 +13,7 @@ import re
 import warnings
 from typing import Any, Iterable, Union, Optional
 import sys
+from packaging import version
 
 import pyspark
 import pyspark.sql.types as pst
@@ -32,6 +33,8 @@ except ImportError:  # pragma: no cover
 
 DEFAULT_PYSPARK_PREC = pst.DecimalType().precision
 DEFAULT_PYSPARK_SCALE = pst.DecimalType().scale
+
+CURRENT_PYSPARK_VERSION = version.parse(pyspark.__version__)
 
 
 @immutable(init=True)
@@ -346,7 +349,7 @@ class Date(DataType, dtypes.Date):  # type: ignore
 equivalents = ["datetime", "timestamp", "TimestampType", "TimestampType()", pst.TimestampType(), pst.TimestampType]  # type: ignore
 
 # Include new Spark 3.4 TimestampNTZType as equivalents
-if pyspark.__version__ >= "3.4":
+if CURRENT_PYSPARK_VERSION >= version.parse("3.4"):
     equivalents += ["TimestampNTZType", "TimestampNTZType()", pst.TimestampNTZType, pst.TimestampNTZType()]  # type: ignore
 
 

--- a/pandera/engines/pyspark_engine.py
+++ b/pandera/engines/pyspark_engine.py
@@ -14,6 +14,7 @@ import warnings
 from typing import Any, Iterable, Union, Optional
 import sys
 
+import pyspark
 import pyspark.sql.types as pst
 
 from pandera import dtypes, errors
@@ -341,10 +342,15 @@ class Date(DataType, dtypes.Date):  # type: ignore
 # timestamp
 ###############################################################################
 
+# Default timestamp equivalents
+equivalents = ["datetime", "timestamp", "TimestampType", "TimestampType()", pst.TimestampType(), pst.TimestampType]  # type: ignore
 
-@Engine.register_dtype(
-    equivalents=["datetime", "timestamp", "TimestampType", "TimestampType()", pst.TimestampType(), pst.TimestampType],  # type: ignore
-)
+# Include new Spark 3.4 TimestampNTZType as equivalents
+if pyspark.__version__ >= "3.4":
+    equivalents += ["TimestampNTZType", "TimestampNTZType()", pst.TimestampNTZType, pst.TimestampNTZType()]  # type: ignore
+
+
+@Engine.register_dtype(equivalents=equivalents)  # type: ignore
 @immutable
 class Timestamp(DataType, dtypes.Timestamp):  # type: ignore
     """Semantic representation of a :class:`pyspark.sql.types.TimestampType`."""

--- a/tests/pyspark/test_pyspark_dtypes.py
+++ b/tests/pyspark/test_pyspark_dtypes.py
@@ -1,6 +1,7 @@
 """Unit tests for pyspark container."""
 
 from typing import Any
+import pyspark
 import pyspark.sql.types as T
 from pyspark.sql import DataFrame
 
@@ -239,6 +240,18 @@ class TestAllNumericTypes(BaseClass):
 class TestAllDatetimeTestClass(BaseClass):
     """This class is to test all the datetime types"""
 
+    # Include new Spark 3.4 TimestampNTZType as equivalents
+    ntz_equivalents = (
+        [
+            {"pandera_equivalent": "TimestampNTZType"},
+            {"pandera_equivalent": "TimestampNTZType()"},
+            {"pandera_equivalent": T.TimestampNTZType},
+            {"pandera_equivalent": T.TimestampNTZType()},
+        ]
+        if pyspark.__version__ >= "3.4"
+        else []
+    )
+
     # a map specifying multiple argument sets for a test method
     params = {
         "test_pyspark_all_date_types": [
@@ -253,7 +266,8 @@ class TestAllDatetimeTestClass(BaseClass):
             {"pandera_equivalent": T.TimestampType()},
             {"pandera_equivalent": "datetime"},
             {"pandera_equivalent": "timestamp"},
-        ],
+        ]
+        + ntz_equivalents,
     }
 
     def test_pyspark_all_date_types(


### PR DESCRIPTION
When loading a parquet file with timestamp fields into a dataframe using Spark 3.4, pyspark can make use of the new `pyspark.sql.types.TimestampNTZType()` but these news fields were not declared as equivalent to Pandera's Timestamp.

<details>
  <summary>Stack Trace</summary>

```txt
Data type '<class 'pyspark.sql.types.TimestampNTZType'>' not understood by Engine.

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮

...

│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/model.py:289 in validate     │
│                                                                                                  │
│   286 │   │   """%(validate_doc)s"""                                                             │
│   287 │   │   return cast(                                                                       │
│   288 │   │   │   DataFrameBase[TDataFrameModel],                                                │
│ ❱ 289 │   │   │   cls.to_schema().validate(                                                      │
│   290 │   │   │   │   check_obj, head, tail, sample, random_state, lazy, inplace                 │
│   291 │   │   │   ),                                                                             │
│   292 │   │   )                                                                                  │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/model.py:242 in to_schema    │
│                                                                                                  │
│   239 │   │   )                                                                                  │
│   240 │   │   cls.__root_checks__ = df_custom_checks + df_registered_checks                      │
│   241 │   │                                                                                      │
│ ❱ 242 │   │   columns = cls._build_columns_index(cls.__fields__, cls.__checks__)                 │
│   243 │   │                                                                                      │
│   244 │   │   kwargs = {}                                                                        │
│   245 │   │   if cls.__config__ is not None:                                                     │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/model.py:330 in              │
│ _build_columns_index                                                                             │
│                                                                                                  │
│   327 │   │   │   │   │   │   f"'check_name' is not supported for {field_name}."                 │
│   328 │   │   │   │   │   )                                                                      │
│   329 │   │   │   │                                                                              │
│ ❱ 330 │   │   │   │   columns[field_name] = col_constructor(  # type: ignore                     │
│   331 │   │   │   │   │   dtype,                                                                 │
│   332 │   │   │   │   │   required=not annotation.optional,                                      │
│   333 │   │   │   │   │   checks=field_checks,                                                   │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/model_components.py:61 in    │
│ to_column                                                                                        │
│                                                                                                  │
│    58 │   │   name: str = None,                                                                  │
│    59 │   ) -> Column:                                                                           │
│    60 │   │   """Create a schema_components.Column from a field."""                              │
│ ❱  61 │   │   return self._to_schema_component(                                                  │
│    62 │   │   │   dtype,                                                                         │
│    63 │   │   │   Column,                                                                        │
│    64 │   │   │   nullable=self.nullable,                                                        │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/model_components.py:51 in    │
│ _to_schema_component                                                                             │
│                                                                                                  │
│    48 │   │   if self.dtype_kwargs:                                                              │
│    49 │   │   │   dtype = dtype(**self.dtype_kwargs)  # type: ignore                             │
│    50 │   │   checks = self.checks + to_checklist(checks)                                        │
│ ❱  51 │   │   return component(dtype, checks=checks, **kwargs)  # type: ignore                   │
│    52 │                                                                                          │
│    53 │   def to_column(                                                                         │
│    54 │   │   self,                                                                              │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/components.py:70 in __init__ │
│                                                                                                  │
│    67 │   │                                                                                      │
│    68 │   │   See :ref:`here<column>` for more usage details.                                    │
│    69 │   │   """                                                                                │
│ ❱  70 │   │   super().__init__(                                                                  │
│    71 │   │   │   dtype=dtype,                                                                   │
│    72 │   │   │   checks=checks,                                                                 │
│    73 │   │   │   nullable=nullable,                                                             │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/column_schema.py:52 in       │
│ __init__                                                                                         │
│                                                                                                  │
│    49 │   │   :type nullable: bool                                                               │
│    50 │   │   """                                                                                │
│    51 │   │                                                                                      │
│ ❱  52 │   │   super().__init__(                                                                  │
│    53 │   │   │   dtype=dtype,                                                                   │
│    54 │   │   │   checks=checks,                                                                 │
│    55 │   │   │   coerce=coerce,                                                                 │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/base/schema.py:39 in __init__        │
│                                                                                                  │
│    36 │   │   drop_invalid_rows=False,                                                           │
│    37 │   ):                                                                                     │
│    38 │   │   """Abstract base schema initializer."""                                            │
│ ❱  39 │   │   self.dtype = dtype                                                                 │
│    40 │   │   self.checks = checks                                                               │
│    41 │   │   self.coerce = coerce                                                               │
│    42 │   │   self.name = name                                                                   │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/api/pyspark/column_schema.py:81 in dtype │
│                                                                                                  │
│    78 │   def dtype(self, value: Optional[PySparkDtypeInputTypes]) -> None:                      │
│    79 │   │   """Set the pyspark dtype"""                                                        │
│    80 │   │   self._dtype = (                                                                    │
│ ❱  81 │   │   │   pyspark_engine.Engine.dtype(value) if value else None                          │
│    82 │   │   )  # pylint:disable=no-value-for-parameter                                         │
│    83 │                                                                                          │
│    84 │   def validate(                                                                          │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/engines/pyspark_engine.py:125 in dtype   │
│                                                                                                  │
│   122 │   │   │   │   subst = ""                                                                 │
│   123 │   │   │   │   # You can manually specify the number of replacements by changing the 4t   │
│   124 │   │   │   │   data_type = re.sub(regex, subst, data_type, 0, re.MULTILINE)               │
│ ❱ 125 │   │   │   return engine.Engine.dtype(cls, data_type)                                     │
│   126 │   │   except TypeError:  # pylint:disable=try-except-raise # pragma: no cover            │
│   127 │   │   │   raise                                                                          │
│   128                                                                                            │
│                                                                                                  │
│ /Users/fo2/c1s/worktree/pyspark_optional_fields/pandera/engines/engine.py:271 in dtype           │
│                                                                                                  │
│   268 │   │   try:                                                                               │
│   269 │   │   │   return registry.dispatch(data_type)                                            │
│   270 │   │   except (KeyError, ValueError):                                                     │
│ ❱ 271 │   │   │   raise TypeError(                                                               │
│   272 │   │   │   │   f"Data type '{data_type}' not understood by {cls.__name__}."               │
│   273 │   │   │   ) from None                                                                    │
│   274                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: Data type '<class 'pyspark.sql.types.TimestampNTZType'>' not understood by Engine.
```

</details>

#### Issue
The `pyspark_engine.py` module was not prepared to process `pyspark.sql.types.TimestampNTZType()` as a Timestamp.

#### Proposed solution
As this type is exclusive to Spark 3.4 and newer versions, an IF condition was needed to ensure that it's added only when pyspark >= 3.4 is being used, both in the main code as in tests:

Behavior when using PySpark 3.3, with common types only:
![image](https://github.com/unionai-oss/pandera/assets/110418479/02987e46-9f6b-47fc-a284-e1e176c06cde)

Behavior when using PySpark 3.4, with the new type:
![image](https://github.com/unionai-oss/pandera/assets/110418479/911ef583-6e42-4710-b8b1-6f115218a063)

#### Additional details
Version in use: 0.17.2
OS: MacOS 13.6 (M1)