### PR TITLE
Fix optional fields in PySpark SQL

### DIFF
--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -283,7 +283,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
         schema_components = []
         for col_name, column in schema.columns.items():
             if (
-                column.required or col_name in check_obj
+                column.required or col_name in check_obj.columns
             ) and col_name not in column_info.lazy_exclude_column_names:
                 column = copy.deepcopy(column)
                 if schema.dtype is not None:

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -300,18 +300,56 @@ def test_docstring_substitution() -> None:
     )
 
 
-def test_optional_column() -> None:
-    """Test that optional columns are not required."""
+# Define a fixture for the Schema
+@pytest.fixture(scope="module", name="test_schema_optional_columns")
+def test_schema():
+    """Fixture containing DataFrameModel with optional columns."""
 
-    class Schema(DataFrameModel):  # pylint:disable=missing-class-docstring
+    class Schema(pa.DataFrameModel):
+        """Simple DataFrameModel containing optional columns."""
+
         a: Optional[str]
         b: Optional[str] = pa.Field(eq="b")
         c: Optional[str]  # test pandera.typing alias
 
-    schema = Schema.to_schema()
-    assert not schema.columns["a"].required
-    assert not schema.columns["b"].required
-    assert not schema.columns["c"].required
+    return Schema
+
+
+def test_optional_column(test_schema_optional_columns) -> None:
+    """Test that optional columns are not required."""
+
+    schema = test_schema_optional_columns.to_schema()
+    assert not schema.columns[
+        "a"
+    ].required, "Optional column 'a' shouldn't be required"
+    assert not schema.columns[
+        "b"
+    ].required, "Optional column 'b' shouldn't be required"
+    assert not schema.columns[
+        "c"
+    ].required, "Optional column 'c' shouldn't be required"
+
+
+def test_validation_succeeds_with_missing_optional_column(
+    spark, test_schema_optional_columns
+) -> None:
+    """Test that validation succeeds even when an optional column is missing."""
+
+    data = [("5", "b"), ("15", "b")]
+    spark_schema = T.StructType(
+        [
+            T.StructField("a", T.StringType(), False),
+            T.StructField("b", T.StringType(), False),
+            # 'c' column is missing, but it's optional
+        ],
+    )
+    df = spark_df(spark, data, spark_schema)
+    df_out = test_schema_optional_columns.validate(check_obj=df)
+
+    # `df_out.pandera.errors` should be empty if validation is successful.
+    assert (
+        df_out.pandera.errors == {}
+    ), "No error should be raised in case of a missing optional column."
 
 
 def test_invalid_field() -> None:


### PR DESCRIPTION
When using `Optional` fields under Pyspark integration, Pandera raises a ValueError exception:
`ValueError: Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.`


<details>
  <summary>Test code</summary>

```py
import pyspark.sql.types as T
import json
from typing import Optional
from decimal import Decimal
from pyspark.sql import SparkSession
import pandera.pyspark as pa
from pandera.pyspark import DataFrameModel

spark = SparkSession.builder.getOrCreate()

class PanderaDataModelIn(DataFrameModel):
    id: T.IntegerType = pa.Field(gt=10)
    unrequired_field: Optional[T.StringType] = pa.Field()

data = [
    (15, ),
    (16, ),
    (17, ),
]
spark_schema = T.StructType([
    T.StructField("id", T.IntegerType(), False),
],)
df = spark.createDataFrame(data, spark_schema)
df.show()

df_out = PanderaDataModelIn.validate(check_obj=df)

print(json.dumps(dict(df_out.pandera.errors), indent=4))
```
</details>

<details>
  <summary>Output</summary>

```txt
+---+
| id|
+---+
| 15|
| 16|
| 17|
+---+
```

</details>

<details>
  <summary>Stack Trace</summary>

```txt
{
	"name": "ValueError",
	"message": "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.",
	"stack": "---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)

File ~/c1s/pandera/pandera/api/pyspark/model.py:289, in DataFrameModel.validate(cls, check_obj, head, tail, sample, random_state, lazy, inplace)
    274 @classmethod
    275 @docstring_substitution(validate_doc=DataFrameSchema.validate.__doc__)
    276 def validate(
   (...)
    284     inplace: bool = False,
    285 ) -> Optional[DataFrameBase[TDataFrameModel]]:
    286     \"\"\"%(validate_doc)s\"\"\"
    287     return cast(
    288         DataFrameBase[TDataFrameModel],
--> 289         cls.to_schema().validate(
    290             check_obj, head, tail, sample, random_state, lazy, inplace
    291         ),
    292     )

File ~/c1s/pandera/pandera/api/pyspark/container.py:331, in DataFrameSchema.validate(self, check_obj, head, tail, sample, random_state, lazy, inplace)
    328     return
    329 error_handler = ErrorHandler(lazy)
--> 331 return self._validate(
    332     check_obj=check_obj,
    333     head=head,
    334     tail=tail,
    335     sample=sample,
    336     random_state=random_state,
    337     lazy=lazy,
    338     inplace=inplace,
    339     error_handler=error_handler,
    340 )

File ~/c1s/pandera/pandera/api/pyspark/container.py:362, in DataFrameSchema._validate(self, check_obj, head, tail, sample, random_state, lazy, inplace, error_handler)
    353 if self._is_inferred:
    354     warnings.warn(
    355         f\"This {type(self)} is an inferred schema that hasn't been \"
    356         \"modified. It's recommended that you refine the schema \"
   (...)
    359         UserWarning,
    360     )
--> 362 return self.get_backend(check_obj).validate(
    363     check_obj=check_obj,
    364     schema=self,
    365     head=head,
    366     tail=tail,
    367     sample=sample,
    368     random_state=random_state,
    369     lazy=lazy,
    370     inplace=inplace,
    371     error_handler=error_handler,
    372 )

File ~/c1s/pandera/pandera/backends/pyspark/container.py:124, in DataFrameSchemaBackend.validate(self, check_obj, schema, head, tail, sample, random_state, lazy, inplace, error_handler)
    119 check_obj = self._column_checks(
    120     check_obj, schema, column_info, error_handler
    121 )
    123 # collect schema components and prepare check object to be validated
--> 124 schema_components = self.collect_schema_components(
    125     check_obj, schema, column_info
    126 )
    127 check_obj_subsample = self.subsample(
    128     check_obj, sample=sample, random_state=random_state
    129 )
    130 try:

File ~/c1s/pandera/pandera/backends/pyspark/container.py:286, in DataFrameSchemaBackend.collect_schema_components(self, check_obj, schema, column_info)
    283 schema_components = []
    284 for col_name, column in schema.columns.items():
    285     if (
--> 286         column.required or col_name in check_obj
    287     ) and col_name not in column_info.lazy_exclude_column_names:
    288         column = copy.deepcopy(column)
    289         if schema.dtype is not None:
    290             # override column dtype with dataframe dtype

File ~/miniconda3/envs/pandera_dev_1/lib/python3.9/site-packages/pyspark/sql/column.py:1369, in Column.__nonzero__(self)
   1368 def __nonzero__(self) -> None:
-> 1369     raise ValueError(
   1370         \"Cannot convert column into bool: please use '&' for 'and', '|' for 'or', \"
   1371         \"'~' for 'not' when building DataFrame boolean expressions.\"
   1372     )

ValueError: Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions."
}
```

Debugging info:
<img width="1511" alt="image" src="https://github.com/unionai-oss/pandera/assets/110418479/f7465ad5-49ee-41bd-96ae-da93ac02deb0">

</details>

#### Issue
In `container.py`, `schema.columns.items()` gives a `dict_items(str, Schema Column)` and checking the key of this dict directly against a DataFrame (`check_obj`) results in such exception.

#### Proposed solution
Test the string key against the DataFrame columns (`check_obj.columns`) instead.
Additional tests were added to the `tests/pyspark/test_pyspark_model.py`'s `test_optional_column()` unit test case, to ensure that this optionality works well.

#### Additional details
Version in use: 0.17.2
OS: MacOS 13.6 (M1)

PS: I tried to run `make nox-conda` locally but I got some issues, like this one:
<img width="1504" alt="image" src="https://github.com/unionai-oss/pandera/assets/110418479/bfa1ab59-1c23-4a2c-a4f5-25c646e6d195">

PS²: This PR had it's content moved from #1376. Trying to sign off old commits to make DCO pass became unmanageable and it was easier to start from scrach.