### PR TITLE
Add support for `unique` validation in PySpark

### DIFF
--- a/docs/source/pyspark_sql.rst
+++ b/docs/source/pyspark_sql.rst
@@ -343,3 +343,16 @@ We also provided a helper function to extract metadata from a schema as follows:
 .. note::
 
     This feature is available for ``pyspark.sql`` and ``pandas`` both.
+
+Unique support
+--------------
+
+*new in 0.17.3*
+
+.. warning::
+
+    The `unique` support in PySpark to define which columns must be tested for
+    unique values may cause a performance hit during validation, given it's distributed
+    nature.
+
+    Use with caution.

--- a/docs/source/pyspark_sql.rst
+++ b/docs/source/pyspark_sql.rst
@@ -344,15 +344,15 @@ We also provided a helper function to extract metadata from a schema as follows:
 
     This feature is available for ``pyspark.sql`` and ``pandas`` both.
 
-Unique support
---------------
+`unique` support
+----------------
 
 *new in 0.17.3*
 
 .. warning::
 
-    The `unique` support in PySpark to define which columns must be tested for
-    unique values may cause a performance hit during validation, given it's distributed
+    The `unique` support for PySpark-based validations to define which columns must be
+    tested for unique values may incur in a performance hit, given Spark's distributed
     nature.
 
     Use with caution.

--- a/pandera/api/pyspark/error_handler.py
+++ b/pandera/api/pyspark/error_handler.py
@@ -14,7 +14,6 @@ class ErrorCategory(Enum):
     DATA = "data-failures"
     SCHEMA = "schema-failures"
     DTYPE_COERCION = "dtype-coercion-failures"
-    UNIQUENESS = "uniqueness-failures"
 
 
 class ErrorHandler:

--- a/pandera/api/pyspark/error_handler.py
+++ b/pandera/api/pyspark/error_handler.py
@@ -14,6 +14,7 @@ class ErrorCategory(Enum):
     DATA = "data-failures"
     SCHEMA = "schema-failures"
     DTYPE_COERCION = "dtype-coercion-failures"
+    UNIQUENESS = "uniqueness-failures"
 
 
 class ErrorHandler:

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -532,10 +532,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
         :param schema: schema object.
         :returns: dataframe checked.
         """
-        # Use unique definition of columns as first option
-        # unique_columns = [col.unique for col in schema.columns.values()]
-
-        # Overwrite it, if schemas's Config class has a unique declaration
+        # Determine unique columns based on schema's config
         unique_columns = (
             [schema.unique]
             if isinstance(schema.unique, str)

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -91,16 +91,9 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
         """Run the checks related to data validation and uniqueness."""
 
         # uniqueness of values
-        try:
-            check_obj = self.unique(
-                check_obj, schema=schema, error_handler=error_handler
-            )
-        except SchemaError as exc:
-            error_handler.collect_error(
-                type=ErrorCategory.DATA,
-                reason_code=exc.reason_code,
-                schema_error=exc,
-            )
+        check_obj = self.unique(
+            check_obj, schema=schema, error_handler=error_handler
+        )
 
         return check_obj
 

--- a/pandera/backends/pyspark/decorators.py
+++ b/pandera/backends/pyspark/decorators.py
@@ -88,10 +88,6 @@ def validate_scope(scope: ValidationScope):
                 Returns:
                     The DataFrame object.
                 """
-                if kwargs:
-                    for value in kwargs.values():
-                        if isinstance(value, pyspark.sql.DataFrame):
-                            return value
                 if args:
                     for value in args:
                         if isinstance(value, pyspark.sql.DataFrame):
@@ -109,7 +105,7 @@ def validate_scope(scope: ValidationScope):
                         stacklevel=2,
                     )
                     # If the function was skip, return the `check_obj` value anyway,
-                    # if it's present as a kwarg or an arg
+                    # given that some return value is expected
                     return _get_check_obj()
 
             elif scope == ValidationScope.DATA:
@@ -124,7 +120,7 @@ def validate_scope(scope: ValidationScope):
                         stacklevel=2,
                     )
                     # If the function was skip, return the `check_obj` value anyway,
-                    # if it's present as a kwarg or an arg
+                    # given that some return value is expected
                     return _get_check_obj()
 
         return wrapper

--- a/tests/pyspark/test_pyspark_config.py
+++ b/tests/pyspark/test_pyspark_config.py
@@ -53,7 +53,7 @@ class TestPanderaConfig:
         CONFIG.validation_enabled = True
         CONFIG.validation_depth = ValidationDepth.SCHEMA_ONLY
 
-        pandra_schema = DataFrameSchema(
+        pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
                 "price_val": Column(T.IntegerType()),
@@ -67,7 +67,7 @@ class TestPanderaConfig:
         assert CONFIG.dict() == expected
 
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
-        output_dataframeschema_df = pandra_schema.validate(input_df)
+        output_dataframeschema_df = pandera_schema.validate(input_df)
         expected_dataframeschema = {
             "SCHEMA": {
                 "COLUMN_NOT_IN_DATAFRAME": [

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -1,6 +1,7 @@
 """Unit tests for DataFrameModel module."""
 # pylint:disable=abstract-method
 
+from contextlib import nullcontext as does_not_raise
 from typing import Optional
 from pyspark.sql import DataFrame
 import pyspark.sql.types as T
@@ -221,6 +222,84 @@ def test_pyspark_fields_metadata():
         }
     }
     assert PanderaSchema.get_metadata() == expected
+
+
+@pytest.fixture
+def datamodel_unique_single_column() -> pa.DataFrameModel:
+    """Fixture containing DataFrameModel with optional columns."""
+
+    class MyDataModel(pa.DataFrameModel):
+        """Simple DataFrameModel containing a column."""
+
+        a: T.LongType = pa.Field()
+        b: T.LongType = pa.Field()
+
+        class Config:
+            """Config class."""
+
+            unique = "a"
+
+    return MyDataModel
+
+
+@pytest.fixture
+def datamodel_unique_multiple_columns() -> pa.DataFrameModel:
+    """Fixture containing DataFrameModel with optional columns."""
+
+    class MyDataModel(pa.DataFrameModel):
+        """Simple DataFrameModel containing a column."""
+
+        a: T.LongType = pa.Field()
+        b: T.LongType = pa.Field()
+
+        class Config:
+            """Config class."""
+
+            unique = ["a", "b"]
+
+    return MyDataModel
+
+
+@pytest.mark.parametrize(
+    "data_model, data, expectation",
+    [
+        (
+            datamodel_unique_single_column,
+            ([1, 4], [2, 5], [3, 6]),
+            does_not_raise(),
+        ),
+        (
+            datamodel_unique_multiple_columns,
+            ([1, 4], [2, 5], [3, 6]),
+            does_not_raise(),
+        ),
+        (
+            datamodel_unique_single_column,
+            ([0, 0], [0, 0], [3, 6]),
+            pytest.raises(pa.PysparkSchemaError),
+        ),
+        (
+            datamodel_unique_multiple_columns,
+            ([0, 0], [0, 0], [3, 6]),
+            pytest.raises(pa.PysparkSchemaError),
+        ),
+    ],
+)
+def test_dataframe_schema_unique(spark, data_model, data, expectation):
+    """Test uniqueness checks on pyspark dataframes."""
+    print(f"{type(spark)=}")
+    print(f"{type(data_model)=}")
+    print(f"{type(data)=}")
+    print(f"{type(expectation)=}")
+
+    df = spark.createDataFrame(data, ["a", "b"])
+
+    # assert isinstance(data_model(df), DataFrame)
+
+    with expectation:
+        df_out = data_model.validate(check_obj=df)
+        if df_out.pandera.errors:
+            raise pa.PysparkSchemaError
 
 
 def test_dataframe_schema_strict(spark, config_params: PanderaConfig) -> None:

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -224,42 +224,6 @@ def test_pyspark_fields_metadata():
     assert PanderaSchema.get_metadata() == expected
 
 
-# @pytest.fixture
-# def datamodel_unique_single_column() -> pa.DataFrameModel:
-#     """Fixture containing DataFrameModel with optional columns."""
-
-#     class MyDataModel(pa.DataFrameModel):
-#         """Simple DataFrameModel containing a column."""
-
-#         a: T.LongType = pa.Field()
-#         b: T.LongType = pa.Field()
-
-#         class Config:
-#             """Config class."""
-
-#             unique = "a"
-
-#     return MyDataModel
-
-
-# @pytest.fixture
-# def datamodel_unique_multiple_columns() -> pa.DataFrameModel:
-#     """Fixture containing DataFrameModel with optional columns."""
-
-#     class MyDataModel(pa.DataFrameModel):
-#         """Simple DataFrameModel containing a column."""
-
-#         a: T.LongType = pa.Field()
-#         b: T.LongType = pa.Field()
-
-#         class Config:
-#             """Config class."""
-
-#             unique = ["a", "b"]
-
-#     return MyDataModel
-
-
 @pytest.mark.parametrize(
     "data, expectation",
     [
@@ -276,7 +240,7 @@ def test_pyspark_fields_metadata():
             pytest.raises(pa.PysparkSchemaError),
         ),
     ],
-    ids=["no_data", "non_duplicated_data", "duplicated_data"],
+    ids=["no_data", "unique_data", "duplicated_data"],
 )
 def test_dataframe_schema_unique(spark, data, expectation):
     """Test uniqueness checks on pyspark dataframes."""


### PR DESCRIPTION
Currently, the `unique` property in a `Config` class for `DataFrameModel` (PySpark) does not work, given no support for it was added in the initial pyspark support in release `0.16.0`.

This PR adds support for it: test cases and a warning in the docs about a possible performance hit when using it were added. 
The Column/Field-based `unique` capability remained untouched.

This PR is open for improvement suggestions.

##### Test code I

```py
import pandera.pyspark as pa
from pyspark.sql import types as T
from pyspark.sql import SparkSession
from pprint import pprint as pp

class InputSchema(pa.DataFrameModel):
    year: T.IntegerType = pa.Field(gt=2000, coerce=True)
    month: T.IntegerType = pa.Field(ge=1, le=12, coerce=True)
    day: T.IntegerType = pa.Field(ge=0, le=365, coerce=True)

    class Config:
        unique = "year"  # More than one column can be set too: ["year", "month"]

data = [(2001, 3, 200), (2001, 6, 156), (2100, 12, 365), (2100, 12, 365)]
spark_schema = T.StructType(
    [
        T.StructField("year", T.IntegerType(), False),
        T.StructField("month", T.IntegerType(), False),
        T.StructField("day", T.IntegerType(), False),
    ],
)
spark = SparkSession.builder.getOrCreate()
df = spark.createDataFrame(data=data, schema=spark_schema, verifySchema=False)

df_out = InputSchema.validate(df)
pp(df_out.pandera.errors)
```

##### Output
Considering `year` column only, two rows have duplicated values:
```txt
defaultdict(<function ErrorHandler.__init__.<locals>.<lambda> at 0x17820a790>,  
            {'DATA': defaultdict(<class 'list'>,
                                 {'DUPLICATES': [{'check': 'unique',
                                                  'column': 'InputSchema',
                                                  'error': 'Duplicated rows '
                                                           '[2] were found for '
                                                           "columns ['year']",
                                                  'schema': 'InputSchema'}]})})
```

##### Test code II
If two columns are used:
```py
    class Config:
        unique = ["year", "month"]
```

##### Output
Considering `year` and `month` columns, just one row has duplicated values:
```txt
defaultdict(<function ErrorHandler.__init__.<locals>.<lambda> at 0x14c20a790>,  
            {'DATA': defaultdict(<class 'list'>,
                                 {'DUPLICATES': [{'check': 'unique',
                                                  'column': 'InputSchema',
                                                  'error': 'Duplicated rows '
                                                           '[1] were found for '
                                                           "columns ['year', "
                                                           "'month']",
                                                  'schema': 'InputSchema'}]})})
```