### PR TITLE
[BUGFIX] [PYSPARK] Avoid running nullable checks if `nullable=True`

### DIFF
--- a/pandera/backends/pyspark/column.py
+++ b/pandera/backends/pyspark/column.py
@@ -125,10 +125,16 @@ class ColumnSchemaBackend(PysparkSchemaBackend):
 
     @validate_scope(scope=ValidationScope.SCHEMA)
     def check_nullable(self, check_obj: DataFrame, schema):
-        isna = (
-            check_obj.filter(col(schema.name).isNull()).limit(1).count() == 0
-        )
-        passed = schema.nullable or isna
+        # If True, ignore this `nullable` check
+        passed = schema.nullable
+
+        # If False, execute the costly validation
+        if not schema.nullable:
+            passed = (
+                check_obj.filter(col(schema.name).isNull()).limit(1).count()
+                == 0
+            )
+
         return CoreCheckResult(
             check="not_nullable",
             reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,


### PR DESCRIPTION
The check for `nullable` columns in PySpark is being triggered every time, when the column does not have the `nullable` property (`False` by default) and when it's set with `True`.
When it's set, it shouldn't run. As each run relies on a `.count()` PySpark action, that is very costly regarding time and cpu usage.

In my test scenario, I have a complex Spark DAG and 42 `nullable=True` in a schema with 92 `Fields` in total.
Without this fix it was running in **1h20m**. With this fix it decreased for **41m**.

Added a corresponding test case for it.