### PR TITLE
Fix disabling validation for PySpark DataFrame Schemas

### DIFF
--- a/pandera/api/pyspark/container.py
+++ b/pandera/api/pyspark/container.py
@@ -327,7 +327,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
             [Row(product='Bread', price=9), Row(product='Butter', price=15)]
         """
         if not CONFIG.validation_enabled:
-            return
+            return check_obj
         error_handler = ErrorHandler(lazy)
 
         return self._validate(

--- a/tests/pyspark/test_pyspark_config.py
+++ b/tests/pyspark/test_pyspark_config.py
@@ -44,8 +44,8 @@ class TestPanderaConfig:
         }
 
         assert CONFIG.dict() == expected
-        assert pandra_schema.validate(input_df) is None
-        assert TestSchema.validate(input_df) is None
+        assert pandra_schema.validate(input_df)
+        assert TestSchema.validate(input_df)
 
     # pylint:disable=too-many-locals
     def test_schema_only(self, spark, sample_spark_schema):


### PR DESCRIPTION
Currently when validation is disabled through environment variables, instead of returning the original DataFrame the `validate` funcion returns `None` which breaks the code.

To fix this the `check_obj` is returned directly if validation should be skipped.