### PR TITLE
feature: support string column validation for pandas 2.1.3

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -718,7 +718,7 @@ class NpString(numpy_engine.String):
             )
         else:
             is_python_string = data_container.map(lambda x: isinstance(x, str))  # type: ignore[operator]
-        return is_python_string | data_container.isna()
+        return is_python_string.astype(bool) | data_container.isna()
 
 
 Engine.register_dtype(


### PR DESCRIPTION
The problem and solution are as described in https://github.com/unionai-oss/pandera/issues/1424.

This PR
- casts `is_python_string.astype(bool)` in `NpString.check`
- adds tests for `data_type.check` to ensure the check results are always boolean or reduceable to boolean-like by [`.all()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.all.html#pandas.Series.all), in order to pass the column validation in [`ArraySchemaBackend.check_dtype`](https://github.com/unionai-oss/pandera/blob/4425ad8012342960c98f673206a4149ce4cd22dc/pandera/backends/pandas/array.py#L260-L280)