### PR TITLE
Bugfix/763: DataFrameModel validate returns the correct type

### DIFF
--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -31,7 +31,7 @@ cloudpickle==2.2.1        # via dask, distributed, doit
 colorama==0.4.6           # via typer
 colorlog==6.7.0           # via nox
 commonmark==0.9.1         # via recommonmark
-coverage[toml]==7.3.1     # via coverage, pytest-cov
+coverage[toml]==7.3.1     # via pytest-cov
 dask==2023.9.2            # via -r requirements.in, distributed
 defusedxml==0.7.1         # via nbconvert
 dill==0.3.7               # via pylint
@@ -182,7 +182,7 @@ tornado==6.3.3            # via distributed, jupyter-client, jupyter-server, ter
 traitlets==5.10.0         # via jupyter-client, jupyter-core, jupyter-events, jupyter-server, nbclient, nbconvert, nbformat
 twine==4.0.2              # via -r requirements.in
 typeguard==4.1.5          # via -r requirements.in
-typer[all]==0.9.0         # via frictionless, typer
+typer[all]==0.9.0         # via frictionless
 types-click==7.1.8        # via -r requirements.in
 types-pkg-resources==0.1.3  # via -r requirements.in
 types-pytz==2023.3.0.1    # via -r requirements.in, pandas-stubs

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -32,7 +32,7 @@ cloudpickle==2.2.1        # via dask, distributed, doit
 colorama==0.4.6           # via typer
 colorlog==6.7.0           # via nox
 commonmark==0.9.1         # via recommonmark
-coverage[toml]==7.3.1     # via coverage, pytest-cov
+coverage[toml]==7.3.1     # via pytest-cov
 dask==2023.9.2            # via -r requirements.in, distributed
 defusedxml==0.7.1         # via nbconvert
 dill==0.3.7               # via pylint
@@ -184,7 +184,7 @@ tornado==6.3.3            # via distributed, jupyter-client, jupyter-server, ter
 traitlets==5.10.0         # via jupyter-client, jupyter-core, jupyter-events, jupyter-server, nbclient, nbconvert, nbformat
 twine==4.0.2              # via -r requirements.in
 typeguard==4.1.5          # via -r requirements.in
-typer[all]==0.9.0         # via frictionless, typer
+typer[all]==0.9.0         # via frictionless
 types-click==7.1.8        # via -r requirements.in
 types-pkg-resources==0.1.3  # via -r requirements.in
 types-pytz==2023.3.0.1    # via -r requirements.in, pandas-stubs

--- a/ci/requirements-py3.11-pandas2.0.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.0.3-pydantic1.10.11.txt
@@ -31,7 +31,7 @@ cloudpickle==2.2.1        # via dask, distributed, doit
 colorama==0.4.6           # via typer
 colorlog==6.7.0           # via nox
 commonmark==0.9.1         # via recommonmark
-coverage[toml]==7.3.1     # via coverage, pytest-cov
+coverage[toml]==7.3.1     # via pytest-cov
 dask==2023.9.2            # via -r requirements.in, distributed
 defusedxml==0.7.1         # via nbconvert
 dill==0.3.7               # via pylint
@@ -182,7 +182,7 @@ tornado==6.3.3            # via distributed, jupyter-client, jupyter-server, ter
 traitlets==5.10.0         # via jupyter-client, jupyter-core, jupyter-events, jupyter-server, nbclient, nbconvert, nbformat
 twine==4.0.2              # via -r requirements.in
 typeguard==4.1.5          # via -r requirements.in
-typer[all]==0.9.0         # via frictionless, typer
+typer[all]==0.9.0         # via frictionless
 types-click==7.1.8        # via -r requirements.in
 types-pkg-resources==0.1.3  # via -r requirements.in
 types-pytz==2023.3.0.1    # via -r requirements.in, pandas-stubs

--- a/ci/requirements-py3.11-pandas2.0.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.0.3-pydantic2.3.0.txt
@@ -32,7 +32,7 @@ cloudpickle==2.2.1        # via dask, distributed, doit
 colorama==0.4.6           # via typer
 colorlog==6.7.0           # via nox
 commonmark==0.9.1         # via recommonmark
-coverage[toml]==7.3.1     # via coverage, pytest-cov
+coverage[toml]==7.3.1     # via pytest-cov
 dask==2023.9.2            # via -r requirements.in, distributed
 defusedxml==0.7.1         # via nbconvert
 dill==0.3.7               # via pylint
@@ -184,7 +184,7 @@ tornado==6.3.3            # via distributed, jupyter-client, jupyter-server, ter
 traitlets==5.10.0         # via jupyter-client, jupyter-core, jupyter-events, jupyter-server, nbclient, nbconvert, nbformat
 twine==4.0.2              # via -r requirements.in
 typeguard==4.1.5          # via -r requirements.in
-typer[all]==0.9.0         # via frictionless, typer
+typer[all]==0.9.0         # via frictionless
 types-click==7.1.8        # via -r requirements.in
 types-pkg-resources==0.1.3  # via -r requirements.in
 types-pytz==2023.3.0.1    # via -r requirements.in, pandas-stubs

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -209,7 +209,7 @@ jupyter-core==5.3.1
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.7.0
+jupyter-events==0.9.0
     # via jupyter-server
 jupyter-server==2.11.2
     # via

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -204,7 +204,7 @@ jupyter-core==5.3.1
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.7.0
+jupyter-events==0.9.0
     # via jupyter-server
 jupyter-server==2.11.2
     # via

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -221,7 +221,7 @@ jupyter-core==5.3.1
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.7.0
+jupyter-events==0.9.0
     # via jupyter-server
 jupyter-server==2.11.2
     # via

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -216,7 +216,7 @@ jupyter-core==5.3.1
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.7.0
+jupyter-events==0.9.0
     # via jupyter-server
 jupyter-server==2.11.2
     # via

--- a/pandera/api/base/model.py
+++ b/pandera/api/base/model.py
@@ -44,7 +44,7 @@ class BaseModel(metaclass=MetaModel):
     __checks__: Dict[str, List[Check]] = {}
     __root_checks__: List[Check] = []
 
-    # This is syntantic sugar that delegates to the validate method
+    # This is syntactic sugar that delegates to the validate method
     def __new__(cls, *args, **kwargs) -> Any:
         raise NotImplementedError
 

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -40,8 +40,7 @@ from pandera.api.pandas.model_config import BaseConfig
 from pandera.engines import PYDANTIC_V2
 from pandera.errors import SchemaInitError
 from pandera.strategies import pandas_strategies as st
-from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo
-from pandera.typing.common import DataFrameBase
+from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo, DataFrame
 
 if PYDANTIC_V2:
     from pydantic_core import core_schema
@@ -149,10 +148,11 @@ class DataFrameModel(BaseModel):
     __root_checks__: List[Check] = []
 
     @docstring_substitution(validate_doc=DataFrameSchema.validate.__doc__)
-    def __new__(cls, *args, **kwargs) -> DataFrameBase[TDataFrameModel]:  # type: ignore [misc]
+    def __new__(cls, *args, **kwargs) -> DataFrame[TDataFrameModel]:  # type: ignore [misc]
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel], cls.validate(*args, **kwargs)
+            DataFrame[TDataFrameModel],
+            cls.validate(*args, **kwargs),
         )
 
     def __init_subclass__(cls, **kwargs):
@@ -299,10 +299,10 @@ class DataFrameModel(BaseModel):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-    ) -> DataFrameBase[TDataFrameModel]:
+    ) -> DataFrame[TDataFrameModel]:
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel],
+            DataFrame[TDataFrameModel],
             cls.to_schema().validate(
                 check_obj, head, tail, sample, random_state, lazy, inplace
             ),
@@ -321,10 +321,10 @@ class DataFrameModel(BaseModel):
     def example(
         cls: Type[TDataFrameModel],
         **kwargs,
-    ) -> DataFrameBase[TDataFrameModel]:
+    ) -> DataFrame[TDataFrameModel]:
         """%(example_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel], cls.to_schema().example(**kwargs)
+            DataFrame[TDataFrameModel], cls.to_schema().example(**kwargs)
         )
 
     @classmethod

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -37,8 +37,7 @@ from pandera.api.pyspark.model_components import (
 )
 from pandera.api.pyspark.model_config import BaseConfig
 from pandera.errors import SchemaInitError
-from pandera.typing import AnnotationInfo
-from pandera.typing.common import DataFrameBase
+from pandera.typing import AnnotationInfo, DataFrame
 
 try:
     from typing_extensions import get_type_hints
@@ -140,10 +139,11 @@ class DataFrameModel(BaseModel):
     __root_checks__: List[Check] = []
 
     @docstring_substitution(validate_doc=DataFrameSchema.validate.__doc__)
-    def __new__(cls, *args, **kwargs) -> DataFrameBase[TDataFrameModel]:  # type: ignore [misc]
+    def __new__(cls, *args, **kwargs) -> DataFrame[TDataFrameModel]:  # type: ignore [misc]
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel], cls.validate(*args, **kwargs)
+            DataFrame[TDataFrameModel],
+            cls.validate(*args, **kwargs),
         )
 
     def __init_subclass__(cls, **kwargs):
@@ -282,10 +282,10 @@ class DataFrameModel(BaseModel):
         random_state: Optional[int] = None,
         lazy: bool = True,
         inplace: bool = False,
-    ) -> Optional[DataFrameBase[TDataFrameModel]]:
+    ) -> Optional[DataFrame[TDataFrameModel]]:
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel],
+            DataFrame[TDataFrameModel],
             cls.to_schema().validate(
                 check_obj, head, tail, sample, random_state, lazy, inplace
             ),


### PR DESCRIPTION
Updates the return type casting of various model methods to return the correct type (`DataFrame` instead of `DataFrameBase`). The issue called for typing overload but that didn't seem to be necessary in looking at the code, because  as best as I can tell calling these methods should always return the same thing (and `DataFrame` inherits from `DataFrameBase` anyway).

Resolves #763 