### PR TITLE
 Improved error messaging

### DIFF
--- a/docs/source/lazy_validation.rst
+++ b/docs/source/lazy_validation.rst
@@ -98,17 +98,6 @@ of all schemas and schema components gives you the option of doing just this:
                     int_column   dtype('int64')                   [object]                1
                     str_column   equal_to(a)                        [b, d]                2
 
-    Usage Tip
-    ---------
-
-    Directly inspect all errors by catching the exception:
-
-    ```
-    try:
-        schema.validate(dataframe, lazy=True)
-    except SchemaErrors as err:
-        err.failure_cases  # dataframe of schema errors
-        err.data  # invalid dataframe
     ```
 
 As you can see from the output above, a :class:`~pandera.errors.SchemaErrors`

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -345,9 +345,18 @@ def dataframe_to_tabular_formatted_string(
     # Bottom border and additional rows message if applicable
     if len(dataframe) > limit:
         formatted_string += (
-            "│ " + " ┆ ".join(["…" for _ in column_widths.values()]) + " │\n"
+            "│"
+            + "│".join(
+                [" " + "…" * (width) + " " for width in column_widths.values()]
+            )
+            + "│\n"
         )
-        formatted_string += f"And {len(dataframe) - limit} others"
+        formatted_string += (
+            "└"
+            + "┴".join(["─" * (width + 2) for width in column_widths.values()])
+            + "┘\n"
+        )
+        formatted_string += f"And {len(dataframe) - limit} more rows\n"
     else:
         formatted_string += (
             "└"

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -238,23 +238,6 @@ def consolidate_failure_cases(schema_errors: List[SchemaError]):
     )
 
 
-SCHEMA_ERRORS_SUFFIX = """
-
-Usage Tip
----------
-
-Directly inspect all errors by catching the exception:
-
-```
-try:
-    schema.validate(dataframe, lazy=True)
-except SchemaErrors as err:
-    err.failure_cases  # dataframe of schema errors
-    err.data  # invalid dataframe
-```
-"""
-
-
 def summarize_failure_cases(
     schema_name: str,
     schema_errors: List[SchemaError],
@@ -311,5 +294,4 @@ def summarize_failure_cases(
     msg += "\n--------------------\n"
     with pd.option_context("display.max_colwidth", 100):
         msg += summarized_failure_cases.to_string()
-    msg += SCHEMA_ERRORS_SUFFIX
     return msg, error_counts

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -269,7 +269,7 @@ def summarize_failure_cases(
     )
     msg += failure_cases_table
 
-    return msg
+    return msg, len(schema_errors)
 
 
 def dataframe_to_tabular_formatted_string(

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -269,12 +269,18 @@ def summarize_failure_cases(
     )
     msg += failure_cases_table
 
-    return msg, len(schema_errors)
+    error_counts = defaultdict(int)  # type: ignore
+    for schema_error in schema_errors:
+        reason_code = schema_error.reason_code
+        error_counts[reason_code] += 1
+
+    return msg, error_counts
 
 
 def dataframe_to_tabular_formatted_string(
     dataframe, limit=10, max_width=20, max_cell_length=200, column_order=None
 ):
+    """Produce a string based on a dataframe formatted like a table"""
     formatted_string = ""
 
     # Reorder DataFrame columns if column_order is provided
@@ -321,9 +327,10 @@ def dataframe_to_tabular_formatted_string(
     # Each row
     for _, row in truncated_df.iterrows():
         wrapped_row = [
-            [line for line in textwrap.wrap(str(value), width)]
+            textwrap.wrap(str(value), width)
             for value, width in zip(row, column_widths.values())
         ]
+
         max_lines = max(len(wrapped) for wrapped in wrapped_row)
 
         for line in range(max_lines):

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -113,23 +113,6 @@ class BaseStrategyOnlyError(Exception):
     """Custom error for reporting strategies that must be base strategies."""
 
 
-SCHEMA_ERRORS_SUFFIX = """
-
-Usage Tip
----------
-
-Directly inspect all errors by catching the exception:
-
-```
-try:
-    schema.validate(dataframe, lazy=True)
-except SchemaErrors as err:
-    err.failure_cases  # dataframe of schema errors
-    err.data  # invalid dataframe
-```
-"""
-
-
 class FailureCaseMetadata(NamedTuple):
     """Consolidated failure cases, summary message, and error counts."""
 

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -557,7 +557,7 @@ def test_check_types_arguments() -> None:
     ) -> DataFrame[OnlyZeroesSchema]:
         return pd.DataFrame({"a": [1, 1]})  # type: ignore
 
-    with pytest.raises(errors.SchemaErrors, match="Usage Tip"):
+    with pytest.raises(errors.SchemaErrors):
         transform_lazy(df)  # type: ignore
 
 

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -1,0 +1,95 @@
+from pandera.api.checks import Check
+from pandera.api.pandas.components import Column
+from pandera.api.pandas.container import DataFrameSchema
+from pandera.backends.pandas.error_formatters import summarize_failure_cases
+import pytest
+from pandera.errors import SchemaError, SchemaErrorReason
+import pandas as pd
+
+check = Check.isin(["coke", "7up", "mountain_dew"])
+mock_schema = DataFrameSchema({"flavour": Column(str, checks=[check])})
+
+dataframe = pd.DataFrame({"flavour": ["pepsi", "coke", "fanta"]})
+
+
+@pytest.mark.parametrize(
+    "schema_name, schema_errors, failure_cases",
+    [
+        (
+            "MySchema",
+            [
+                SchemaError(
+                    schema=mock_schema,
+                    data=dataframe,
+                    message=None,
+                    failure_cases=pd.DataFrame(
+                        {"index": [0, 2], "failure_case": ["pepsi", "fanta"]}
+                    ),
+                    check=check,
+                    check_index=0,
+                    check_output=pd.Series(
+                        name="Flavour", data=[False, True, False]
+                    ),
+                    reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+                )
+            ],
+            pd.DataFrame(
+                {
+                    "index": [0, 1],
+                    "schema_context": ["Column", "Column"],
+                    "column": ["flavour", "flavour"],
+                    "check": [
+                        "isin(['coke', '7up', 'mountain_dew'])",
+                        "isin(['coke', '7up', 'mountain_dew'])",
+                    ],
+                    "check_number": [0, 0],
+                    "failure_case": ["pepsi", "fanta"],
+                }
+            ),
+        )
+    ],
+)
+def test_summarize_failure_cases(schema_name, schema_errors, failure_cases):
+    summary = summarize_failure_cases(
+        schema_name=schema_name,
+        schema_errors=schema_errors,
+        failure_cases=failure_cases,
+    )
+
+    assert summary == "foo"
+
+
+if __name__ == "__main__":
+    schema_name = None
+    schema_errors = [
+        SchemaError(
+            schema=mock_schema,
+            data=dataframe,
+            message=None,
+            failure_cases=pd.DataFrame(
+                {"index": [0, 2], "failure_case": ["pepsi", "fanta"]}
+            ),
+            check=check,
+            check_index=0,
+            check_output=pd.Series(name="Flavour", data=[False, True, False]),
+            reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+        )
+    ]
+    failure_cases = pd.DataFrame(
+        {
+            "index": [0, 1],
+            "schema_context": ["Column", "Column"],
+            "column": ["flavour", "flavour"],
+            "check": [
+                "isin(['coke', '7up', 'mountain_dew'])",
+                "isin(['coke', '7up', 'mountain_dew'])",
+            ],
+            "check_number": [0, 0],
+            "failure_case": ["pepsi", "fanta"],
+        }
+    )
+    summary = summarize_failure_cases(
+        schema_name=schema_name,
+        schema_errors=schema_errors,
+        failure_cases=failure_cases,
+    )

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -81,11 +81,11 @@ Schema MySchema: A total of 2 schema errors were found.
             ),
             """
 Schema Wide Schema: A total of 1 schema errors were found.
-┌───────┬─────────────┬───────────────────┬──────────────┬─────────────────┬──────────────┐
-│ index ┆    column   ┆       check       ┆ failure_case ┆  schema_context ┆ check_number │
-╞═══════╪═════════════╪═══════════════════╪══════════════╪═════════════════╪══════════════╡
-│ None  │ Wide Schema │ custom_wide_check │ False        │ DataFrameSchema │ 0            │
-└───────┴─────────────┴───────────────────┴──────────────┴─────────────────┴──────────────┘
+┌───────┬─────────────┬────────────────────────┬──────────────┬─────────────────┬──────────────┐
+│ index ┆    column   ┆          check         ┆ failure_case ┆  schema_context ┆ check_number │
+╞═══════╪═════════════╪════════════════════════╪══════════════╪═════════════════╪══════════════╡
+│ None  │ Wide Schema │  custom_wide_check     │ False        │ DataFrameSchema │ 0            │
+└───────┴─────────────┴────────────────────────┴──────────────┴─────────────────┴──────────────┘
 """,
         ),
     ],

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -81,11 +81,12 @@ Schema MySchema: A total of 2 schema errors were found.
             ),
             """
 Schema Wide Schema: A total of 1 schema errors were found.
-┌───────┬─────────────┬────────────────────────┬──────────────┬─────────────────┬──────────────┐
-│ index ┆    column   ┆          check         ┆ failure_case ┆  schema_context ┆ check_number │
-╞═══════╪═════════════╪════════════════════════╪══════════════╪═════════════════╪══════════════╡
-│ None  │ Wide Schema │  custom_wide_check     │ False        │ DataFrameSchema │ 0            │
-└───────┴─────────────┴────────────────────────┴──────────────┴─────────────────┴──────────────┘
+┌───────┬─────────────┬──────────────────────┬──────────────┬─────────────────┬──────────────┐
+│ index ┆    column   ┆        check         ┆ failure_case ┆  schema_context ┆ check_number │
+╞═══════╪═════════════╪══════════════════════╪══════════════╪═════════════════╪══════════════╡
+│ None  │ Wide Schema │ _mock_custom_wide_ch │ False        │ DataFrameSchema │ 0            │
+│       │             │ eck                  │              │                 │              │
+└───────┴─────────────┴──────────────────────┴──────────────┴─────────────────┴──────────────┘
 """,
         ),
     ],

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -13,7 +13,7 @@ dataframe = pd.DataFrame({"flavour": ["pepsi", "coke", "fanta"]})
 
 
 @pytest.mark.parametrize(
-    "schema_name, schema_errors, failure_cases",
+    "schema_name, schema_errors, failure_cases, error_message",
     [
         (
             "MySchema",
@@ -46,50 +46,28 @@ dataframe = pd.DataFrame({"flavour": ["pepsi", "coke", "fanta"]})
                     "failure_case": ["pepsi", "fanta"],
                 }
             ),
+            """
+Schema MySchema: A total of 2 schema errors were found.
+┌───────┬─────────┬──────────────────────┬──────────────┬────────────────┬──────────────┐
+│ index ┆  column ┆        check         ┆ failure_case ┆ schema_context ┆ check_number │
+╞═══════╪═════════╪══════════════════════╪══════════════╪════════════════╪══════════════╡
+│ 0     │ flavour │ isin(['coke', '7up', │ pepsi        │ Column         │ 0            │
+│       │         │ 'mountain_dew'])     │              │                │              │
+│ 1     │ flavour │ isin(['coke', '7up', │ fanta        │ Column         │ 0            │
+│       │         │ 'mountain_dew'])     │              │                │              │
+└───────┴─────────┴──────────────────────┴──────────────┴────────────────┴──────────────┘
+""",
         )
     ],
 )
-def test_summarize_failure_cases(schema_name, schema_errors, failure_cases):
+def test_summarize_failure_cases(
+    schema_name, schema_errors, failure_cases, error_message
+):
     summary = summarize_failure_cases(
         schema_name=schema_name,
         schema_errors=schema_errors,
         failure_cases=failure_cases,
     )
 
-    assert summary == "foo"
+    assert summary.strip() == error_message.strip()
 
-
-if __name__ == "__main__":
-    schema_name = None
-    schema_errors = [
-        SchemaError(
-            schema=mock_schema,
-            data=dataframe,
-            message=None,
-            failure_cases=pd.DataFrame(
-                {"index": [0, 2], "failure_case": ["pepsi", "fanta"]}
-            ),
-            check=check,
-            check_index=0,
-            check_output=pd.Series(name="Flavour", data=[False, True, False]),
-            reason_code=SchemaErrorReason.DATAFRAME_CHECK,
-        )
-    ]
-    failure_cases = pd.DataFrame(
-        {
-            "index": [0, 1],
-            "schema_context": ["Column", "Column"],
-            "column": ["flavour", "flavour"],
-            "check": [
-                "isin(['coke', '7up', 'mountain_dew'])",
-                "isin(['coke', '7up', 'mountain_dew'])",
-            ],
-            "check_number": [0, 0],
-            "failure_case": ["pepsi", "fanta"],
-        }
-    )
-    summary = summarize_failure_cases(
-        schema_name=schema_name,
-        schema_errors=schema_errors,
-        failure_cases=failure_cases,
-    )

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -1,51 +1,50 @@
 from pandera.api.checks import Check
 from pandera.api.pandas.components import Column
 from pandera.api.pandas.container import DataFrameSchema
-from pandera.backends.pandas.error_formatters import summarize_failure_cases
 import pytest
-from pandera.errors import SchemaError, SchemaErrorReason
+from pandera.errors import SchemaErrors
 import pandas as pd
 
-check = Check.isin(["coke", "7up", "mountain_dew"])
-mock_schema = DataFrameSchema({"flavour": Column(str, checks=[check])})
 
-dataframe = pd.DataFrame({"flavour": ["pepsi", "coke", "fanta"]})
+def custom_wide_check(df):
+    return (df["column_1"] + df["column_2"] >= df["column_3"]).all()
 
 
 @pytest.mark.parametrize(
-    "schema_name, schema_errors, failure_cases, error_message",
+    "schema, df, error_message",
     [
         (
-            "MySchema",
-            [
-                SchemaError(
-                    schema=mock_schema,
-                    data=dataframe,
-                    message=None,
-                    failure_cases=pd.DataFrame(
-                        {"index": [0, 2], "failure_case": ["pepsi", "fanta"]}
-                    ),
-                    check=check,
-                    check_index=0,
-                    check_output=pd.Series(
-                        name="Flavour", data=[False, True, False]
-                    ),
-                    reason_code=SchemaErrorReason.DATAFRAME_CHECK,
-                )
-            ],
+            DataFrameSchema(
+                {"color": Column(str), "size": Column(str)}, strict=True
+            ),
             pd.DataFrame(
                 {
-                    "index": [0, 1],
-                    "schema_context": ["Column", "Column"],
-                    "column": ["flavour", "flavour"],
-                    "check": [
-                        "isin(['coke', '7up', 'mountain_dew'])",
-                        "isin(['coke', '7up', 'mountain_dew'])",
-                    ],
-                    "check_number": [0, 0],
-                    "failure_case": ["pepsi", "fanta"],
+                    "color": ["red", "blue", "green"],
+                    "size": ["1A", "2", "3"],
+                    "year": ["2022", "2021", "2024"],
                 }
             ),
+            """
+Schema Nameless Schema: A total of 1 schema errors were found.
+┌───────┬────────┬──────────────────┬──────────────┬─────────────────┬──────────────┐
+│ index ┆ column ┆      check       ┆ failure_case ┆  schema_context ┆ check_number │
+╞═══════╪════════╪══════════════════╪══════════════╪═════════════════╪══════════════╡
+│ None  │ None   │ column_in_schema │ year         │ DataFrameSchema │ None         │
+└───────┴────────┴──────────────────┴──────────────┴─────────────────┴──────────────┘
+""",
+        ),
+        (
+            DataFrameSchema(
+                {
+                    "flavour": Column(
+                        str,
+                        checks=[Check.isin(["coke", "7up", "mountain_dew"])],
+                    )
+                },
+                name="MySchema",
+                strict=True,
+            ),
+            pd.DataFrame({"flavour": ["pepsi", "coke", "fanta"]}),
             """
 Schema MySchema: A total of 2 schema errors were found.
 ┌───────┬─────────┬──────────────────────┬──────────────┬────────────────┬──────────────┐
@@ -53,21 +52,43 @@ Schema MySchema: A total of 2 schema errors were found.
 ╞═══════╪═════════╪══════════════════════╪══════════════╪════════════════╪══════════════╡
 │ 0     │ flavour │ isin(['coke', '7up', │ pepsi        │ Column         │ 0            │
 │       │         │ 'mountain_dew'])     │              │                │              │
-│ 1     │ flavour │ isin(['coke', '7up', │ fanta        │ Column         │ 0            │
+│ 2     │ flavour │ isin(['coke', '7up', │ fanta        │ Column         │ 0            │
 │       │         │ 'mountain_dew'])     │              │                │              │
 └───────┴─────────┴──────────────────────┴──────────────┴────────────────┴──────────────┘
 """,
-        )
+        ),
+        (
+            DataFrameSchema(
+                {
+                    "column_1": Column(int),
+                    "column_2": Column(int),
+                    "column_3": Column(int),
+                },
+                name="Wide Schema",
+                strict=True,
+                checks=[Check(custom_wide_check)],
+            ),
+            pd.DataFrame(
+                {
+                    "column_1": [1, 2, 1],
+                    "column_2": [1, 0, 1],
+                    "column_3": [2, 2, 4],
+                }
+            ),
+            """
+Schema Wide Schema: A total of 1 schema errors were found.
+┌───────┬─────────────┬───────────────────┬──────────────┬─────────────────┬──────────────┐
+│ index ┆    column   ┆       check       ┆ failure_case ┆  schema_context ┆ check_number │
+╞═══════╪═════════════╪═══════════════════╪══════════════╪═════════════════╪══════════════╡
+│ None  │ Wide Schema │ custom_wide_check │ False        │ DataFrameSchema │ 0            │
+└───────┴─────────────┴───────────────────┴──────────────┴─────────────────┴──────────────┘
+""",
+        ),
     ],
 )
-def test_summarize_failure_cases(
-    schema_name, schema_errors, failure_cases, error_message
-):
-    summary = summarize_failure_cases(
-        schema_name=schema_name,
-        schema_errors=schema_errors,
-        failure_cases=failure_cases,
-    )
+def test_schema_error_messages(schema, df, error_message):
+    """Test the error message produced from validating an invalid dataframe is correctly formatted`"""
+    with pytest.raises(SchemaErrors) as e:
+        schema.validate(df, lazy=True)
 
-    assert summary.strip() == error_message.strip()
-
+    assert error_message.strip() == str(e.value).strip()

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -1,12 +1,16 @@
+"""Test the error message produced from validating an invalid dataframe is correctly formatted`"""
+
+import pytest
+import pandas as pd
+
 from pandera.api.checks import Check
 from pandera.api.pandas.components import Column
 from pandera.api.pandas.container import DataFrameSchema
-import pytest
 from pandera.errors import SchemaErrors
-import pandas as pd
 
 
-def custom_wide_check(df):
+def _mock_custom_wide_check(df):
+    """Mock check function for us in the spec below"""
     return (df["column_1"] + df["column_2"] >= df["column_3"]).all()
 
 
@@ -66,7 +70,7 @@ Schema MySchema: A total of 2 schema errors were found.
                 },
                 name="Wide Schema",
                 strict=True,
-                checks=[Check(custom_wide_check)],
+                checks=[Check(_mock_custom_wide_check)],
             ),
             pd.DataFrame(
                 {
@@ -87,7 +91,7 @@ Schema Wide Schema: A total of 1 schema errors were found.
     ],
 )
 def test_schema_error_messages(schema, df, error_message):
-    """Test the error message produced from validating an invalid dataframe is correctly formatted`"""
+    """Test the SchemaErrors message produced by schema validation"""
     with pytest.raises(SchemaErrors) as e:
         schema.validate(df, lazy=True)
 

--- a/tests/core/test_error_formatters.py
+++ b/tests/core/test_error_formatters.py
@@ -89,6 +89,35 @@ Schema Wide Schema: A total of 1 schema errors were found.
 └───────┴─────────────┴──────────────────────┴──────────────┴─────────────────┴──────────────┘
 """,
         ),
+        (
+            DataFrameSchema(
+                {"count": Column(int, checks=[Check.greater_than(1)])}
+            ),
+            pd.DataFrame(
+                {
+                    "count": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                }
+            ),
+            """
+Schema Nameless Schema: A total of 16 schema errors were found.
+┌───────┬────────┬─────────────────┬──────────────┬────────────────┬──────────────┐
+│ index ┆ column ┆      check      ┆ failure_case ┆ schema_context ┆ check_number │
+╞═══════╪════════╪═════════════════╪══════════════╪════════════════╪══════════════╡
+│ 0     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 1     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 2     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 3     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 4     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 5     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 6     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 7     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 8     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ 9     │ count  │ greater_than(1) │ 0            │ Column         │ 0            │
+│ …………… │ ……………… │ ……………………………………… │ ……………………………… │ …………………………………… │ ……………………………… │
+└───────┴────────┴─────────────────┴──────────────┴────────────────┴──────────────┘
+And 6 more rows
+""",
+        ),
     ],
 )
 def test_schema_error_messages(schema, df, error_message):

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -377,7 +377,7 @@ def test_check_single_column() -> None:
 
     df = pd.DataFrame({"a": [101]})
     schema = Schema.to_schema()
-    err_msg = r"Column\s*a\s*int_column_lt_100\s*\[101\]\s*1"
+    err_msg = "│ 0     │ a      │ int_column_lt_100 │ 101          │ Column         │ 0            │"
     with pytest.raises(pa.errors.SchemaErrors, match=err_msg):
         schema.validate(df, lazy=True)
 
@@ -395,7 +395,7 @@ def test_check_single_index() -> None:
             return ~idx.str.contains("dog")
 
     df = pd.DataFrame(index=["cat", "dog"])
-    err_msg = r"Index\s*<NA>\s*not_dog\s*\[dog\]\s*"
+    err_msg = "│ 1     │ None   │ not_dog │ dog          │ Index          │ 0            │"
     with pytest.raises(pa.errors.SchemaErrors, match=err_msg):
         Schema.validate(df, lazy=True)
 
@@ -453,12 +453,12 @@ def test_multiple_checks() -> None:
     assert len(schema.columns["a"].checks) == 2
 
     df = pd.DataFrame({"a": [0]})
-    err_msg = r"Column\s*a\s*int_column_gt_0\s*\[0\]\s*1"
+    err_msg = "│ 0     │ a      │ int_column_gt_0 │ 0            │ Column         │ 1            │"
     with pytest.raises(pa.errors.SchemaErrors, match=err_msg):
         schema.validate(df, lazy=True)
 
     df = pd.DataFrame({"a": [101]})
-    err_msg = r"Column\s*a\s*int_column_lt_100\s*\[101\]\s*1"
+    err_msg = " 0     │ a      │ int_column_lt_100 │ 101          │ Column         │ 0            │"
     with pytest.raises(pa.errors.SchemaErrors, match=err_msg):
         schema.validate(df, lazy=True)
 
@@ -608,7 +608,7 @@ def test_inherit_field_checks() -> None:
     assert len(schema.columns["abc"].checks) == 0
 
     df = pd.DataFrame({"a": [15], "abc": [100]})
-    err_msg = r"Column\s*a\s*a_max\s*\[15\]\s*1"
+    err_msg = "0     │ a      │ a_max │ 15           │ Column         │ 0"
     with pytest.raises(pa.errors.SchemaErrors, match=err_msg):
         schema.validate(df, lazy=True)
 

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -264,7 +264,7 @@ def tests_multi_index_subindex_coerce() -> None:
     # coerce=False at the MultiIndex level should result in two type errors
     schema = DataFrameSchema(index=MultiIndex(indexes))
     with pytest.raises(
-        errors.SchemaErrors, match="A total of 2 schema errors were found"
+        errors.SchemaErrors, match="A total of 8 schema errors were found"
     ):
         schema(data, lazy=True)
 


### PR DESCRIPTION
### Improved error messaging
See https://github.com/unionai-oss/pandera/issues/1276 for context

The current error messages are quite hard to understand at a glance. This PR updates the `SchemaErrors` message to be a tabular view of the failure cases. 


### To do
- [ ] update the pyspark backend to use the same error display logic (unsure if this needs to be done or is done already by the changes in this PR)