### PR TITLE
Bug Fix | Geopandas import error

### DIFF
--- a/pandera/backends/pandas/__init__.py
+++ b/pandera/backends/pandas/__init__.py
@@ -2,7 +2,8 @@
 
 import pandas as pd
 
-import pandera.typing
+# import pandera.typing
+from pandera.typing import *
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
 from pandera.api.pandas.array import SeriesSchema


### PR DESCRIPTION
The pandera import was not working as the geopandas.py was not being imported properly to the the pandera backend pandas __init__.py file. Finxed this issue.