### PR TITLE
Fix copy-on-write chained assignment for default assignment

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -333,7 +333,7 @@ class ArraySchemaBackend(PandasSchemaBackend):
         elif not is_field(check_obj) and not isinstance(
             check_obj[schema.name].dtype, pd.SparseDtype
         ):
-            check_obj[schema.name].fillna(schema.default, inplace=True)
+            check_obj.fillna({schema.name: schema.default}, inplace=True)
 
         return check_obj
 

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1,4 +1,5 @@
 """Testing creation and manipulation of DataFrameSchema objects."""
+
 # pylint: disable=too-many-lines,redefined-outer-name
 
 import copy
@@ -2233,6 +2234,23 @@ def test_dataframe_default_with_correct_dtype(
     """Test that missing rows are backfilled with the default if missing"""
     validated_dataframe = dataframe_schema.validate(dataframe)
     pd.testing.assert_frame_equal(validated_dataframe, expected_dataframe)
+
+
+def test_dataframe_set_default_warning():
+    """Test that a warning is not emitted when performing an in-place update."""
+    dataframe_schema = DataFrameSchema(
+        columns={
+            "a": Column(pd.Int64Dtype(), default=9),
+            "b": Column(pd.Int64Dtype(), nullable=True),
+        },
+    )
+    dataframe = pd.DataFrame({"a": [0, None], "b": [None, 5]}, dtype="Int64")
+
+    with pd.option_context("mode.copy_on_write", True), pytest.warns(
+        match=r"chained assignment"
+    ) as record:
+        dataframe_schema.validate(dataframe)
+    assert len(record) == 0
 
 
 def test_default_works_correctly_on_schemas_with_multiple_colummns():


### PR DESCRIPTION
With Copy-On-Write enabled with at least Pandas 2.2.0, Pandera emits `ChainedAssignmentError` warnings whenever setting defaults:

```
[…]/.venv/lib/python3.11/site-packages/pandera/backends/pandas/array.py:337: ChainedAssignmentError: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
When using the Copy-on-Write mode, such inplace method never works to update the original DataFrame or Series, because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' instead, to perform the operation inplace on the original object.


  check_obj[schema.name].fillna(schema.default, inplace=True)
```

This PR just changes the offending line to use the suggested syntax.