### PR TITLE
chore: DataFrameBase to DataFrame in DataFrameModel.validate.

### DIFF
--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -40,8 +40,7 @@ from pandera.api.pandas.model_config import BaseConfig
 from pandera.engines import PYDANTIC_V2
 from pandera.errors import SchemaInitError
 from pandera.strategies import pandas_strategies as st
-from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo
-from pandera.typing.common import DataFrameBase
+from pandera.typing import INDEX_TYPES, SERIES_TYPES, AnnotationInfo, DataFrame
 
 if PYDANTIC_V2:
     from pydantic_core import core_schema
@@ -149,10 +148,10 @@ class DataFrameModel(BaseModel):
     __root_checks__: List[Check] = []
 
     @docstring_substitution(validate_doc=DataFrameSchema.validate.__doc__)
-    def __new__(cls, *args, **kwargs) -> DataFrameBase[TDataFrameModel]:  # type: ignore [misc]
+    def __new__(cls, *args, **kwargs) -> DataFrame[TDataFrameModel]:  # type: ignore [misc]
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel], cls.validate(*args, **kwargs)
+            DataFrame[TDataFrameModel], cls.validate(*args, **kwargs)
         )
 
     def __init_subclass__(cls, **kwargs):
@@ -299,10 +298,10 @@ class DataFrameModel(BaseModel):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-    ) -> DataFrameBase[TDataFrameModel]:
+    ) -> DataFrame[TDataFrameModel]:
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel],
+            DataFrame[TDataFrameModel],
             cls.to_schema().validate(
                 check_obj, head, tail, sample, random_state, lazy, inplace
             ),
@@ -321,10 +320,10 @@ class DataFrameModel(BaseModel):
     def example(
         cls: Type[TDataFrameModel],
         **kwargs,
-    ) -> DataFrameBase[TDataFrameModel]:
+    ) -> DataFrame[TDataFrameModel]:
         """%(example_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel], cls.to_schema().example(**kwargs)
+            DataFrame[TDataFrameModel], cls.to_schema().example(**kwargs)
         )
 
     @classmethod


### PR DESCRIPTION
`DataFrameModel.validate` returns a `DataFrame` rather than a `DataFrameBase`, which is more convenient for the user.

I assume that validate actually returns `pd.DataFrame`, but am I missing something as to why `DataFrameBase` should be used?