### PR TITLE
bugfix: add index validation to SeriesSchema

### DIFF
--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -470,7 +470,7 @@ class SeriesSchema(ArraySchema):
             inplace=inplace,
         )
         if self.index is not None:
-            validated_obj.index = self.index.validate(
+            validated_obj = self.index.validate(
                 check_obj,
                 head=head,
                 tail=tail,

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -469,6 +469,16 @@ class SeriesSchema(ArraySchema):
             lazy=lazy,
             inplace=inplace,
         )
+        if self.index is not None:
+            validated_obj.index = self.index.validate(
+                check_obj,
+                head=head,
+                tail=tail,
+                sample=sample,
+                random_state=random_state,
+                lazy=lazy,
+                inplace=inplace,
+            )
         return cast(pd.Series, validated_obj)
 
     def example(self, size=None) -> pd.Series:

--- a/pandera/backends/pandas/__init__.py
+++ b/pandera/backends/pandas/__init__.py
@@ -72,6 +72,7 @@ for t in dataframe_datatypes:
 for t in series_datatypes:
     SeriesSchema.register_backend(t, SeriesSchemaBackend)
     Column.register_backend(t, ColumnBackend)
+    MultiIndex.register_backend(t, MultiIndexBackend)
     Index.register_backend(t, IndexBackend)
 
 for t in index_datatypes:

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1643,9 +1643,9 @@ def test_lazy_dataframe_unique() -> None:
             Index(str, checks=Check.isin(["a", "b", "c"])),
             pd.DataFrame({"col": [1, 2, 3]}, index=["a", "b", "d"]),
             {
-                # expect that the data in the SchemaError is the pd.Index cast
-                # into a Series
-                "data": pd.Series(["a", "b", "d"]),
+                "data": pd.DataFrame(
+                    {"col": [1, 2, 3]}, index=["a", "b", "d"]
+                ),
                 "schema_errors": {
                     "Index": {"isin(['a', 'b', 'c'])": ["d"]},
                 },
@@ -1666,8 +1666,6 @@ def test_lazy_dataframe_unique() -> None:
                 ),
             ),
             {
-                # expect that the data in the SchemaError is the pd.MultiIndex
-                # cast into a DataFrame
                 "data": pd.DataFrame(
                     {"column": [1, 2, 3]},
                     index=pd.MultiIndex.from_arrays(
@@ -1745,12 +1743,12 @@ def test_capture_check_errors() -> None:
 @pytest.mark.parametrize(
     "from_dtype,to_dtype",
     [
-        # [float, int],
-        # [int, float],
-        # [object, int],
-        # [object, float],
+        [float, int],
+        [int, float],
+        [object, int],
+        [object, float],
         [int, object],
-        # [float, object],
+        [float, object],
     ],
 )
 def test_schema_coerce_inplace_validation(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -667,6 +667,27 @@ def test_series_schema_with_index(coerce: bool) -> None:
     assert (validated_series_multiindex.index == multi_index).all()
 
 
+def test_series_schema_with_index_errors() -> None:
+    """Test that SeriesSchema raises errors for invalid index."""
+    schema_with_index = SeriesSchema(dtype=int, index=Index(int))
+    data = pd.Series([1, 2, 3], index=[1.0, 2.0, 3.0])
+    with pytest.raises(errors.SchemaError):
+        schema_with_index(data)
+
+    schema_with_index_check = SeriesSchema(
+        dtype=int, index=Index(float, Check(lambda x: x == 1.0))
+    )
+    with pytest.raises(errors.SchemaError):
+        schema_with_index_check(data)
+
+    schema_with_index_coerce = SeriesSchema(
+        dtype=int, index=Index(int, coerce=True)
+    )
+    expected = pd.Series([1, 2, 3], index=[1, 2, 3])
+    schema_with_index_coerce(data)
+    assert schema_with_index_coerce(data).equals(expected)
+
+
 class SeriesGreaterCheck:
     # pylint: disable=too-few-public-methods
     """Class creating callable objects to check if series elements exceed a


### PR DESCRIPTION
Fixes #1523

Fixes a bug that was likely introduced by the [pandera internals rewrite](https://github.com/unionai-oss/pandera/pull/913). `SeriesSchema` objects should now do `Index` validation.