### PR TITLE
Refector the polars type engine to use LazyFrames, add support for Nested types

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,7 +199,7 @@ copybutton_prompt_is_regexp = True
 
 # this is a workaround to filter out forward reference issue in
 # sphinx_autodoc_typehints
-class FilterPandasTypeAnnotationWarning(pylogging.Filter):
+class FilterTypeAnnotationWarnings(pylogging.Filter):
     def filter(self, record: pylogging.LogRecord) -> bool:
         # You probably should make this check more specific by checking
         # that dataclass name is in the message, so that you don't filter out
@@ -225,7 +225,7 @@ class FilterPandasTypeAnnotationWarning(pylogging.Filter):
 
 
 logging.getLogger("sphinx_autodoc_typehints").logger.addFilter(
-    FilterPandasTypeAnnotationWarning()
+    FilterTypeAnnotationWarnings()
 )
 
 

--- a/docs/source/polars.rst
+++ b/docs/source/polars.rst
@@ -362,11 +362,11 @@ object-based and class-based APIs:
 
    .. testcode:: polars
 
-        schema = DataFrameSchema(
+        schema = pa.DataFrameSchema(
             {
-                "list_col": Column(pl.List(pl.Int64())),
-                "array_col": Column(pl.Array(pl.Int64(), 3)),
-                "struct_col": Column(pl.Struct({"a": pl.Utf8(), "b": pl.Float64()})),
+                "list_col": pa.Column(pl.List(pl.Int64())),
+                "array_col": pa.Column(pl.Array(pl.Int64(), 3)),
+                "struct_col": pa.Column(pl.Struct({"a": pl.Utf8(), "b": pl.Float64()})),
             },
         )
 
@@ -374,7 +374,12 @@ object-based and class-based APIs:
 
    .. testcode:: polars
 
-        class ModelWithAnnotated(DataFrameModel):
+        try:
+            from typing import Annotated  # python 3.9+
+        except ImportError:
+            from typing_extensions import Annotated
+
+        class ModelWithAnnotated(pa.DataFrameModel):
             list_col: Annotated[pl.List, pl.Int64()]
             array_col: Annotated[pl.Array, pl.Int64(), 3]
             struct_col: Annotated[pl.Struct, {"a": pl.Utf8(), "b": pl.Float64()}]
@@ -383,7 +388,7 @@ object-based and class-based APIs:
 
    .. testcode:: polars
 
-        class ModelWithDtypeKwargs(DataFrameModel):
+        class ModelWithDtypeKwargs(pa.DataFrameModel):
             list_col: pl.List = pa.Field(dtype_kwargs={"inner": pl.Int64()})
             array_col: pl.Array = pa.Field(dtype_kwargs={"inner": pl.Int64(), "width": 3})
             struct_col: pl.Struct = pa.Field(dtype_kwargs={"fields": {"a": pl.Utf8(), "b": pl.Float64()}})

--- a/docs/source/polars.rst
+++ b/docs/source/polars.rst
@@ -370,7 +370,7 @@ object-based and class-based APIs:
             },
         )
 
-.. tabbed:: DataFrameModel (Annotated Type)
+.. tabbed:: DataFrameModel (Annotated)
 
    .. testcode:: polars
 
@@ -379,7 +379,7 @@ object-based and class-based APIs:
             array_col: Annotated[pl.Array, pl.Int64(), 3]
             struct_col: Annotated[pl.Struct, {"a": pl.Utf8(), "b": pl.Float64()}]
 
-.. tabbed:: DataFrameModel (``dtype_kwargs``)
+.. tabbed:: DataFrameModel (Field)
 
    .. testcode:: polars
 

--- a/docs/source/polars.rst
+++ b/docs/source/polars.rst
@@ -322,10 +322,10 @@ present in the data.
 Supported Data Types
 --------------------
 
-``pandera`` currently supports all the `scalar data types <https://docs.pola.rs/py-polars/html/reference/datatypes.html>`__.
-`Nested data types <https://docs.pola.rs/py-polars/html/reference/datatypes.html#nested>`__
-are not yet supported. Built-in python types like ``str``, ``int``, ``float``,
-and ``bool`` will be handled in the same way that ``polars`` handles them:
+``pandera`` currently supports all of the
+`polars data types <https://docs.pola.rs/py-polars/html/reference/datatypes.html>`__.
+Built-in python types like ``str``, ``int``, ``float``, and ``bool`` will be
+handled in the same way that ``polars`` handles them:
 
 .. testcode:: polars
 
@@ -350,6 +350,44 @@ So the following schemas are equivalent:
     })
 
     assert schema1 == schema2
+
+Nested Types
+^^^^^^^^^^^^
+
+Polars nested datetypes are also supported via :ref:`parameterized data types <parameterized dtypes>`.
+See the examples below for the different ways to specify this through the
+object-based and class-based APIs:
+
+.. tabbed:: DataFrameSchema
+
+   .. testcode:: polars
+
+        schema = DataFrameSchema(
+            {
+                "list_col": Column(pl.List(pl.Int64())),
+                "array_col": Column(pl.Array(pl.Int64(), 3)),
+                "struct_col": Column(pl.Struct({"a": pl.Utf8(), "b": pl.Float64()})),
+            },
+        )
+
+.. tabbed:: DataFrameModel (Annotated Type)
+
+   .. testcode:: polars
+
+        class ModelWithAnnotated(DataFrameModel):
+            list_col: Annotated[pl.List, pl.Int64()]
+            array_col: Annotated[pl.Array, pl.Int64(), 3]
+            struct_col: Annotated[pl.Struct, {"a": pl.Utf8(), "b": pl.Float64()}]
+
+.. tabbed:: DataFrameModel (``dtype_kwargs``)
+
+   .. testcode:: polars
+
+        class ModelWithDtypeKwargs(DataFrameModel):
+            list_col: pl.List = pa.Field(dtype_kwargs={"inner": pl.Int64()})
+            array_col: pl.Array = pa.Field(dtype_kwargs={"inner": pl.Int64(), "width": 3})
+            struct_col: pl.Struct = pa.Field(dtype_kwargs={"fields": {"a": pl.Utf8(), "b": pl.Float64()}})
+
 
 Custom checks
 -------------

--- a/docs/source/reference/dtypes.rst
+++ b/docs/source/reference/dtypes.rst
@@ -92,6 +92,41 @@ Pydantic Dtypes
 
    pandera.engines.pandas_engine.PydanticModel
 
+Polars Dtypes
+-------------
+
+*new in 0.19.0*
+
+.. autosummary::
+   :toctree: generated
+   :template: dtype.rst
+   :nosignatures:
+
+   pandera.engines.polars_engine.Int8
+   pandera.engines.polars_engine.Int16
+   pandera.engines.polars_engine.Int32
+   pandera.engines.polars_engine.Int64
+   pandera.engines.polars_engine.UInt8
+   pandera.engines.polars_engine.UInt16
+   pandera.engines.polars_engine.UInt32
+   pandera.engines.polars_engine.UInt64
+   pandera.engines.polars_engine.Float32
+   pandera.engines.polars_engine.Float64
+   pandera.engines.polars_engine.Decimal
+   pandera.engines.polars_engine.Date
+   pandera.engines.polars_engine.DateTime
+   pandera.engines.polars_engine.Time
+   pandera.engines.polars_engine.Timedelta
+   pandera.engines.polars_engine.Array
+   pandera.engines.polars_engine.List
+   pandera.engines.polars_engine.Struct
+   pandera.engines.polars_engine.Bool
+   pandera.engines.polars_engine.String
+   pandera.engines.polars_engine.Categorical
+   pandera.engines.polars_engine.Category
+   pandera.engines.polars_engine.Null
+   pandera.engines.polars_engine.Object
+
 
 Utility functions
 -----------------

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -95,7 +95,8 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
             dtype = None if dtype is Any else dtype
 
             if (
-                annotation.origin is None
+                annotation.is_annotated_type
+                or annotation.origin is None
                 or annotation.origin in SERIES_TYPES
                 or annotation.raw_annotation in SERIES_TYPES
             ):

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -68,7 +68,9 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
 
             dtype = None if dtype is Any else dtype
 
-            if annotation.origin is None:
+            if annotation.origin is None or isinstance(
+                annotation.origin, pl.datatypes.DataTypeClass
+            ):
                 if check_name is False:
                     raise SchemaInitError(
                         f"'check_name' is not supported for {field_name}."

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -413,7 +413,7 @@ class Decimal(_Number):
     """The number of digits after the decimal point."""
 
     # pylint: disable=line-too-long
-    rounding: str = dataclasses.field(
+    rounding: Optional[str] = dataclasses.field(
         default_factory=lambda: decimal.getcontext().rounding
     )
     """

--- a/pandera/engines/__init__.py
+++ b/pandera/engines/__init__.py
@@ -1,6 +1,14 @@
 """Pandera type engines."""
 
-from pandera.engines.utils import pydantic_version
+import pydantic
+
+from packaging import version
+
+
+def pydantic_version():
+    """Return the pydantic version."""
+
+    return version.parse(pydantic.__version__)
 
 
 PYDANTIC_V2 = pydantic_version().release >= (2, 0, 0)

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -1,25 +1,73 @@
 """Polars engine and data types."""
+
 import dataclasses
 import datetime
 import decimal
 import inspect
 import warnings
-from typing import Any, Union, Optional, Iterable, Literal
+from typing import Any, Union, Optional, Iterable, Literal, Sequence
 
 
 import polars as pl
 from polars.datatypes import py_type_to_dtype
+from polars.type_aliases import SchemaDict
 
 from pandera import dtypes, errors
+from pandera.api.polars.types import PolarsData
 from pandera.dtypes import immutable
 from pandera.engines import engine
-from pandera.engines.type_aliases import PolarsObject
-from pandera.engines.utils import (
-    polars_coerce_failure_cases,
-    polars_object_coercible,
-    polars_failure_cases_from_coercible,
-    check_polars_container_all_true,
-)
+
+
+PolarsDataContainer = Union[pl.LazyFrame, PolarsData]
+COERCIBLE_KEY = "_is_coercible"
+
+
+def polars_object_coercible(
+    data_container: PolarsData, type_: pl.datatypes.DataTypeClass
+) -> pl.LazyFrame:
+    """Checks whether a polars object is coercible with respect to a type."""
+    key = data_container.key or "*"
+    coercible = data_container.lazyframe.cast(
+        {key: type_}, strict=False
+    ).select(pl.col(key).is_not_null())
+    # reduce to a single boolean column
+    return coercible.select(pl.all_horizontal(key).alias(COERCIBLE_KEY))
+
+
+def polars_failure_cases_from_coercible(
+    data_container: PolarsData,
+    is_coercible: pl.LazyFrame,
+) -> pl.LazyFrame:
+    """Get the failure cases resulting from trying to coerce a polars object."""
+    return data_container.lazyframe.with_context(is_coercible).filter(
+        pl.col(COERCIBLE_KEY).not_()
+    )
+
+
+def polars_coerce_failure_cases(
+    data_container: PolarsData,
+    type_: Any,
+) -> pl.DataFrame:
+    """
+    Get the failure cases resulting from trying to coerce a polars object
+    into particular data type.
+    """
+    try:
+        is_coercible = polars_object_coercible(data_container, type_)
+        failure_cases = polars_failure_cases_from_coercible(
+            data_container, is_coercible
+        ).collect()
+    except (
+        TypeError,
+        pl.ArrowError,
+        pl.InvalidOperationError,
+        pl.ComputeError,
+    ):
+        # If coercion fails, all of the relevant rows are failure cases
+        failure_cases = data_container.lazyframe.select(
+            data_container.key or "*"
+        ).collect()
+    return failure_cases
 
 
 @immutable(init=True)
@@ -49,21 +97,34 @@ class DataType(dtypes.DataType):
             self, "type", py_type_to_dtype(self.type)
         )  # pragma: no cover
 
-    def coerce(self, data_container: PolarsObject) -> PolarsObject:
+    def coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container to the data type."""
-        return data_container.cast(self.type, strict=True)
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
 
-    def try_coerce(self, data_container: PolarsObject) -> PolarsObject:
+        if data_container.key is None:
+            dtypes = self.type
+        else:
+            dtypes = {data_container.key: self.type}
+
+        return data_container.lazyframe.cast(dtypes, strict=True)
+
+    def try_coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container to the data type,
         raises a :class:`~pandera.errors.ParserError` if the coercion fails
         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
         """
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
+
         try:
-            return self.coerce(data_container)
+            lf = self.coerce(data_container)
+            lf.collect()
+            return lf
         except Exception as exc:  # pylint:disable=broad-except
             raise errors.ParserError(
-                f"Could not coerce {type(data_container)} data_container "
-                f"into type {self.type}",
+                f"Could not coerce {type(data_container.lazyframe)} "
+                f"data_container into type {self.type}",
                 failure_cases=polars_coerce_failure_cases(
                     data_container=data_container, type_=self.type
                 ),
@@ -72,7 +133,7 @@ class DataType(dtypes.DataType):
     def check(
         self,
         pandera_dtype: dtypes.DataType,
-        data_container: Optional[PolarsObject] = None,
+        data_container: Optional[PolarsDataContainer] = None,
     ) -> Union[bool, Iterable[bool]]:
         try:
             pandera_dtype = Engine.dtype(pandera_dtype)
@@ -236,15 +297,17 @@ class Float64(DataType, dtypes.Float64):
 class Decimal(DataType, dtypes.Decimal):
     """Polars decimal data type."""
 
-    type = pl.Float64
+    type = pl.Decimal
 
     def __init__(  # pylint:disable=super-init-not-called
         self,
         precision: int = dtypes.DEFAULT_PYTHON_PREC,
         scale: int = 0,
     ) -> None:
-        dtypes.Decimal.__init__(
-            self, precision=precision, scale=scale, rounding=None
+        object.__setattr__(self, "precision", precision)
+        object.__setattr__(self, "scale", scale)
+        object.__setattr__(
+            self, "type", pl.Decimal(precision=precision, scale=scale)
         )
 
     @classmethod
@@ -253,17 +316,21 @@ class Decimal(DataType, dtypes.Decimal):
         a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
         return cls(precision=polars_dtype.precision, scale=polars_dtype.scale)
 
-    def coerce(self, data_container: PolarsObject) -> PolarsObject:
+    def coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container to the data type."""
-        data_container = data_container.cast(pl.Float64)
-        return data_container.cast(
-            pl.Decimal(scale=self.scale, precision=self.precision), strict=True
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
+
+        key = data_container.key or "*"
+        return data_container.lazyframe.cast({key: pl.Float64}).cast(
+            {key: pl.Decimal(scale=self.scale, precision=self.precision)},
+            strict=True,
         )
 
     def check(
         self,
         pandera_dtype: dtypes.DataType,
-        data_container: Any = None,  # pylint: disable=unused-argument)
+        data_container: Optional[PolarsDataContainer] = None,
     ) -> Union[bool, Iterable[bool]]:
         try:
             pandera_dtype = Engine.dtype(pandera_dtype)
@@ -390,6 +457,72 @@ class Timedelta(DataType, dtypes.Timedelta):
 ###############################################################################
 
 
+@Engine.register_dtype(equivalents=[pl.Array])
+@immutable(init=True)
+class Array(DataType):
+    """Polars datetime data type."""
+
+    type = pl.Array
+
+    def __init__(  # pylint:disable=super-init-not-called
+        self,
+        inner: Optional[pl.PolarsDataType] = None,
+        width: Optional[int] = None,
+    ) -> None:
+        if inner or width:
+            object.__setattr__(
+                self, "type", pl.Array(inner=inner, width=width)
+            )
+
+    @classmethod
+    def from_parametrized_dtype(cls, polars_dtype: pl.Array):
+        """Convert a :class:`polars.Decimal` to
+        a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
+        return cls(inner=polars_dtype.inner, width=polars_dtype.width)
+
+
+@Engine.register_dtype(equivalents=[pl.List])
+@immutable(init=True)
+class List(DataType):
+    """Polars datetime data type."""
+
+    type = pl.List
+
+    def __init__(  # pylint:disable=super-init-not-called
+        self,
+        inner: Optional[pl.PolarsDataType] = None,
+    ) -> None:
+        if inner:
+            object.__setattr__(self, "type", pl.List(inner=inner))
+
+    @classmethod
+    def from_parametrized_dtype(cls, polars_dtype: pl.List):
+        """Convert a :class:`polars.Decimal` to
+        a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
+        return cls(inner=polars_dtype.inner)
+
+
+@Engine.register_dtype(equivalents=[pl.Struct])
+@immutable(init=True)
+class Struct(DataType):
+    """Polars datetime data type."""
+
+    type = pl.Struct
+
+    def __init__(  # pylint:disable=super-init-not-called
+        self,
+        fields: Optional[Sequence[pl.Field] | SchemaDict] = None,
+    ) -> None:
+        if fields:
+            object.__setattr__(self, "type", pl.Struct(fields=fields))
+
+    @classmethod
+    def from_parametrized_dtype(cls, polars_dtype: pl.Struct):
+        """Convert a :class:`polars.Decimal` to
+        a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
+        return cls(fields=polars_dtype.fields)
+
+
 ###############################################################################
 # Other types
 ###############################################################################
@@ -437,31 +570,46 @@ class Category(DataType, dtypes.Category):
     ):
         dtypes.Category.__init__(self, categories, ordered=False)
 
-    def coerce(self, data_container: PolarsObject) -> PolarsObject:
+    def coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container to the data type."""
-        data_container = data_container.cast(self.type, strict=True)
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
 
-        belongs_to_categories = self.__belongs_to_categories(data_container)
+        lf = data_container.lazyframe.cast(self.type, strict=True)
 
-        if not check_polars_container_all_true(belongs_to_categories):
+        key = data_container.key or "*"
+        belongs_to_categories = self.__belongs_to_categories(lf, key=key)
+
+        all_true = (
+            belongs_to_categories.select(pl.all_horizontal(key))
+            .select(pl.all().all())
+            .collect()
+            .item()
+        )
+        if not all_true:
             raise ValueError(
-                f"Could not coerce {type(data_container)} data_container "
+                f"Could not coerce {type(lf)} data_container "
                 f"into type {self.type}. Invalid categories found in data_container."
             )
-        return data_container
+        return lf
 
-    def try_coerce(self, data_container: PolarsObject) -> PolarsObject:
+    def try_coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container to the data type,
 
         raises a :class:`~pandera.errors.ParserError` if the coercion fails
         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
         """
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
+
         try:
             return self.coerce(data_container)
         except Exception as exc:  # pylint:disable=broad-except
-            is_coercible: PolarsObject = polars_object_coercible(
+            is_coercible: pl.LazyFrame = polars_object_coercible(
                 data_container, self.type
-            ) & self.__belongs_to_categories(data_container)
+            ) & self.__belongs_to_categories(
+                data_container.lazyframe, key=data_container.key
+            )
 
             failure_cases = polars_failure_cases_from_coercible(
                 data_container, is_coercible
@@ -473,18 +621,11 @@ class Category(DataType, dtypes.Category):
             ) from exc
 
     def __belongs_to_categories(
-        self, data_container: PolarsObject
-    ) -> PolarsObject:
-        if isinstance(data_container, pl.Series):
-            belongs_to_categories = data_container.is_in(self.categories)
-        else:
-            belongs_to_categories = pl.DataFrame(
-                {
-                    column: data_container[column].is_in(self.categories)
-                    for column in data_container.columns
-                }
-            )
-        return belongs_to_categories
+        self,
+        lf: pl.LazyFrame,
+        key: Optional[str] = None,
+    ) -> pl.LazyFrame:
+        return lf.select(pl.col(key or "*").is_in(self.categories))
 
     def __str__(self):
         return "Category"

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -512,7 +512,7 @@ class Struct(DataType):
 
     def __init__(  # pylint:disable=super-init-not-called
         self,
-        fields: Optional[Sequence[pl.Field] | SchemaDict] = None,
+        fields: Optional[Union[Sequence[pl.Field], SchemaDict]] = None,
     ) -> None:
         if fields:
             object.__setattr__(self, "type", pl.Struct(fields=fields))

--- a/pandera/engines/type_aliases.py
+++ b/pandera/engines/type_aliases.py
@@ -12,19 +12,9 @@ try:
 except ImportError:  # pragma: no cover
     PYSPARK_INSTALLED = False
 
-try:
-    import polars as pl
-
-    POLARS_INSTALLED = True
-except ImportError:  # pragma: no cover
-    POLARS_INSTALLED = False
-
 PandasObject = Union[pd.Series, pd.DataFrame]
 PandasExtensionType = pd.core.dtypes.base.ExtensionDtype
 PandasDataType = Union[pd.core.dtypes.base.ExtensionDtype, np.dtype, type]
 
 if PYSPARK_INSTALLED:
     PysparkObject = Union[DataFrame]
-
-if POLARS_INSTALLED:
-    PolarsObject = Union[pl.Series, pl.DataFrame, pl.LazyFrame]

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -254,11 +254,10 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.args = args
         self.arg = args[0] if args else args
 
-        self.metadata = getattr(self.arg, "__metadata__", None)
+        self.metadata = getattr(raw_annotation, "__metadata__", None)
         self.literal = typing_inspect.is_literal_type(self.arg)
-        if self.metadata:
-            self.arg = typing_inspect.get_args(self.arg)[0]
-        elif self.literal:
+
+        if self.literal:
             self.arg = typing_inspect.get_args(self.arg)[0]
         elif self.origin is None:
             if isinstance(raw_annotation, type) and issubclass(

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -241,6 +241,7 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         """
         self.raw_annotation = raw_annotation
         self.origin = self.arg = None
+        self.is_annotated_type = False
 
         self.optional = typing_inspect.is_optional_type(raw_annotation)
         if self.optional and typing_inspect.is_union_type(raw_annotation):
@@ -254,12 +255,18 @@ class AnnotationInfo:  # pylint:disable=too-few-public-methods
         self.args = args
         self.arg = args[0] if args else args
 
-        self.metadata = getattr(raw_annotation, "__metadata__", None)
+        metadata = getattr(raw_annotation, "__metadata__", None)
+        if metadata:
+            self.is_annotated_type = True
+        else:
+            metadata = getattr(self.arg, "__metadata__", None)
+
+        self.metadata = metadata
         self.literal = typing_inspect.is_literal_type(self.arg)
 
         if self.literal:
             self.arg = typing_inspect.get_args(self.arg)[0]
-        elif self.origin is None:
+        elif self.origin is None and self.metadata is None:
             if isinstance(raw_annotation, type) and issubclass(
                 raw_annotation, SeriesBase
             ):

--- a/tests/core/test_pydantic.py
+++ b/tests/core/test_pydantic.py
@@ -7,7 +7,7 @@ import pytest
 
 import pandera as pa
 from pandera.typing import DataFrame, Series
-from pandera.engines.utils import pydantic_version
+from pandera.engines import pydantic_version
 
 try:
     from pydantic import BaseModel, ValidationError

--- a/tests/geopandas/test_geopandas.py
+++ b/tests/geopandas/test_geopandas.py
@@ -175,7 +175,7 @@ def test_schema_parametrized_crs():
 
     class Schema2(pa.DataFrameModel):
         # pylint: disable=missing-class-docstring
-        geometry: Annotated[GeoSeries, "EPSG:4326"]
+        geometry: Annotated[Geometry, "EPSG:4326"]
 
     assert isinstance(GeoDataFrame[Schema2](gdf), gpd.GeoDataFrame)
 

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-outer-name
 """Unit tests for polars container."""
 
-from typing import Optional
+from typing import Annotated, Optional
 
 import polars as pl
 
@@ -9,7 +9,7 @@ import pytest
 import pandera as pa
 from pandera import Check as C
 from pandera.api.polars.types import PolarsData
-from pandera.polars import Column, DataFrameSchema
+from pandera.polars import Column, DataFrameSchema, DataFrameModel
 
 
 @pytest.fixture
@@ -423,3 +423,63 @@ def test_lazy_validation_errors():
         schema.validate(invalid_lf, lazy=True)
     except pa.errors.SchemaErrors as exc:
         assert exc.failure_cases.shape[0] == 6
+
+
+@pytest.fixture
+def lf_with_nested_types():
+    return pl.LazyFrame(
+        {
+            "list_col": [[1, 2], [4, 5, 6, 5]],
+            "array_col": [[1, 2, 3], [4, 5, 6]],
+            "struct_col": [{"a": "a", "b": 1.0}, {"a": "b", "b": 2.0}],
+        }
+    )
+
+
+def test_dataframe_schema_with_nested_types(lf_with_nested_types):
+
+    schema = DataFrameSchema(
+        {
+            "list_col": Column(pl.List(pl.Int64())),
+            "array_col": Column(pl.Array(pl.Int64(), 3)),
+            "struct_col": Column(
+                pl.Struct({"a": pl.Utf8(), "b": pl.Float64()})
+            ),
+        },
+        coerce=True,
+    )
+
+    validated_lf = schema.validate(lf_with_nested_types, lazy=True)
+    assert validated_lf.collect().equals(lf_with_nested_types.collect())
+
+
+def test_dataframe_model_with_annotated_nested_types(lf_with_nested_types):
+    class ModelWithAnnotated(DataFrameModel):
+        list_col: Annotated[pl.List, pl.Int64()]
+        array_col: Annotated[pl.Array, pl.Int64(), 3]
+        struct_col: Annotated[pl.Struct, {"a": pl.Utf8(), "b": pl.Float64()}]
+
+        class Config:
+            coerce = True
+
+    validated_lf = ModelWithAnnotated.validate(lf_with_nested_types, lazy=True)
+    assert validated_lf.collect().equals(validated_lf.collect())
+
+
+def test_dataframe_schema_with_kwargs_nested_types(lf_with_nested_types):
+    class ModelWithDtypeKwargs(DataFrameModel):
+        list_col: pl.List = pa.Field(dtype_kwargs={"inner": pl.Int64()})
+        array_col: pl.Array = pa.Field(
+            dtype_kwargs={"inner": pl.Int64(), "width": 3}
+        )
+        struct_col: pl.Struct = pa.Field(
+            dtype_kwargs={"fields": {"a": pl.Utf8(), "b": pl.Float64()}}
+        )
+
+        class Config:
+            coerce = True
+
+    validated_lf = ModelWithDtypeKwargs.validate(
+        lf_with_nested_types, lazy=True
+    )
+    assert validated_lf.collect().equals(validated_lf.collect())

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -1,7 +1,12 @@
 # pylint: disable=redefined-outer-name
 """Unit tests for polars container."""
 
-from typing import Annotated, Optional
+from typing import Optional
+
+try:
+    from typing import Annotated  # type: ignore
+except ImportError:
+    from typing_extensions import Annotated  # type: ignore
 
 import polars as pl
 

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -1,23 +1,21 @@
 """Polars dtype tests."""
 import decimal
-import itertools
-import random
 from decimal import Decimal
 from typing import Union, Tuple, Sequence
-from unittest.mock import patch
 
 from hypothesis import strategies as st, settings
 import pytest
 from hypothesis import given
-from polars.testing import assert_frame_equal, assert_series_equal
-from polars.testing.parametric import dataframes, series
+from polars.testing import assert_frame_equal
+from polars.testing.parametric import dataframes
 import polars as pl
 
 import pandera.errors
+from pandera.api.polars.types import PolarsData
 from pandera.engines import polars_engine as pe
-from pandera.engines.utils import (
-    polars_series_coercible,
+from pandera.engines.polars_engine import (
     polars_object_coercible,
+    COERCIBLE_KEY,
 )
 
 
@@ -64,93 +62,46 @@ special_types = [
 all_types = numeric_dtypes + temporal_types + other_types
 
 
-def get_series_strategy(type_: pl.DataType) -> st.SearchStrategy:
-    """Get a strategy for a polars series of a given dtype."""
-    return series(allowed_dtypes=type_, null_probability=0.1, size=100)
-
-
 def get_dataframe_strategy(type_: pl.DataType) -> st.SearchStrategy:
     """Get a strategy for a polars dataframe of a given dtype."""
     return dataframes(
-        cols=2, allowed_dtypes=type_, null_probability=0.1, size=100
-    )
-
-
-def get_decimal_series(size: int, precision: int, scale: int) -> pl.Series:
-    """Generate a polars series of decimal numbers."""
-    decimal.getcontext().prec = precision
-
-    max_value = 10 ** (precision - scale) - 1
-    return pl.Series(
-        [
-            convert_object_to_decimal(
-                random.randrange(0, max_value) / max_value,
-                precision=precision,
-                scale=scale,
-            )
-            for _ in range(size)
-        ],
-        dtype=pl.Decimal(scale=scale, precision=precision),
+        cols=2, lazy=True, allowed_dtypes=type_, null_probability=0.1, size=10
     )
 
 
 # Hypothesis slow if test is failing
-@pytest.mark.parametrize(
-    "dtype, strategy",
-    list(
-        itertools.product(
-            all_types, [get_dataframe_strategy, get_series_strategy]
-        )
-    ),
-)
+@pytest.mark.parametrize("dtype", all_types)
 @given(st.data())
-@settings(max_examples=5)
-def test_coerce_no_cast(dtype, strategy, data):
+@settings(max_examples=1)
+def test_coerce_no_cast(dtype, data):
     """Test that dtypes can be coerced without casting."""
     pandera_dtype = dtype()
-
-    df = data.draw(strategy(type_=pandera_dtype.type))
-
-    coerced = pandera_dtype.coerce(data_container=df)
-
-    if isinstance(df, pl.DataFrame):
-        assert_frame_equal(df, coerced)
-    else:
-        assert_series_equal(df, coerced)
+    df = data.draw(get_dataframe_strategy(type_=pandera_dtype.type))
+    coerced = pandera_dtype.coerce(data_container=PolarsData(df))
+    assert_frame_equal(df, coerced)
 
 
 @pytest.mark.parametrize(
     "to_dtype, strategy",
     [
-        (pe.Null(), pl.Series([None, None, None], dtype=pl.Null)),
-        (pe.Null(), pl.DataFrame({"0": [None, None, None]})),
-        (pe.Object(), pl.Series([1, 2, 3], dtype=pl.Object)),
-        (pe.Object(), pl.DataFrame({"0": [1, 2, 3]}, schema={"0": pl.Object})),
-        (
-            pe.Decimal(precision=6, scale=5),
-            get_decimal_series(size=5, precision=6, scale=5),
-        ),
+        (pe.Null(), pl.LazyFrame([[None, None, None]])),
+        (pe.Object(), pl.LazyFrame([[1, 2, 3]]).cast(pl.Object)),
         (
             pe.Category(categories=["a", "b", "c"]),
-            pl.Series(["a", "b", "c"], dtype=pl.Utf8),
+            pl.LazyFrame([["a", "b", "c"]]).cast(pl.Utf8),
         ),
     ],
 )
 def test_coerce_no_cast_special(to_dtype, strategy):
     """Test that dtypes can be coerced without casting."""
     coerced = to_dtype.coerce(data_container=strategy)
-
-    if isinstance(strategy, pl.Series):
-        assert coerced.dtype == to_dtype.type
-    else:
-        assert coerced[coerced.columns[0]].dtype == to_dtype.type
+    for dtype in coerced.dtypes:
+        assert dtype == to_dtype.type
 
 
 @pytest.mark.parametrize(
     "from_dtype, to_dtype, strategy",
     [
-        (pe.Int16(), pe.Int32(), get_series_strategy),
-        (pe.UInt16(), pe.Int64(), get_series_strategy),
         (pe.UInt32(), pe.UInt64(), get_dataframe_strategy),
         (pe.Float32(), pe.Float64(), get_dataframe_strategy),
         (pe.String(), pe.Categorical(), get_dataframe_strategy),
@@ -164,11 +115,8 @@ def test_coerce_cast(from_dtype, to_dtype, strategy, data):
     s = data.draw(strategy(from_dtype.type))
 
     coerced = to_dtype.coerce(data_container=s)
-
-    if isinstance(s, pl.Series):
-        assert coerced.dtype == to_dtype.type
-    else:
-        assert coerced[coerced.columns[0]].dtype == to_dtype.type
+    for dtype in coerced.dtypes:
+        assert dtype == to_dtype.type
 
 
 @pytest.mark.parametrize(
@@ -176,11 +124,11 @@ def test_coerce_cast(from_dtype, to_dtype, strategy, data):
     [
         (
             pe.Decimal(precision=3, scale=2),
-            pl.Series(["1.11111", "2.22222", "3.33333"]),
+            pl.LazyFrame([["1.11111", "2.22222", "3.33333"]]),
         ),
         (
             pe.Category(categories=["a", "b", "c"]),
-            pl.Series(["a", "b", "c"]),
+            pl.LazyFrame([["a", "b", "c"]]),
         ),
     ],
 )
@@ -188,73 +136,57 @@ def test_coerce_cast_special(pandera_dtype, data_container):
     """Test that dtypes can be coerced with casting."""
     coerced = pandera_dtype.coerce(data_container=data_container)
 
-    assert coerced.dtype == pandera_dtype.type
+    for dtype in coerced.dtypes:
+        assert dtype == pandera_dtype.type
 
-    data_container = pl.DataFrame(
-        {
-            "0": data_container,
-            "1": data_container,
-        }
-    )
-
-    coerced = pandera_dtype.coerce(data_container=data_container)
-
-    assert coerced["0"].dtype == pandera_dtype.type
+    if isinstance(pandera_dtype, pe.Decimal):
+        # collecting a LazyFrame with decimal type has a bug that casts to
+        # pl.Float64
+        df = coerced.collect()
+        for dtype in df.dtypes:
+            assert dtype == pl.Float64
 
 
 @pytest.mark.parametrize(
-    "pl_to_dtype, container",
+    "pl_to_dtype, container, exception_cls",
     [
-        (pe.Int8(), pl.Series([1000, 100, 200], dtype=pl.Int64)),
-        (pe.Bool(), pl.Series(["a", "b", "c"], dtype=pl.Utf8)),
-        (pe.Int64(), pl.Series(["1", "b"])),
-        (pe.Decimal(precision=2, scale=1), pl.Series([100.11, 2, 3])),
+        (pe.Int8(), pl.LazyFrame({"0": [1000, 100, 200]}), pl.ComputeError),
+        (
+            pe.Bool(),
+            pl.LazyFrame({"0": ["a", "b", "c"]}),
+            pl.InvalidOperationError,
+        ),
+        (pe.Int64(), pl.LazyFrame({"0": ["1", "b"]}), pl.ComputeError),
+        (
+            pe.Decimal(precision=2, scale=1),
+            pl.LazyFrame({"0": [100.11, 2, 3]}),
+            pl.ComputeError,
+        ),
         (
             pe.Category(categories=["a", "b", "c"]),
-            pl.Series(["a", "b", "c", "f"]),
+            pl.LazyFrame({"0": ["a", "b", "c", "f"]}),
+            ValueError,
         ),
     ],
 )
-def test_coerce_cast_failed(pl_to_dtype, container):
+def test_coerce_cast_failed(pl_to_dtype, container, exception_cls):
     """Test that dtypes fail when not data is not coercible."""
-    error = None
-
-    try:
-        pl_to_dtype.coerce(data_container=container)
-    except Exception as e:  # pylint: disable=broad-except
-        error = e
-
-    assert error is not None
-
-    container = pl.DataFrame({"0": container, "1": container})
-
-    try:
-        pl_to_dtype.coerce(data_container=container)
-    except Exception as e:  # pylint: disable=broad-except
-        error = e
-
-    assert error is not None
+    with pytest.raises(exception_cls):
+        pl_to_dtype.coerce(data_container=container).collect()
 
 
 @pytest.mark.parametrize(
     "to_dtype, container",
     [
-        (pe.Int8(), pl.Series([1000, 100, 200], dtype=pl.Int64)),
-        (pe.Bool(), pl.Series(["a", "b", "c"], dtype=pl.Utf8)),
-        (pe.Int64(), pl.DataFrame({"0": ["1", "b"], "1": ["c", "d"]})),
+        (pe.Int8(), pl.LazyFrame({"0": [1000, 100, 200]})),
+        (pe.Bool(), pl.LazyFrame({"0": ["a", "b", "c"]})),
+        (pe.Int64(), pl.LazyFrame({"0": ["1", "b"], "1": ["c", "d"]})),
     ],
 )
-@patch("pandera.engines.polars_engine.polars_coerce_failure_cases")
-def test_try_coerce_cast_failed(_, to_dtype, container):
+def test_try_coerce_cast_failed(to_dtype, container):
     """Test that try_coerce() raises ParserError when not coercible."""
-    error = None
-
-    try:
+    with pytest.raises(pandera.errors.ParserError):
         to_dtype.try_coerce(data_container=container)
-    except pandera.errors.ParserError as e:
-        error = e
-
-    assert error is not None
 
 
 @pytest.mark.parametrize("dtype", all_types + special_types)
@@ -309,92 +241,165 @@ def test_check_equivalent_custom(first_dtype, second_dtype, equivalent):
 
 
 @pytest.mark.parametrize(
-    "to_dtype, container",
-    [
-        (pe.UInt32, pl.Series([1000, 100, 200], dtype=pl.Int32)),
-        (pe.Int64, pl.Series([1000, 100, 200], dtype=pl.UInt32)),
-        (pe.Int16, pl.Series(["1", "2", "3"], dtype=pl.Utf8)),
-        (pe.Categorical, pl.Series(["False", "False"])),
-        (pe.Float32, pl.Series([None, "1"])),
-    ],
-)
-def test_polars_series_coercible(to_dtype, container):
-    """Test that polars_series_coercible can detect that a series is coercible."""
-    is_coercible = polars_series_coercible(container, to_dtype.type)
-    assert isinstance(is_coercible, pl.Series)
-    assert is_coercible.dtype == pl.Boolean
-
-    assert is_coercible.all() is True
-
-
-@pytest.mark.parametrize(
     "to_dtype, container, result",
     [
         (
-            pe.Bool,
-            pl.Series(["False", "False"]),
-            pl.Series([False, False]),
-        ),  # This tests for Pyarrow error
-        (
-            pe.Int64,
-            pl.Series([None, "False", "1"]),
-            pl.Series([True, False, True]),
-        ),
-        (pe.UInt8, pl.Series([266, 255, 1]), pl.Series([False, True, True])),
-    ],
-)
-def test_polars_series_not_coercible(to_dtype, container, result):
-    """Test that polars_series_coercible can detect that a series is not coercible."""
-    is_coercible = polars_series_coercible(container, to_dtype.type)
-    assert isinstance(is_coercible, pl.Series)
-    assert is_coercible.dtype == pl.Boolean
-
-    assert is_coercible.all() is False
-    assert_series_equal(is_coercible, result)
-
-
-@pytest.mark.parametrize(
-    "to_dtype, container, result",
-    [
-        (
-            pe.UInt32,
-            pl.DataFrame(
+            pl.UInt32,
+            pl.LazyFrame(
                 data={"0": [1000, 100, 200], "1": [1000, 100, 200]},
                 schema={"0": pl.Int32, "1": pl.Int32},
             ),
-            pl.DataFrame(
-                data={"0": [True, True, True], "1": [True, True, True]},
-                schema={"0": pl.Boolean, "1": pl.Boolean},
-            ),
+            pl.LazyFrame({COERCIBLE_KEY: [True, True, True]}),
         ),
         (
             pl.Int64,
-            pl.Series([1000, 100, 200], dtype=pl.Int32),
-            pl.Series([True, True, True]),
+            pl.LazyFrame(
+                data={"0": [1000, 100, 200]},
+                schema={"0": pl.Int32},
+            ),
+            pl.LazyFrame({COERCIBLE_KEY: [True, True, True]}),
         ),
         (
-            pe.UInt32,
-            pl.DataFrame(
+            pl.UInt32,
+            pl.LazyFrame(
                 data={"0": ["1000", "a", "200"], "1": ["1000", "100", "c"]},
                 schema={"0": pl.Utf8, "1": pl.Utf8},
             ),
-            pl.DataFrame(
-                data={"0": [True, False, True], "1": [True, True, False]},
-                schema={"0": pl.Boolean, "1": pl.Boolean},
-            ),
+            pl.LazyFrame({COERCIBLE_KEY: [True, False, False]}),
         ),
         (
             pl.Int64,
-            pl.Series(["d", "100", "200"], dtype=pl.Utf8),
-            pl.Series([False, True, True]),
+            pl.LazyFrame(data={"0": ["d", "100", "200"]}),
+            pl.LazyFrame({COERCIBLE_KEY: [False, True, True]}),
         ),
     ],
 )
 def test_polars_object_coercible(to_dtype, container, result):
-    """Test that polars_object_coercible can detect that a polars object is coercible or not."""
-    is_coercible = polars_object_coercible(container, to_dtype)
+    """
+    Test that polars_object_coercible can detect that a polars object is
+    coercible or not.
+    """
+    is_coercible = polars_object_coercible(PolarsData(container), to_dtype)
+    assert_frame_equal(is_coercible, result)
 
-    if isinstance(container, pl.DataFrame):
-        assert_frame_equal(is_coercible, result)
-    else:
-        assert_series_equal(is_coercible, result)
+
+@pytest.mark.parametrize(
+    "inner_dtype_cls",
+    [
+        pl.Utf8,
+        *pl.NUMERIC_DTYPES,
+    ],
+)
+@given(st.integers(min_value=2, max_value=10))
+@settings(max_examples=5)
+def test_polars_nested_array_type_check(inner_dtype_cls, width):
+    polars_dtype = pl.Array(inner_dtype_cls(), width)
+    pandera_dtype = pe.Engine.dtype(polars_dtype)
+
+    assert pandera_dtype.check(polars_dtype)
+    assert pandera_dtype.check(pandera_dtype)
+    assert not pandera_dtype.check(inner_dtype_cls)
+    assert not pandera_dtype.check(inner_dtype_cls())
+
+
+@pytest.mark.parametrize(
+    "inner_dtype_cls",
+    [
+        pl.Utf8,
+        *pl.NUMERIC_DTYPES,
+    ],
+)
+def test_polars_list_nested_type(inner_dtype_cls):
+    polars_dtype = pl.List(inner_dtype_cls())
+    pandera_dtype = pe.Engine.dtype(polars_dtype)
+
+    assert pandera_dtype.check(polars_dtype)
+    assert pandera_dtype.check(pandera_dtype)
+    assert not pandera_dtype.check(inner_dtype_cls)
+    assert not pandera_dtype.check(inner_dtype_cls())
+
+
+@pytest.mark.parametrize(
+    "inner_dtype_cls",
+    [
+        pl.Utf8,
+        *pl.NUMERIC_DTYPES,
+    ],
+)
+def test_polars_struct_nested_type(inner_dtype_cls):
+    polars_dtype = pl.Struct({k: inner_dtype_cls() for k in "abc"})
+    pandera_dtype = pe.Engine.dtype(polars_dtype)
+
+    assert pandera_dtype.check(polars_dtype)
+    assert pandera_dtype.check(pandera_dtype)
+    assert not pandera_dtype.check(inner_dtype_cls)
+    assert not pandera_dtype.check(inner_dtype_cls())
+
+
+@pytest.mark.parametrize(
+    "coercible_dtype, noncoercible_dtype, data",
+    [
+        # Array
+        [
+            pl.Array(pl.Int64(), 2),
+            pl.Array(pl.Int64(), 3),
+            pl.LazyFrame({"a": [[1, 2], [3, 4]]}),
+        ],
+        [
+            pl.Array(pl.Int32(), 1),
+            pl.Array(pl.Int32(), 2),
+            pl.LazyFrame({"a": [["1"], ["3"]]}),
+        ],
+        [
+            pl.Array(pl.Float64(), 3),
+            pl.Array(pl.Float64(), 5),
+            pl.LazyFrame({"a": [[1.0, 2.0, 3.1], [3.0, 4.0, 5.1]]}),
+        ],
+        # List
+        [
+            pl.List(pl.Utf8()),
+            pl.List(pl.Int64()),
+            pl.LazyFrame({"0": [[*"abc"]]}),
+        ],
+        [
+            pl.List(pl.Utf8()),
+            pl.List(pl.Boolean()),
+            pl.LazyFrame({"0": [[*"xyz"]]}),
+        ],
+        [
+            pl.List(pl.Float64()),
+            pl.List(pl.Object()),
+            pl.LazyFrame({"0": [[1.0, 2.0, 3.0]]}),
+        ],
+        # Struct
+        [
+            pl.Struct({"a": pl.Utf8(), "b": pl.Int64(), "c": pl.Float64()}),
+            pl.Struct({"a": pl.Utf8()}),
+            pl.LazyFrame({"0": [{"a": "foo", "b": 1, "c": 1.0}]}),
+        ],
+        [
+            pl.Struct({"a": pl.Utf8(), "b": pl.List(pl.Int64())}),
+            pl.Struct({"c": pl.Float64()}),
+            pl.LazyFrame({"0": [{"a": "foo", "b": [1, 2, 3]}]}),
+        ],
+        [
+            pl.Struct({"a": pl.Array(pl.Int64(), 2), "b": pl.Utf8()}),
+            pl.Struct({"d": pl.Utf8()}),
+            pl.LazyFrame({"0": [{"a": [1, 2], "b": "foo"}]}),
+        ],
+    ],
+)
+def test_polars_nested_dtypes_try_coercion(
+    coercible_dtype,
+    noncoercible_dtype,
+    data,
+):
+    pandera_dtype = pe.Engine.dtype(coercible_dtype)
+    coerced_data = pandera_dtype.try_coerce(PolarsData(data))
+    assert coerced_data.collect().equals(data.collect())
+
+    # coercing data with invalid type should raise an error
+    try:
+        pe.Engine.dtype(noncoercible_dtype).try_coerce(PolarsData(data))
+    except pandera.errors.ParserError as exc:
+        assert exc.failure_cases.equals(data.collect())


### PR DESCRIPTION
This PR refactors the `polars_engine.py` module to primarily support `pl.LazyFrame` objects. This is done to better-align with the polars backend implementation, which uses the polars lazy API as much as possible, only performing `.collect()` calls when data values need to be operated on.

This is beneficial because:
- It reduces the complexity of the code: eventual support for `pl.Series` can simply leverage all the the existing code via a thin wrapper that does `pl.Series(...).to_frame().lazy()`.
- It also sets the polars integration up for potential optimizations in the validation backend implementation: the current structure was modelled from eagerly-exectued dataframes (i.e. pandas DataFrames). It's yet unclear what these optimizations might be, but leveraging the lazy API would be a prerequisite.

This PR also adds support for [nested datatypes](https://docs.pola.rs/py-polars/html/reference/datatypes.html#nested), with test and docs updates.