### PR TITLE
Polars LazyFrames are validated at the schema-level by default

### DIFF
--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -467,11 +467,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -471,11 +471,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.10-pandas2.0.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.0.3-pydantic1.10.11.txt
@@ -467,11 +467,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.10-pandas2.0.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.0.3-pydantic2.3.0.txt
@@ -471,11 +471,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.10-pandas2.2.0-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.0-pydantic1.10.11.txt
@@ -461,11 +461,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/ci/requirements-py3.10-pandas2.2.0-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.0-pydantic2.3.0.txt
@@ -465,11 +465,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -462,11 +462,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -466,11 +466,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.11-pandas2.0.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.0.3-pydantic1.10.11.txt
@@ -462,11 +462,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.11-pandas2.0.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.0.3-pydantic2.3.0.txt
@@ -466,11 +466,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.11-pandas2.2.0-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.0-pydantic1.10.11.txt
@@ -456,11 +456,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/ci/requirements-py3.11-pandas2.2.0-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.0-pydantic2.3.0.txt
@@ -460,11 +460,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -483,11 +483,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -487,11 +487,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.8-pandas2.0.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas2.0.3-pydantic1.10.11.txt
@@ -483,11 +483,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.8-pandas2.0.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas2.0.3-pydantic2.3.0.txt
@@ -487,11 +487,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -474,11 +474,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -478,11 +478,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.9-pandas2.0.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.0.3-pydantic1.10.11.txt
@@ -474,11 +474,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.9-pandas2.0.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.0.3-pydantic2.3.0.txt
@@ -478,11 +478,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/ci/requirements-py3.9-pandas2.2.0-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.0-pydantic1.10.11.txt
@@ -468,11 +468,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/ci/requirements-py3.9-pandas2.2.0-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.0-pydantic2.3.0.txt
@@ -472,11 +472,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -458,11 +458,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -453,11 +453,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -473,11 +473,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -465,11 +465,13 @@ sphinx==4.5.0
     #   sphinx-autodoc-typehints
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-design
     #   sphinx-panels
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+sphinx-design==0.4.1
 sphinx-panels==0.6.0
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx_copybutton",
     "recommonmark",
     "sphinx_panels",
+    "sphinx_design",
     "jupyterlite_sphinx",
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,6 @@ extensions = [
     "sphinx_copybutton",
     "recommonmark",
     "sphinx_panels",
-    "sphinx_design",
     "jupyterlite_sphinx",
 ]
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -9,9 +9,13 @@ Configuration
 ``pandera`` provides a global config `~pandera.config.PanderaConfig`.
 
 This configuration can also be set using environment variables. For instance:
-```
-export PANDERA_VALIDATION_ENABLED=False
-export PANDERA_VALIDATION_DEPTH=DATA_ONLY
-```
 
-Runtime data validation incurs a performance overhead. To mitigate this, you have the option to disable validation globally. This can be achieved by setting the environment variable `PANDERA_VALIDATION_ENABLE=False`. When validation is disabled, any `validate` call will return `None`.
+.. code::
+
+   export PANDERA_VALIDATION_ENABLED=False
+   export PANDERA_VALIDATION_DEPTH=DATA_ONLY
+
+Runtime data validation incurs a performance overhead. To mitigate this, you have
+the option to disable validation globally. This can be achieved by setting the
+environment variable ``PANDERA_VALIDATION_ENABLE=False``. When validation is
+disabled, any ``validate`` call will return ``None``.

--- a/environment.yml
+++ b/environment.yml
@@ -67,6 +67,7 @@ dependencies:
 
   # documentation
   - sphinx
+  - sphinx-design
   - sphinx-panels
   - sphinx-autodoc-typehints <= 1.14.1
   - sphinx-copybutton

--- a/pandera/api/base/error_handler.py
+++ b/pandera/api/base/error_handler.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Dict, List, Union
 
 from pandera.api.checks import Check
-from pandera.config import CONFIG, ValidationDepth
+from pandera.config import get_config_context, ValidationDepth
 from pandera.validation_depth import ValidationScope, validation_type
 from pandera.errors import SchemaError, SchemaErrorReason
 
@@ -153,15 +153,16 @@ class ErrorHandler:
 
         :param category: Enum object
         """
-        if CONFIG.validation_depth == ValidationDepth.SCHEMA_AND_DATA:
+        config = get_config_context()
+        if config.validation_depth == ValidationDepth.SCHEMA_AND_DATA:
             return False
         elif (
-            CONFIG.validation_depth == ValidationDepth.DATA_ONLY
+            config.validation_depth == ValidationDepth.DATA_ONLY
             and category == ValidationScope.DATA.name
         ):
             return False
         elif (
-            CONFIG.validation_depth == ValidationDepth.SCHEMA_ONLY
+            config.validation_depth == ValidationDepth.SCHEMA_ONLY
             and category == ValidationScope.SCHEMA.name
         ):
             return False

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -12,7 +12,7 @@ from pandera.api.base.types import CheckList
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
 from pandera.api.pandas.types import PandasDtypeInputTypes, is_field
-from pandera.config import CONFIG
+from pandera.config import get_config_context
 from pandera.dtypes import DataType, UniqueSettings
 from pandera.engines import pandas_engine, PYDANTIC_V2
 
@@ -426,7 +426,7 @@ class SeriesSchema(ArraySchema):
         dtype: float64
 
         """
-        if not CONFIG.validation_enabled:
+        if not get_config_context().validation_enabled:
             return check_obj
 
         if self._is_inferred:

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Union, cast, overload
 import pandas as pd
 
 from pandera import errors
-from pandera.config import CONFIG
+from pandera.config import get_config_context
 from pandera import strategies as st
 from pandera.api.base.schema import BaseSchema, inferred_schema_guard
 from pandera.api.base.types import StrictType, CheckList
@@ -337,7 +337,7 @@ class DataFrameSchema(BaseSchema):
         4         0.80      dog
         5         0.76      dog
         """
-        if not CONFIG.validation_enabled:
+        if not get_config_context().validation_enabled:
             return check_obj
 
         # NOTE: Move this into its own schema-backend variant. This is where

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -131,8 +131,9 @@ class Column(_Column):
         if is_dataframe:
             check_obj = check_obj.lazy()
 
-        config_from_ctx = get_config_context()
-        with config_context(validation_depth=config_from_ctx.validation_depth):
+        config_ctx = get_config_context(validation_depth_default=None)
+        validation_depth = config_ctx.validation_depth
+        with config_context(validation_depth=validation_depth):
             output = self.get_backend(check_obj).validate(
                 check_obj,
                 self,

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -3,9 +3,12 @@
 import logging
 from typing import Any, Optional
 
+import polars as pl
+
 from pandera.api.base.types import CheckList
 from pandera.api.pandas.components import Column as _Column
-from pandera.api.polars.types import PolarsDtypeInputTypes
+from pandera.api.polars.types import PolarsDtypeInputTypes, PolarsCheckObjects
+from pandera.config import config_context, get_config_context
 from pandera.engines import polars_engine
 from pandera.utils import is_regex
 
@@ -14,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class Column(_Column):
-    """Polars column scheme component."""
+    """Polars column schema component."""
 
     def __init__(
         self,
@@ -95,6 +98,52 @@ class Column(_Column):
             drop_invalid_rows=drop_invalid_rows,
         )
         self.set_regex()
+
+    def validate(
+        self,
+        check_obj: PolarsCheckObjects,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> PolarsCheckObjects:
+        """Validate a Column in a DataFrame object.
+
+        :param check_obj: polars LazyFrame to validate.
+        :param head: validate the first n rows. Rows overlapping with `tail` or
+            `sample` are de-duplicated.
+        :param tail: validate the last n rows. Rows overlapping with `head` or
+            `sample` are de-duplicated.
+        :param sample: validate a random sample of n rows. Rows overlapping
+            with `head` or `tail` are de-duplicated.
+        :param random_state: random seed for the ``sample`` argument.
+        :param lazy: if True, lazily evaluates dataframe against all validation
+            checks and raises a ``SchemaErrors``. Otherwise, raise
+            ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
+        :returns: validated DataFrame.
+        """
+        is_dataframe = isinstance(check_obj, pl.DataFrame)
+
+        if is_dataframe:
+            check_obj = check_obj.lazy()
+
+        config_from_ctx = get_config_context()
+        with config_context(validation_depth=config_from_ctx.validation_depth):
+            output = self.get_backend(check_obj).validate(
+                check_obj,
+                self,
+                head=head,
+                tail=tail,
+                sample=sample,
+                random_state=random_state,
+                lazy=lazy,
+                inplace=inplace,
+            )
+        return output
 
     @property
     def dtype(self):

--- a/pandera/api/polars/utils.py
+++ b/pandera/api/polars/utils.py
@@ -15,7 +15,15 @@ def get_validation_depth(check_obj: PolarsCheckObjects) -> ValidationDepth:
     is_dataframe = isinstance(check_obj, pl.DataFrame)
 
     config_global = get_config_global()
-    config_ctx = get_config_context()
+    config_ctx = get_config_context(validation_depth_default=None)
+
+    if config_ctx.validation_depth is not None:
+        # use context configuration if specified
+        return config_ctx.validation_depth
+
+    if config_global.validation_depth is not None:
+        # use global configuration if specified
+        return config_global.validation_depth
 
     if (
         isinstance(check_obj, pl.LazyFrame)
@@ -24,13 +32,13 @@ def get_validation_depth(check_obj: PolarsCheckObjects) -> ValidationDepth:
         # if global validation depth is not set, use schema only validation
         # when validating LazyFrames
         validation_depth = ValidationDepth.SCHEMA_ONLY
-    elif is_dataframe and config_ctx.validation_depth is None:
-        # use schema and data validation when validating pl.DataFrame
+    elif is_dataframe and (
+        config_ctx.validation_depth is None
+        or config_ctx.validation_depth is None
+    ):
+        # if context validation depth is not set, use schema and data validation
+        # when validating DataFrames
         validation_depth = ValidationDepth.SCHEMA_AND_DATA
-    elif is_dataframe or config_ctx.validation_depth is not None:
-        # when validating pl.DataFrame, or when context-level config is set,
-        # propagate the context-level configuration
-        validation_depth = config_ctx.validation_depth  # type: ignore[assignment]
     else:
         validation_depth = ValidationDepth.SCHEMA_ONLY
 

--- a/pandera/api/polars/utils.py
+++ b/pandera/api/polars/utils.py
@@ -1,0 +1,31 @@
+"""Polars validation engine utilities."""
+
+import polars as pl
+
+from pandera.api.polars.types import PolarsCheckObjects
+from pandera.config import (
+    get_config_context,
+    get_config_global,
+    ValidationDepth,
+)
+
+
+def get_validation_depth(check_obj: PolarsCheckObjects) -> ValidationDepth:
+    is_dataframe = isinstance(check_obj, pl.DataFrame)
+
+    config = get_config_global()
+    config_from_ctx = get_config_context()
+
+    if isinstance(check_obj, pl.LazyFrame) and config.validation_depth is None:
+        # if global validation depth is not set, use schema only validation
+        validation_depth = ValidationDepth.SCHEMA_ONLY
+    elif is_dataframe and config_from_ctx.validation_depth is None:
+        validation_depth = ValidationDepth.SCHEMA_AND_DATA
+    elif is_dataframe or config_from_ctx.validation_depth is not None:
+        # when validating pl.DataFrame, or when context-level config is set,
+        # propagate the context-level configuration
+        validation_depth = config_from_ctx.validation_depth  # type: ignore[assignment]
+    else:
+        validation_depth = ValidationDepth.SCHEMA_ONLY
+
+    return validation_depth

--- a/pandera/api/polars/utils.py
+++ b/pandera/api/polars/utils.py
@@ -11,20 +11,26 @@ from pandera.config import (
 
 
 def get_validation_depth(check_obj: PolarsCheckObjects) -> ValidationDepth:
+    """Get validation depth for a given polars check object."""
     is_dataframe = isinstance(check_obj, pl.DataFrame)
 
-    config = get_config_global()
-    config_from_ctx = get_config_context()
+    config_global = get_config_global()
+    config_ctx = get_config_context()
 
-    if isinstance(check_obj, pl.LazyFrame) and config.validation_depth is None:
+    if (
+        isinstance(check_obj, pl.LazyFrame)
+        and config_global.validation_depth is None
+    ):
         # if global validation depth is not set, use schema only validation
+        # when validating LazyFrames
         validation_depth = ValidationDepth.SCHEMA_ONLY
-    elif is_dataframe and config_from_ctx.validation_depth is None:
+    elif is_dataframe and config_ctx.validation_depth is None:
+        # use schema and data validation when validating pl.DataFrame
         validation_depth = ValidationDepth.SCHEMA_AND_DATA
-    elif is_dataframe or config_from_ctx.validation_depth is not None:
+    elif is_dataframe or config_ctx.validation_depth is not None:
         # when validating pl.DataFrame, or when context-level config is set,
         # propagate the context-level configuration
-        validation_depth = config_from_ctx.validation_depth  # type: ignore[assignment]
+        validation_depth = config_ctx.validation_depth  # type: ignore[assignment]
     else:
         validation_depth = ValidationDepth.SCHEMA_ONLY
 

--- a/pandera/api/pyspark/container.py
+++ b/pandera/api/pyspark/container.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Union, cast, overload
 from pyspark.sql import DataFrame
 
 from pandera import errors
-from pandera.config import CONFIG
+from pandera.config import get_config_context
 from pandera.api.base.schema import BaseSchema
 from pandera.api.base.types import StrictType
 from pandera.api.checks import Check
@@ -323,7 +323,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         >>> schema_withchecks.validate(df).take(2)
             [Row(product='Bread', price=9), Row(product='Butter', price=15)]
         """
-        if not CONFIG.validation_enabled:
+        if not get_config_context().validation_enabled:
             return check_obj
         error_handler = ErrorHandler(lazy)
 

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -22,7 +22,8 @@ def format_generic_error_message(
     :param check_index: The validator that failed.
     """
     return (
-        f"{parent_schema.__class__.__name__} '{parent_schema.name}' failed series or dataframe validator "
+        f"{parent_schema.__class__.__name__} '{parent_schema.name}' failed "
+        "series or dataframe validator "
         f"{check_index}: {check}"
     )
 
@@ -63,7 +64,8 @@ def format_vectorized_error_message(
     failure_cases_string = ", ".join(failure_cases.astype(str))
 
     return (
-        f"{parent_schema.__class__.__name__} '{parent_schema.name}' failed element-wise validator number {check_index}: "
+        f"{parent_schema.__class__.__name__} '{parent_schema.name}' failed "
+        f"element-wise validator number {check_index}: "
         f"{check_str} failure cases: {failure_cases_string}"
     )
 

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -86,10 +86,11 @@ class PolarsSchemaBackend(BaseSchemaBackend):
             else:
                 # use check_result
                 failure_cases = check_result.failure_cases.collect()
+                failure_cases_msg = failure_cases.head().rows(named=True)
                 message = (
                     f"{schema.__class__.__name__} '{schema.name}' failed "
                     f"validator number {check_index}: "
-                    f"{check} failure cases: {failure_cases}"
+                    f"{check} failure case examples: {failure_cases_msg}"
                 )
 
             # raise a warning without exiting if the check is specified to do so

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -8,7 +8,7 @@ import polars as pl
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.api.polars.types import CheckResult
 from pandera.backends.base import BaseSchemaBackend, CoreCheckResult
-from pandera.backends.polars.constants import CHECK_OUTPUT_KEY
+from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.errors import (
     SchemaError,
     FailureCaseMetadata,

--- a/pandera/backends/polars/checks.py
+++ b/pandera/backends/polars/checks.py
@@ -10,7 +10,7 @@ from pandera.api.base.checks import CheckResult
 from pandera.api.checks import Check
 from pandera.api.polars.types import PolarsData
 from pandera.backends.base import BaseCheckBackend
-from pandera.backends.polars.constants import CHECK_OUTPUT_KEY
+from pandera.constants import CHECK_OUTPUT_KEY
 
 
 class PolarsCheckBackend(BaseCheckBackend):

--- a/pandera/backends/polars/components.py
+++ b/pandera/backends/polars/components.py
@@ -168,7 +168,7 @@ class ColumnBackend(PolarsSchemaBackend):
         if schema.dtype is None or not schema.coerce:
             return check_obj
 
-        config_ctx = get_config_context()
+        config_ctx = get_config_context(validation_depth_default=None)
         coerce_fn: Callable[[pl.LazyFrame], pl.LazyFrame] = (
             schema.dtype.coerce
             if config_ctx.validation_depth == ValidationDepth.SCHEMA_ONLY

--- a/pandera/backends/polars/components.py
+++ b/pandera/backends/polars/components.py
@@ -1,7 +1,7 @@
 """Validation backend for polars components."""
 
 import warnings
-from typing import Iterable, List, Optional, cast
+from typing import Any, Callable, Iterable, List, Optional, cast
 
 import polars as pl
 
@@ -9,7 +9,7 @@ from pandera.api.base.error_handler import ErrorHandler
 from pandera.api.polars.components import Column
 from pandera.backends.base import CoreCheckResult
 from pandera.backends.polars.base import PolarsSchemaBackend, is_float_dtype
-from pandera.config import ValidationScope
+from pandera.config import ValidationScope, ValidationDepth, get_config_context
 from pandera.errors import (
     ParserError,
     SchemaDefinitionError,
@@ -61,7 +61,22 @@ class ColumnBackend(PolarsSchemaBackend):
                 "When drop_invalid_rows is True, lazy must be set to True."
             )
 
-        check_obj = self.set_default(check_obj, schema)
+        core_parsers: List[Callable[..., Any]] = [
+            self.coerce_dtype,
+            self.set_default,
+        ]
+
+        for parser in core_parsers:
+            try:
+                check_obj = parser(check_obj, schema)
+            except SchemaError as exc:
+                error_handler.collect_error(
+                    validation_type(exc.reason_code),
+                    exc.reason_code,
+                    exc,
+                )
+            except SchemaErrors as exc:
+                error_handler.collect_errors(exc.schema_errors)
 
         error_handler = self.run_checks_and_handle_errors(
             error_handler,
@@ -153,8 +168,15 @@ class ColumnBackend(PolarsSchemaBackend):
         if schema.dtype is None or not schema.coerce:
             return check_obj
 
+        config_ctx = get_config_context()
+        coerce_fn: Callable[[pl.LazyFrame], pl.LazyFrame] = (
+            schema.dtype.coerce
+            if config_ctx.validation_depth == ValidationDepth.SCHEMA_ONLY
+            else schema.dtype.try_coerce
+        )
+
         try:
-            return schema.dtype.try_coerce(check_obj)
+            return coerce_fn(check_obj)
         except ParserError as exc:
             raise SchemaError(
                 schema=schema,

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -433,7 +433,7 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
         """
         error_handler = ErrorHandler(lazy=True)
 
-        config_ctx = get_config_context()
+        config_ctx = get_config_context(validation_depth_default=None)
         coerce_fn: str = (
             "try_coerce"
             if config_ctx.validation_depth

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -12,7 +12,7 @@ from pandera.api.polars.container import DataFrameSchema
 from pandera.api.polars.types import PolarsData
 from pandera.backends.base import CoreCheckResult, ColumnInfo
 from pandera.backends.polars.base import PolarsSchemaBackend
-from pandera.config import ValidationScope
+from pandera.config import ValidationScope, ValidationDepth, get_config_context
 from pandera.errors import (
     ParserError,
     SchemaError,
@@ -433,15 +433,40 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
         """
         error_handler = ErrorHandler(lazy=True)
 
+        config_ctx = get_config_context()
+        coerce_fn: str = (
+            "try_coerce"
+            if config_ctx.validation_depth
+            in (
+                ValidationDepth.SCHEMA_AND_DATA,
+                ValidationDepth.DATA_ONLY,
+            )
+            else "coerce"
+        )
+
         try:
             if schema.dtype is not None:
-                obj = schema.dtype.try_coerce(obj)
+                obj = getattr(schema.dtype, coerce_fn)(obj)
             else:
                 for col_schema in schema.columns.values():
-                    obj = col_schema.dtype.try_coerce(
+                    obj = getattr(col_schema.dtype, coerce_fn)(
                         PolarsData(obj, col_schema.selector)
                     )
-        except (ParserError, pl.ComputeError) as exc:
+        except ParserError as exc:
+            error_handler.collect_error(
+                validation_type(SchemaErrorReason.DATATYPE_COERCION),
+                SchemaErrorReason.DATATYPE_COERCION,
+                SchemaError(
+                    schema=schema,
+                    data=obj,
+                    message=exc.args[0],
+                    check=f"coerce_dtype('{schema.dtypes}')",
+                    reason_code=SchemaErrorReason.DATATYPE_COERCION,
+                    failure_cases=exc.failure_cases,
+                    check_output=exc.parser_output,
+                ),
+            )
+        except pl.ComputeError as exc:
             error_handler.collect_error(
                 validation_type(SchemaErrorReason.DATATYPE_COERCION),
                 SchemaErrorReason.DATATYPE_COERCION,

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -16,7 +16,7 @@ from pandera.backends.pyspark.decorators import (
     cache_check_obj,
 )
 from pandera.backends.pyspark.error_formatters import scalar_failure_case
-from pandera.config import CONFIG
+from pandera.config import get_config_context
 from pandera.validation_depth import ValidationScope
 from pandera.errors import (
     SchemaDefinitionError,
@@ -127,7 +127,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
         assert (
             error_handler is not None
         ), "The `error_handler` argument must be provided."
-        if not CONFIG.validation_enabled:
+        if not get_config_context().validation_enabled:
             warnings.warn(
                 "Skipping the validation checks as validation is disabled"
             )

--- a/pandera/backends/pyspark/decorators.py
+++ b/pandera/backends/pyspark/decorators.py
@@ -8,7 +8,7 @@ from typing import List, Type
 
 from pyspark.sql import DataFrame
 from pandera.api.pyspark.types import PysparkDefaultTypes
-from pandera.config import CONFIG, ValidationDepth
+from pandera.config import get_config_context, ValidationDepth
 from pandera.validation_depth import ValidationScope
 from pandera.errors import SchemaError
 
@@ -89,8 +89,9 @@ def validate_scope(scope: ValidationScope):
                         if isinstance(value, DataFrame):
                             return value
 
+            config = get_config_context()
             if scope == ValidationScope.SCHEMA:
-                if CONFIG.validation_depth in (
+                if config.validation_depth in (
                     ValidationDepth.SCHEMA_AND_DATA,
                     ValidationDepth.SCHEMA_ONLY,
                 ):
@@ -105,7 +106,7 @@ def validate_scope(scope: ValidationScope):
                     return _get_check_obj()
 
             elif scope == ValidationScope.DATA:
-                if CONFIG.validation_depth in (
+                if config.validation_depth in (
                     ValidationDepth.SCHEMA_AND_DATA,
                     ValidationDepth.DATA_ONLY,
                 ):
@@ -149,7 +150,7 @@ def cache_check_obj():
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             # Skip if not enabled
-            if CONFIG.cache_dataframe is not True:
+            if get_config_context().cache_dataframe is not True:
                 return func(self, *args, **kwargs)
 
             check_obj: DataFrame = None
@@ -179,7 +180,7 @@ def cache_check_obj():
 
                 yield  # Execute the decorated function
 
-                if not CONFIG.keep_cached_dataframe:
+                if not get_config_context().keep_cached_dataframe:
                     # If not cached, `.unpersist()` does nothing
                     logger.debug("Unpersisting dataframe...")
                     check_obj.unpersist()

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -1,7 +1,10 @@
 """Pandera configuration."""
 
+
 import os
+from contextlib import contextmanager
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -55,3 +58,29 @@ CONFIG = PanderaConfig(
         False,
     ),
 )
+
+
+@contextmanager
+def config_context(
+    validation_enabled: Optional[bool] = None,
+    validation_depth: Optional[ValidationDepth] = None,
+    cache_dataframe: Optional[bool] = None,
+    keep_cached_dataframe: Optional[bool] = None,
+):
+    """Temporarily set pandera config options to custom settings."""
+    global CONFIG
+
+    original_config = CONFIG.model_copy()
+
+    # if validation_enabled is not None:
+    #     CONFIG.validation_enabled = validation_enabled
+    # if validation_depth is not None:
+    #     CONFIG.validation_depth = validation_depth
+    # if cache_dataframe is not None:
+    #     CONFIG.cache_dataframe = cache_dataframe
+    # if keep_cached_dataframe is not None:
+    #     CONFIG.keep_cached_dataframe = keep_cached_dataframe
+
+    yield
+
+    CONFIG = original_config

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -77,8 +77,6 @@ def config_context(
 ):
     """Temporarily set pandera config options to custom settings."""
     # pylint: disable=global-statement
-    global _CONTEXT_CONFIG
-
     try:
         if validation_enabled is not None:
             _CONTEXT_CONFIG.validation_enabled = validation_enabled
@@ -91,7 +89,14 @@ def config_context(
 
         yield
     finally:
-        _CONTEXT_CONFIG = deepcopy(CONFIG)
+        reset_config_context()
+
+
+def reset_config_context():
+    """Reset the context configuration to the global configuration."""
+    # pylint: disable=global-statement
+    global _CONTEXT_CONFIG
+    _CONTEXT_CONFIG = deepcopy(CONFIG)
 
 
 def get_config_global() -> PanderaConfig:
@@ -99,12 +104,15 @@ def get_config_global() -> PanderaConfig:
     return CONFIG
 
 
-def get_config_context() -> PanderaConfig:
+def get_config_context(
+    validation_depth_default: Optional[
+        ValidationDepth
+    ] = ValidationDepth.SCHEMA_AND_DATA,
+) -> PanderaConfig:
     """Gets the configuration context."""
     config = deepcopy(_CONTEXT_CONFIG)
 
-    if config.validation_depth is None:
-        # if validation depth is not set, default to using SCHEMA_AND_DATA
-        config.validation_depth = ValidationDepth.SCHEMA_AND_DATA
+    if config.validation_depth is None and validation_depth_default:
+        config.validation_depth = validation_depth_default
 
     return config

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -2,6 +2,7 @@
 
 
 import os
+from copy import deepcopy
 from contextlib import contextmanager
 from enum import Enum
 from typing import Optional
@@ -64,7 +65,7 @@ CONFIG = PanderaConfig(
     ),
 )
 
-_CONTEXT_CONFIG = CONFIG.model_copy()
+_CONTEXT_CONFIG = deepcopy(CONFIG)
 
 
 @contextmanager
@@ -79,7 +80,7 @@ def config_context(
     global _CONTEXT_CONFIG
 
     if CONFIG != _CONTEXT_CONFIG:
-        _CONTEXT_CONFIG = CONFIG.model_copy()
+        _CONTEXT_CONFIG = deepcopy(CONFIG)
 
     if CONFIG == _CONTEXT_CONFIG:
         if validation_enabled is not None:
@@ -93,7 +94,7 @@ def config_context(
 
     yield
 
-    _CONTEXT_CONFIG = CONFIG.model_copy()
+    _CONTEXT_CONFIG = deepcopy(CONFIG)
 
 
 def get_config_global() -> PanderaConfig:
@@ -107,7 +108,7 @@ def get_config_context() -> PanderaConfig:
     :param raw: if True, return the configuration context unmodified. Otherwise,
         set the validation_depth to SCHEMA_AND_DATA if it is None.
     """
-    config = _CONTEXT_CONFIG.model_copy()
+    config = deepcopy(_CONTEXT_CONFIG)
     if config.validation_depth is None:
         config.validation_depth = ValidationDepth.SCHEMA_AND_DATA
 

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -77,6 +77,8 @@ def config_context(
 ):
     """Temporarily set pandera config options to custom settings."""
     # pylint: disable=global-statement
+    _outer_config_ctx = get_config_context(validation_depth_default=None)
+
     try:
         if validation_enabled is not None:
             _CONTEXT_CONFIG.validation_enabled = validation_enabled
@@ -89,14 +91,14 @@ def config_context(
 
         yield
     finally:
-        reset_config_context()
+        reset_config_context(_outer_config_ctx)
 
 
-def reset_config_context():
+def reset_config_context(conf: Optional[PanderaConfig] = None):
     """Reset the context configuration to the global configuration."""
     # pylint: disable=global-statement
     global _CONTEXT_CONFIG
-    _CONTEXT_CONFIG = deepcopy(CONFIG)
+    _CONTEXT_CONFIG = deepcopy(conf or CONFIG)
 
 
 def get_config_global() -> PanderaConfig:

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -79,10 +79,7 @@ def config_context(
     # pylint: disable=global-statement
     global _CONTEXT_CONFIG
 
-    if CONFIG != _CONTEXT_CONFIG:
-        _CONTEXT_CONFIG = deepcopy(CONFIG)
-
-    if CONFIG == _CONTEXT_CONFIG:
+    try:
         if validation_enabled is not None:
             _CONTEXT_CONFIG.validation_enabled = validation_enabled
         if validation_depth is not None:
@@ -92,9 +89,9 @@ def config_context(
         if keep_cached_dataframe is not None:
             _CONTEXT_CONFIG.keep_cached_dataframe = keep_cached_dataframe
 
-    yield
-
-    _CONTEXT_CONFIG = deepcopy(CONFIG)
+        yield
+    finally:
+        _CONTEXT_CONFIG = deepcopy(CONFIG)
 
 
 def get_config_global() -> PanderaConfig:
@@ -103,13 +100,11 @@ def get_config_global() -> PanderaConfig:
 
 
 def get_config_context() -> PanderaConfig:
-    """Gets the configuration context.
-
-    :param raw: if True, return the configuration context unmodified. Otherwise,
-        set the validation_depth to SCHEMA_AND_DATA if it is None.
-    """
+    """Gets the configuration context."""
     config = deepcopy(_CONTEXT_CONFIG)
+
     if config.validation_depth is None:
+        # if validation depth is not set, default to using SCHEMA_AND_DATA
         config.validation_depth = ValidationDepth.SCHEMA_AND_DATA
 
     return config

--- a/pandera/constants.py
+++ b/pandera/constants.py
@@ -1,4 +1,4 @@
-"""Polars constants."""
+"""Pandera constants."""
 
 CHECK_OUTPUT_KEY = "check_output"
 FAILURE_CASE_KEY = "failure_case"

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -60,11 +60,12 @@ class ReducedPickleExceptionBase(Exception):
 class ParserError(ReducedPickleExceptionBase):
     """Raised when data cannot be parsed from the raw into its clean form."""
 
-    TO_STRING_KEYS = ["failure_cases"]
+    TO_STRING_KEYS = ["failure_cases", "parser_output"]
 
-    def __init__(self, message, failure_cases):
+    def __init__(self, message, failure_cases, parser_output=None):
         super().__init__(message)
         self.failure_cases = failure_cases
+        self.parser_output = parser_output
 
 
 class SchemaInitError(Exception):

--- a/pandera/validation_depth.py
+++ b/pandera/validation_depth.py
@@ -4,7 +4,7 @@ import functools
 import logging
 
 from pandera.backends.base import CoreCheckResult
-from pandera.config import ValidationDepth, ValidationScope, CONFIG
+from pandera.config import ValidationDepth, ValidationScope, get_config_context
 from pandera.errors import SchemaErrorReason
 
 
@@ -56,9 +56,11 @@ def validate_scope(scope: ValidationScope):
         @functools.wraps(func)
         def wrapper(self, check_obj, *args, **kwargs):
 
+            config = get_config_context()
+
             if scope == ValidationScope.SCHEMA:
-                if CONFIG.validation_depth == ValidationDepth.DATA_ONLY:
-                    logger.info(
+                if config.validation_depth == ValidationDepth.DATA_ONLY:
+                    logger.debug(
                         f"Skipping execution of check {func.__name__} since "
                         "validation depth is set to DATA_ONLY.",
                         stacklevel=2,
@@ -67,16 +69,14 @@ def validate_scope(scope: ValidationScope):
                 return func(self, check_obj, *args, **kwargs)
 
             elif scope == ValidationScope.DATA:
-                if CONFIG.validation_depth == ValidationDepth.SCHEMA_ONLY:
-                    logger.info(
+                if config.validation_depth == ValidationDepth.SCHEMA_ONLY:
+                    logger.debug(
                         f"Skipping execution of check {func.__name__} since "
                         "validation depth is set to SCHEMA_ONLY",
                         stacklevel=2,
                     )
                     return CoreCheckResult(passed=True)
                 return func(self, check_obj, *args, **kwargs)
-
-            raise ValueError(f"Invalid scope {scope}")
 
         return wrapper
 

--- a/requirements.in
+++ b/requirements.in
@@ -40,6 +40,7 @@ importlib_metadata
 uvicorn
 python-multipart
 sphinx
+sphinx-design
 sphinx-panels
 sphinx-autodoc-typehints <= 1.14.1
 sphinx-copybutton

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,65 @@
+"""Tests for configuration functions."""
+
+import pytest
+
+from pandera.config import (
+    config_context,
+    get_config_global,
+    get_config_context,
+    ValidationDepth,
+)
+
+
+@pytest.mark.parametrize(
+    "setting, value, in_ctx_value, post_global_value, post_ctx_value",
+    [
+        ("validation_enabled", False, False, True, True),
+        ("validation_enabled", True, True, True, True),
+        # setting validation depth to None will default to SCHEMA_AND_DATA
+        # validation depth for the context configuration but retain the None
+        # value for the global configuration
+        (
+            "validation_depth",
+            None,
+            ValidationDepth.SCHEMA_AND_DATA,
+            None,
+            ValidationDepth.SCHEMA_AND_DATA,
+        ),
+        (
+            "validation_depth",
+            ValidationDepth.SCHEMA_AND_DATA,
+            ValidationDepth.SCHEMA_AND_DATA,
+            None,
+            ValidationDepth.SCHEMA_AND_DATA,
+        ),
+        (
+            "validation_depth",
+            ValidationDepth.SCHEMA_ONLY,
+            ValidationDepth.SCHEMA_ONLY,
+            None,
+            ValidationDepth.SCHEMA_AND_DATA,
+        ),
+        (
+            "validation_depth",
+            ValidationDepth.DATA_ONLY,
+            ValidationDepth.DATA_ONLY,
+            None,
+            ValidationDepth.SCHEMA_AND_DATA,
+        ),
+        ("cache_dataframe", True, True, False, False),
+        ("cache_dataframe", False, False, False, False),
+        ("keep_cached_dataframe", True, True, False, False),
+        ("keep_cached_dataframe", False, False, False, False),
+    ],
+)
+def test_config_context(
+    setting, value, in_ctx_value, post_global_value, post_ctx_value
+):
+    with config_context(**{setting: value}):
+        config_ctx = get_config_context()
+        assert getattr(config_ctx, setting) == in_ctx_value
+
+    config_ctx = get_config_context()
+    config_gbl = get_config_global()
+    assert getattr(config_ctx, setting) == post_ctx_value
+    assert getattr(config_gbl, setting) == post_global_value

--- a/tests/core/test_pandas_config.py
+++ b/tests/core/test_pandas_config.py
@@ -7,15 +7,14 @@ import pytest
 
 import pandera as pa
 from pandera import DataFrameModel, DataFrameSchema, SeriesSchema
-from pandera.config import CONFIG, ValidationDepth
+from pandera.config import config_context, get_config_context, ValidationDepth
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True, scope="function")
 def disable_validation():
     """Fixture to disable validation and clean up after the test is finished"""
-    CONFIG.validation_enabled = False
-    yield "resource"
-    CONFIG.validation_enabled = True
+    with config_context(validation_enabled=False):
+        yield
 
 
 class TestPandasDataFrameConfig:
@@ -25,7 +24,7 @@ class TestPandasDataFrameConfig:
         (("Bread", 9), ("Cutter", 15)), columns=["product", "price_val"]
     )
     # pylint: disable=unused-argument
-    def test_disable_validation(self, disable_validation):
+    def test_disable_validation(self):
         """This function validates that a none object is loaded if validation is disabled"""
 
         pandera_schema = DataFrameSchema(
@@ -50,7 +49,7 @@ class TestPandasDataFrameConfig:
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
         }
 
-        assert CONFIG.dict() == expected
+        assert get_config_context().dict() == expected
         assert pandera_schema.validate(self.sample_data) is self.sample_data
         assert TestSchema.validate(self.sample_data) is self.sample_data
 
@@ -60,7 +59,7 @@ class TestPandasSeriesConfig:
 
     sample_data = pd.Series([1, 1, 2, 2, 3, 3])
     # pylint: disable=unused-argument
-    def test_disable_validation(self, disable_validation):
+    def test_disable_validation(self):
         """This function validates that a none object is loaded if validation is disabled"""
         expected = {
             "cache_dataframe": False,
@@ -71,5 +70,5 @@ class TestPandasSeriesConfig:
         pandera_schema = SeriesSchema(
             int, pa.Check(lambda s: s.value_counts() == 2, element_wise=False)
         )
-        assert CONFIG.dict() == expected
+        assert get_config_context().dict() == expected
         assert pandera_schema.validate(self.sample_data) is self.sample_data

--- a/tests/core/test_validation_depth.py
+++ b/tests/core/test_validation_depth.py
@@ -3,7 +3,7 @@
 import pytest
 
 from pandera.backends.base import CoreCheckResult
-from pandera.config import CONFIG, ValidationDepth, ValidationScope
+from pandera.config import config_context, ValidationDepth, ValidationScope
 from pandera.validation_depth import validate_scope
 
 
@@ -33,14 +33,14 @@ def custom_backend():
         [ValidationDepth.SCHEMA_ONLY, [False, True]],
         [ValidationDepth.DATA_ONLY, [True, False]],
         [ValidationDepth.SCHEMA_AND_DATA, [False, False]],
+        [None, [False, False]],
     ],
 )
 def test_validate_scope(validation_depth, expected):
 
-    CONFIG.validation_depth = validation_depth
-
-    backend = custom_backend()
-    schema_result = backend.check_schema("foo")
-    data_result = backend.check_data("foo")
-    results = [schema_result.passed, data_result.passed]
-    assert results == expected
+    with config_context(validation_depth=validation_depth):
+        backend = custom_backend()
+        schema_result = backend.check_schema("foo")
+        data_result = backend.check_data("foo")
+        results = [schema_result.passed, data_result.passed]
+        assert results == expected

--- a/tests/polars/conf.py
+++ b/tests/polars/conf.py
@@ -1,8 +1,0 @@
-import os
-
-import pytest
-
-
-@pytest.fixture(scope="session", autouse=True)
-def set_env():
-    os.environ["PANDERA_VALIDATION_DEPTH"] = "SCHEMA_AND_DATA"

--- a/tests/polars/conf.py
+++ b/tests/polars/conf.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_env():
+    os.environ["PANDERA_VALIDATION_DEPTH"] = "SCHEMA_AND_DATA"

--- a/tests/polars/conftest.py
+++ b/tests/polars/conftest.py
@@ -1,0 +1,14 @@
+"""Polars unit test-specific configuration."""
+
+import pytest
+
+from pandera.config import CONFIG, ValidationDepth
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_validation_depth():
+    """
+    These tests ensure that the validation depth is set to schema and data
+    for unit tests.
+    """
+    CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA

--- a/tests/polars/conftest.py
+++ b/tests/polars/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pandera.config import CONFIG, ValidationDepth
+from pandera.config import CONFIG, reset_config_context, ValidationDepth
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -13,5 +13,8 @@ def validation_depth_schema_and_data():
     """
     _validation_depth = CONFIG.validation_depth
     CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA
-    yield
-    CONFIG.validation_depth = _validation_depth
+    try:
+        yield
+    finally:
+        CONFIG.validation_depth = _validation_depth
+        reset_config_context()

--- a/tests/polars/conftest.py
+++ b/tests/polars/conftest.py
@@ -8,7 +8,10 @@ from pandera.config import CONFIG, ValidationDepth
 @pytest.fixture(scope="function", autouse=True)
 def set_validation_depth():
     """
-    These tests ensure that the validation depth is set to schema and data
+    These tests ensure that the validation depth is set to SCHEMA_AND_DATA
     for unit tests.
     """
+    _validation_depth = CONFIG.validation_depth
     CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA
+    yield
+    CONFIG.validation_depth = _validation_depth

--- a/tests/polars/conftest.py
+++ b/tests/polars/conftest.py
@@ -6,7 +6,7 @@ from pandera.config import CONFIG, ValidationDepth
 
 
 @pytest.fixture(scope="function", autouse=True)
-def set_validation_depth():
+def validation_depth_schema_and_data():
     """
     These tests ensure that the validation depth is set to SCHEMA_AND_DATA
     for unit tests.

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -4,7 +4,7 @@ import polars as pl
 import pytest
 
 import pandera.polars as pa
-from pandera.backends.polars.constants import CHECK_OUTPUT_KEY
+from pandera.constants import CHECK_OUTPUT_KEY
 
 
 @pytest.fixture

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -210,3 +210,7 @@ def test_set_default(data, dtype, default):
     backend = ColumnBackend()
     validated_data = backend.set_default(data, column_schema).collect()
     assert validated_data.select(pl.col("column").eq(default).any()).item()
+
+
+def test_column_schema_on_lazyframe_coerce():
+    ...

--- a/tests/polars/test_polars_config.py
+++ b/tests/polars/test_polars_config.py
@@ -6,6 +6,7 @@ import pytest
 import polars as pl
 
 import pandera.polars as pa
+from pandera.api.base.error_handler import ErrorCategory
 from pandera.config import (
     CONFIG,
     ValidationDepth,
@@ -18,9 +19,10 @@ from pandera.config import (
 
 @pytest.fixture(scope="function")
 def validation_depth_none():
-    """
-    These tests ensure that the validation depth is set to 'None'
-    for unit tests.
+    """Ensure that the validation depth is set to None for unit tests.
+
+    This fixture is meant to simulate setting validation depth via the
+    PANDERA_VALIDATION_DEPTH environment variable.
     """
     _validation_depth = CONFIG.validation_depth
     CONFIG.validation_depth = None
@@ -33,9 +35,10 @@ def validation_depth_none():
 
 @pytest.fixture(scope="function")
 def validation_depth_schema_and_data():
-    """
-    These tests ensure that the validation depth is set to 'None'
-    for unit tests.
+    """Ensure that the validation depth is set to SCHEMA_AND_DATA.
+
+    This fixture is meant to simulate setting validation depth via the
+    PANDERA_VALIDATION_DEPTH environment variable.
     """
     _validation_depth = CONFIG.validation_depth
     CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA
@@ -46,44 +49,110 @@ def validation_depth_schema_and_data():
         reset_config_context()
 
 
-def test_lazyframe_validation_depth_none(validation_depth_none):
+@pytest.fixture
+def schema() -> pa.DataFrameSchema:
+    return pa.DataFrameSchema(
+        {
+            "a": pa.Column(pl.Int64, pa.Check.gt(0)),
+            "b": pa.Column(pl.Utf8),
+        }
+    )
+
+
+def test_lazyframe_validation_depth_none(validation_depth_none, schema):
     """
     Test that with default configuration setting for validation depth (None),
     schema validation with LazyFrames is performed only on the schema.
     """
-    schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
-    valid = pl.LazyFrame({"a": [1, 2, 3]})
-    invalid = pl.LazyFrame({"a": [1, 2, -3]})
+    valid = pl.LazyFrame({"a": [1, 2, 3], "b": [*"abc"]})
+    invalid_data_level = pl.LazyFrame({"a": [1, 2, -3], "b": [*"abc"]})
+    invalid_schema_level = pl.LazyFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
 
-    assert valid.pipe(schema.validate).collect().equals(valid.collect())
-    assert invalid.pipe(schema.validate).collect().equals(invalid.collect())
+    # validating LazyFrames should only validate schema-level properties, even
+    # invalid dataframe should not raise an error.
+    assert schema.validate(valid).collect().equals(valid.collect())
+    assert (
+        schema.validate(invalid_data_level)
+        .collect()
+        .equals(invalid_data_level.collect())
+    )
 
+    # invalid schema-level data should only have SCHEMA errors
+    try:
+        invalid_schema_level.pipe(schema.validate, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert ErrorCategory.SCHEMA.name in exc.message
+        assert ErrorCategory.DATA.name not in exc.message
+
+    # invalid data-level data should only have DATA errors
+    try:
+        invalid_data_level.pipe(schema.validate, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert ErrorCategory.SCHEMA.name not in exc.message
+        assert ErrorCategory.DATA.name in exc.message
+
+    # test that using config context manager while environment-level validation
+    # depth is None can activate schema-and-data validation for LazyFrames.
     with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
         assert valid.collect().pipe(schema.validate).equals(valid.collect())
-        with pytest.raises(pa.errors.SchemaError):
-            invalid.collect().pipe(schema.validate)
+        with pytest.raises(
+            pa.errors.SchemaError,
+            match="Column 'a' failed validator .+ <Check greater_than",
+        ):
+            invalid_data_level.pipe(schema.validate)
+
+
+def test_dataframe_validation_depth_none(validation_depth_none, schema):
+    valid = pl.DataFrame({"a": [1, 2, 3], "b": [*"abc"]})
+    invalid_data_level = pl.DataFrame({"a": [1, 2, -3], "b": [*"abc"]})
+    invalid_schema_level = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+
+    assert schema.validate(valid).equals(valid)
+
+    # pl.DataFrame validation should validate schema- and data-level errors
+    with pytest.raises(
+        pa.errors.SchemaError,
+        match="Column 'a' failed validator .+ <Check greater_than",
+    ):
+        assert schema.validate(invalid_data_level)
+
+    with pytest.raises(
+        pa.errors.SchemaError,
+        match="expected column 'b' to have type String, got Int64",
+    ):
+        assert schema.validate(invalid_schema_level)
 
 
 def test_lazyframe_validation_depth_schema_and_data(
     validation_depth_schema_and_data,
+    schema,
 ):
     """
-    Test that with default configuration setting for validation depth (None),
-    schema validation with LazyFrames is performed only on the schema.
+    Test that setting environment-level config for validation depth to
+    SCHEMA_AND_DATA will perform data-level validation on LazyFrames.
     """
-    schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
-    valid = pl.LazyFrame({"a": [1, 2, 3]})
-    invalid = pl.LazyFrame({"a": [1, 2, -3]})
+    valid = pl.LazyFrame({"a": [1, 2, 3], "b": [*"abc"]})
+    invalid = pl.LazyFrame({"a": [1, 2, -3], "b": [1, 2, 3]})
 
-    assert valid.collect().pipe(schema.validate).equals(valid.collect())
-    with pytest.raises(pa.errors.SchemaError):
-        invalid.collect().pipe(schema.validate)
+    assert valid.pipe(schema.validate).collect().equals(valid.collect())
+
+    with pytest.raises(
+        pa.errors.SchemaError,
+        match="Column 'a' failed validator .+ <Check greater_than",
+    ):
+        invalid.pipe(schema.validate)
+
+    try:
+        invalid.pipe(schema.validate, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert ErrorCategory.SCHEMA.name in exc.message
+        assert ErrorCategory.DATA.name in exc.message
 
 
-def test_coerce_validation_depth_none(validation_depth_none):
+def test_coerce_validation_depth_none(validation_depth_none, schema):
     assert get_config_global().validation_depth is None
-    schema = pa.DataFrameSchema({"a": pa.Column(int)}, coerce=True)
-    data = pl.LazyFrame({"a": ["1", "2", "foo"]})
+    schema._coerce = True
+    data = pl.LazyFrame({"a": ["1", "2", "foo"], "b": [*"abc"]})
 
     # simply calling validation shouldn't raise a coercion error, since we're
     # casting the types lazily
@@ -102,4 +171,6 @@ def test_coerce_validation_depth_none(validation_depth_none):
         try:
             schema.validate(data)
         except pa.errors.SchemaError as exc:
-            assert exc.failure_cases.rows(named=True) == [{"a": "foo"}]
+            assert exc.failure_cases.rows(named=True) == [
+                {"a": "foo", "b": "c"}
+            ]

--- a/tests/polars/test_polars_config.py
+++ b/tests/polars/test_polars_config.py
@@ -1,0 +1,28 @@
+"""Unit tests for polars validation based on configuration settings."""
+
+import pytest
+
+import polars as pl
+
+import pandera.polars as pa
+from pandera.config import CONFIG
+
+
+def test_lazyframe_validation_default():
+    """
+    Test that with default configuration setting for validation depth (None),
+    schema validation with LazyFrames is performed only on the schema.
+    """
+    CONFIG.validation_depth = None
+
+    schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
+
+    valid = pl.LazyFrame({"a": [1, 2, 3]})
+    invalid = pl.LazyFrame({"a": [1, 2, -3]})
+
+    assert valid.pipe(schema.validate).collect().equals(valid.collect())
+    assert invalid.pipe(schema.validate).collect().equals(invalid.collect())
+
+    assert valid.collect().pipe(schema.validate).equals(valid.collect())
+    with pytest.raises(pa.errors.SchemaError):
+        invalid.collect().pipe(schema.validate)

--- a/tests/polars/test_polars_config.py
+++ b/tests/polars/test_polars_config.py
@@ -8,13 +8,23 @@ import pandera.polars as pa
 from pandera.config import CONFIG
 
 
+@pytest.fixture(scope="function", autouse=True)
+def set_validation_depth():
+    """
+    These tests ensure that the validation depth is set to 'None'
+    for unit tests.
+    """
+    _validation_depth = CONFIG.validation_depth
+    CONFIG.validation_depth = None
+    yield
+    CONFIG.validation_depth = _validation_depth
+
+
 def test_lazyframe_validation_default():
     """
     Test that with default configuration setting for validation depth (None),
     schema validation with LazyFrames is performed only on the schema.
     """
-    CONFIG.validation_depth = None
-
     schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
 
     valid = pl.LazyFrame({"a": [1, 2, 3]})

--- a/tests/polars/test_polars_config.py
+++ b/tests/polars/test_polars_config.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-argument
 """Unit tests for polars validation based on configuration settings."""
 
 import pytest
@@ -11,41 +12,75 @@ from pandera.config import (
     config_context,
     get_config_global,
     get_config_context,
+    reset_config_context,
 )
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="function")
 def validation_depth_none():
     """
     These tests ensure that the validation depth is set to 'None'
     for unit tests.
     """
-    print("SETTING GLOBAL VALIDATION DEPTH TO NONE")
     _validation_depth = CONFIG.validation_depth
     CONFIG.validation_depth = None
-    yield
-    CONFIG.validation_depth = _validation_depth
+    try:
+        yield
+    finally:
+        CONFIG.validation_depth = _validation_depth
+        reset_config_context()
 
 
-def test_lazyframe_validation_default():
+@pytest.fixture(scope="function")
+def validation_depth_schema_and_data():
+    """
+    These tests ensure that the validation depth is set to 'None'
+    for unit tests.
+    """
+    _validation_depth = CONFIG.validation_depth
+    CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA
+    try:
+        yield
+    finally:
+        CONFIG.validation_depth = _validation_depth
+        reset_config_context()
+
+
+def test_lazyframe_validation_depth_none(validation_depth_none):
     """
     Test that with default configuration setting for validation depth (None),
     schema validation with LazyFrames is performed only on the schema.
     """
     schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
-
     valid = pl.LazyFrame({"a": [1, 2, 3]})
     invalid = pl.LazyFrame({"a": [1, 2, -3]})
 
     assert valid.pipe(schema.validate).collect().equals(valid.collect())
     assert invalid.pipe(schema.validate).collect().equals(invalid.collect())
 
+    with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+        assert valid.collect().pipe(schema.validate).equals(valid.collect())
+        with pytest.raises(pa.errors.SchemaError):
+            invalid.collect().pipe(schema.validate)
+
+
+def test_lazyframe_validation_depth_schema_and_data(
+    validation_depth_schema_and_data,
+):
+    """
+    Test that with default configuration setting for validation depth (None),
+    schema validation with LazyFrames is performed only on the schema.
+    """
+    schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64, pa.Check.gt(0))})
+    valid = pl.LazyFrame({"a": [1, 2, 3]})
+    invalid = pl.LazyFrame({"a": [1, 2, -3]})
+
     assert valid.collect().pipe(schema.validate).equals(valid.collect())
     with pytest.raises(pa.errors.SchemaError):
         invalid.collect().pipe(schema.validate)
 
 
-def test_coerce_validation_depth_none():
+def test_coerce_validation_depth_none(validation_depth_none):
     assert get_config_global().validation_depth is None
     schema = pa.DataFrameSchema({"a": pa.Column(int)}, coerce=True)
     data = pl.LazyFrame({"a": ["1", "2", "foo"]})

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -12,10 +12,10 @@ import polars as pl
 
 import pandera.errors
 from pandera.api.polars.types import PolarsData
+from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.engines import polars_engine as pe
 from pandera.engines.polars_engine import (
     polars_object_coercible,
-    COERCIBLE_KEY,
 )
 
 
@@ -249,7 +249,7 @@ def test_check_equivalent_custom(first_dtype, second_dtype, equivalent):
                 data={"0": [1000, 100, 200], "1": [1000, 100, 200]},
                 schema={"0": pl.Int32, "1": pl.Int32},
             ),
-            pl.LazyFrame({COERCIBLE_KEY: [True, True, True]}),
+            pl.LazyFrame({CHECK_OUTPUT_KEY: [True, True, True]}),
         ),
         (
             pl.Int64,
@@ -257,7 +257,7 @@ def test_check_equivalent_custom(first_dtype, second_dtype, equivalent):
                 data={"0": [1000, 100, 200]},
                 schema={"0": pl.Int32},
             ),
-            pl.LazyFrame({COERCIBLE_KEY: [True, True, True]}),
+            pl.LazyFrame({CHECK_OUTPUT_KEY: [True, True, True]}),
         ),
         (
             pl.UInt32,
@@ -265,12 +265,12 @@ def test_check_equivalent_custom(first_dtype, second_dtype, equivalent):
                 data={"0": ["1000", "a", "200"], "1": ["1000", "100", "c"]},
                 schema={"0": pl.Utf8, "1": pl.Utf8},
             ),
-            pl.LazyFrame({COERCIBLE_KEY: [True, False, False]}),
+            pl.LazyFrame({CHECK_OUTPUT_KEY: [True, False, False]}),
         ),
         (
             pl.Int64,
             pl.LazyFrame(data={"0": ["d", "100", "200"]}),
-            pl.LazyFrame({COERCIBLE_KEY: [False, True, True]}),
+            pl.LazyFrame({CHECK_OUTPUT_KEY: [False, True, True]}),
         ),
     ],
 )

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -1637,8 +1637,8 @@ class TestCustomCheck(BaseClass):
         class Schema(DataFrameModel):
             """Test Schema"""
 
-            product: StringType()
-            code: IntegerType() = Field(
+            product: StringType
+            code: IntegerType = Field(
                 new_pyspark_check={
                     "max_value": self.sample_numeric_data["test_expression"]
                 }

--- a/tests/pyspark/test_pyspark_config.py
+++ b/tests/pyspark/test_pyspark_config.py
@@ -5,7 +5,7 @@
 import pyspark.sql.types as T
 import pytest
 
-from pandera.config import CONFIG, ValidationDepth
+from pandera.config import get_config_context, config_context, ValidationDepth
 from pandera.pyspark import (
     Check,
     DataFrameSchema,
@@ -23,9 +23,6 @@ class TestPanderaConfig:
 
     def test_disable_validation(self, spark, sample_spark_schema):
         """This function validates that a none object is loaded if validation is disabled"""
-
-        CONFIG.validation_enabled = False
-
         pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
@@ -36,8 +33,8 @@ class TestPanderaConfig:
         class TestSchema(DataFrameModel):
             """Test Schema class"""
 
-            product: T.StringType() = Field(str_startswith="B")
-            price_val: T.StringType() = Field()
+            product: T.StringType = Field(str_startswith="B")
+            price_val: T.StringType = Field()
 
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
         expected = {
@@ -47,15 +44,14 @@ class TestPanderaConfig:
             "keep_cached_dataframe": False,
         }
 
-        assert CONFIG.dict() == expected
-        assert pandera_schema.validate(input_df)
-        assert TestSchema.validate(input_df)
+        with config_context(validation_enabled=False):
+            assert get_config_context().dict() == expected
+            assert pandera_schema.validate(input_df) == input_df
+            assert TestSchema.validate(input_df) == input_df
 
     # pylint:disable=too-many-locals
     def test_schema_only(self, spark, sample_spark_schema):
         """This function validates that only schema related checks are run not data level"""
-        CONFIG.validation_enabled = True
-        CONFIG.validation_depth = ValidationDepth.SCHEMA_ONLY
 
         pandera_schema = DataFrameSchema(
             {
@@ -70,10 +66,15 @@ class TestPanderaConfig:
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
         }
-        assert CONFIG.dict() == expected
-
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
-        output_dataframeschema_df = pandera_schema.validate(input_df)
+
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.SCHEMA_ONLY,
+        ):
+            assert get_config_context().dict() == expected
+            output_dataframeschema_df = pandera_schema.validate(input_df)
+
         expected_dataframeschema = {
             "SCHEMA": {
                 "COLUMN_NOT_IN_DATAFRAME": [
@@ -102,10 +103,14 @@ class TestPanderaConfig:
         class TestSchema(DataFrameModel):
             """Test Schema"""
 
-            product: T.StringType() = Field(str_startswith="B")
-            price_val: T.StringType() = Field()
+            product: T.StringType = Field(str_startswith="B")
+            price_val: T.StringType = Field()
 
-        output_dataframemodel_df = TestSchema.validate(input_df)
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.SCHEMA_ONLY,
+        ):
+            output_dataframemodel_df = TestSchema.validate(input_df)
 
         expected_dataframemodel = {
             "SCHEMA": {
@@ -135,8 +140,6 @@ class TestPanderaConfig:
     # pylint:disable=too-many-locals
     def test_data_only(self, spark, sample_spark_schema):
         """This function validates that only data related checks are run not schema level"""
-        CONFIG.validation_enabled = True
-        CONFIG.validation_depth = ValidationDepth.DATA_ONLY
 
         pandera_schema = DataFrameSchema(
             {
@@ -150,10 +153,15 @@ class TestPanderaConfig:
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
         }
-        assert CONFIG.dict() == expected
 
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
-        output_dataframeschema_df = pandera_schema.validate(input_df)
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.DATA_ONLY,
+        ):
+            assert get_config_context().dict() == expected
+            output_dataframeschema_df = pandera_schema.validate(input_df)
+
         expected_dataframeschema = {
             "DATA": {
                 "DATAFRAME_CHECK": [
@@ -185,10 +193,14 @@ class TestPanderaConfig:
         class TestSchema(DataFrameModel):
             """Test Schema"""
 
-            product: T.StringType() = Field(str_startswith="B")
-            price_val: T.StringType() = Field()
+            product: T.StringType = Field(str_startswith="B")
+            price_val: T.StringType = Field()
 
-        output_dataframemodel_df = TestSchema.validate(input_df)
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.DATA_ONLY,
+        ):
+            output_dataframemodel_df = TestSchema.validate(input_df)
 
         expected_dataframemodel = {
             "DATA": {
@@ -222,9 +234,6 @@ class TestPanderaConfig:
     def test_schema_and_data(self, spark, sample_spark_schema):
         """This function validates that both data and schema level checks are validated"""
         # self.remove_python_module_cache()
-        CONFIG.validation_enabled = True
-        CONFIG.validation_depth = ValidationDepth.SCHEMA_AND_DATA
-
         pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
@@ -237,10 +246,16 @@ class TestPanderaConfig:
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
         }
-        assert CONFIG.dict() == expected
 
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
-        output_dataframeschema_df = pandera_schema.validate(input_df)
+
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.SCHEMA_AND_DATA,
+        ):
+            assert get_config_context().dict() == expected
+            output_dataframeschema_df = pandera_schema.validate(input_df)
+
         expected_dataframeschema = {
             "DATA": {
                 "DATAFRAME_CHECK": [
@@ -288,10 +303,14 @@ class TestPanderaConfig:
         class TestSchema(DataFrameModel):
             """Test Schema"""
 
-            product: T.StringType() = Field(str_startswith="B")
-            price_val: T.StringType() = Field()
+            product: T.StringType = Field(str_startswith="B")
+            price_val: T.StringType = Field()
 
-        output_dataframemodel_df = TestSchema.validate(input_df)
+        with config_context(
+            validation_enabled=True,
+            validation_depth=ValidationDepth.SCHEMA_AND_DATA,
+        ):
+            output_dataframemodel_df = TestSchema.validate(input_df)
 
         expected_dataframemodel = {
             "DATA": {
@@ -337,24 +356,25 @@ class TestPanderaConfig:
             == expected_dataframemodel["SCHEMA"]
         )
 
-    @pytest.mark.parametrize("cache_enabled", [True, False])
-    @pytest.mark.parametrize("keep_cache_enabled", [True, False])
+    @pytest.mark.parametrize("cache_dataframe", [True, False])
+    @pytest.mark.parametrize("keep_cached_dataframe", [True, False])
     # pylint:disable=too-many-locals
     def test_cache_dataframe_settings(
         self,
-        cache_enabled,
-        keep_cache_enabled,
+        cache_dataframe,
+        keep_cached_dataframe,
     ):
         """This function validates setters and getters for cache/keep_cache options."""
         # Set expected properties in Config object
-        CONFIG.cache_dataframe = cache_enabled
-        CONFIG.keep_cached_dataframe = keep_cache_enabled
-
         # Evaluate expected Config
         expected = {
             "validation_enabled": True,
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
-            "cache_dataframe": cache_enabled,
-            "keep_cached_dataframe": keep_cache_enabled,
+            "cache_dataframe": cache_dataframe,
+            "keep_cached_dataframe": keep_cached_dataframe,
         }
-        assert CONFIG.dict() == expected
+        with config_context(
+            cache_dataframe=cache_dataframe,
+            keep_cached_dataframe=keep_cached_dataframe,
+        ):
+            assert get_config_context().dict() == expected


### PR DESCRIPTION
Fixes #1528 

This PR modifies the default PANDERA_VALIDATION_DEPTH environment setting to `None`. This allows for setting default validation behavior for the polars backend. If the environment variable is not set, then LazyFrame doesn't perform any data-level validation. It will only check schema-level properties of the LazyFrame. This behavior can be overriden by explicitly setting `export PANDERA_VALIDATION_DEPTH=SCHEMA_AND_DATA`.

When doing `pl.DataFrame` validation it will perform both schema- and data-level validations.
