### PR TITLE
`check_nullable` does not uselessly compute `isna()` anymore in pandas backend

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -194,8 +194,16 @@ class ArraySchemaBackend(PandasSchemaBackend):
 
     @validate_scope(scope=ValidationScope.SCHEMA)
     def check_nullable(self, check_obj: pd.Series, schema) -> CoreCheckResult:
+        if schema.nullable:
+            # Avoid to compute anything for perf reasons. GH#1533
+            return CoreCheckResult(
+                passed=True,
+                check="not_nullable",
+            )
+
+        # Check actual column contents
         isna = check_obj.isna()
-        passed = schema.nullable or not isna.any()
+        passed = not isna.any()
         return CoreCheckResult(
             passed=cast(bool, passed),
             check="not_nullable",


### PR DESCRIPTION
Fixed #1533