### PR TITLE
Enable from_format_kwargs for dict format

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -126,7 +126,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
             reader = config.from_format
         else:
             reader = {
-                Formats.dict: pd.DataFrame,
+                Formats.dict: pd.DataFrame.from_dict,
                 Formats.csv: pd.read_csv,
                 Formats.json: pd.read_json,
                 Formats.feather: pd.read_feather,

--- a/tests/core/test_from_to_format_conversions.py
+++ b/tests/core/test_from_to_format_conversions.py
@@ -31,10 +31,12 @@ class InSchemaDict(InSchema):
     class Config:
         from_format = "dict"
 
+
 class InSchemaDictKwargs(InSchema):
     class Config:
         from_format = "dict"
         from_format_kwargs = {"orient": "index"}
+
 
 class InSchemaJson(InSchema):
     class Config:

--- a/tests/core/test_from_to_format_conversions.py
+++ b/tests/core/test_from_to_format_conversions.py
@@ -31,6 +31,10 @@ class InSchemaDict(InSchema):
     class Config:
         from_format = "dict"
 
+class InSchemaDictKwargs(InSchema):
+    class Config:
+        from_format = "dict"
+        from_format_kwargs = {"orient": "index"}
 
 class InSchemaJson(InSchema):
     class Config:
@@ -177,6 +181,7 @@ def _needs_pyarrow(schema) -> bool:
             io.StringIO,
         ],
         [InSchemaDict, lambda df: df.to_dict(orient="records"), None],
+        [InSchemaDictKwargs, lambda df: df.to_dict(orient="index"), None],
         [
             InSchemaJson,
             lambda df, x: df.to_json(x, orient="records"),


### PR DESCRIPTION
Use the from_dict method of DataFrame instead of the DataFrame constructor for dicts, to align dict from_format with other types in use of kwargs.

closes unionai-oss/pandera#920
