### PR TITLE
fix: prevent environment pollution when importing pyspark

### DIFF
--- a/pandera/external_config.py
+++ b/pandera/external_config.py
@@ -16,6 +16,8 @@ try:
         os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 
     import pyspark.pandas
-except ImportError:
+finally:
+    # TODO: these pops should probably only happen if ^ above code modifies them
+    # otherwise risk undoing user defined values?
     os.environ.pop("SPARK_LOCAL_IP")
     os.environ.pop("PYARROW_IGNORE_TIMEZONE")

--- a/pandera/external_config.py
+++ b/pandera/external_config.py
@@ -2,6 +2,9 @@
 
 import os
 
+is_spark_local_ip_dirty = False
+is_pyarrow_ignore_timezone_dirty = False
+
 try:
     # try importing pyspark to see if it exists. This is important because the
     # pandera.typing module defines a Series type that inherits from
@@ -10,14 +13,16 @@ try:
     # https://spark.apache.org/docs/3.2.0/api/python/user_guide/pandas_on_spark/typehints.html#type-hinting-with-names
     # pylint: disable=unused-import
     if os.getenv("SPARK_LOCAL_IP") is None:
+        is_spark_local_ip_dirty = True
         os.environ["SPARK_LOCAL_IP"] = "127.0.0.1"
     if os.getenv("PYARROW_IGNORE_TIMEZONE") is None:
+        is_pyarrow_ignore_timezone_dirty = True
         # This can be overriden by the user
         os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
 
     import pyspark.pandas
 finally:
-    # TODO: these pops should probably only happen if ^ above code modifies them
-    # otherwise risk undoing user defined values?
-    os.environ.pop("SPARK_LOCAL_IP")
-    os.environ.pop("PYARROW_IGNORE_TIMEZONE")
+    if is_spark_local_ip_dirty:
+        os.environ.pop("SPARK_LOCAL_IP")
+    if is_pyarrow_ignore_timezone_dirty:
+        os.environ.pop("PYARROW_IGNORE_TIMEZONE")


### PR DESCRIPTION
Closes: #1551

- [x] Change `catch` to a `finally` to ensure environment is always popped when probing for `pyspark.pandas` in `external_config.py`
- [x] Keep track of dirty state and only pop environment variables that were modified