### PR TITLE
Add _GenericAlias.__call__ patch

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11.8"]  # python 3.11.9 causes issues with unit tests
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}
@@ -101,7 +101,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11.8"]  # python 3.11.9 causes issues with unit tests
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         pandas-version: ["1.5.3", "2.0.3", "2.2.0"]
         pydantic-version: ["1.10.11", "2.3.0"]
         include:

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ nox.options.sessions = (
 )
 
 DEFAULT_PYTHON = "3.8"
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11.8"]
+PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 PANDAS_VERSIONS = ["1.5.3", "2.0.3", "2.2.0"]
 PYDANTIC_VERSIONS = ["1.10.11", "2.3.0"]
 

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -168,8 +168,9 @@ def __patched_generic_alias_call__(self, *args, **kwargs):
     result = self.__origin__(*args, **kwargs)
     try:
         result.__orig_class__ = self
-    # Limit the patched behavior to pandera errors.
+    # Limit the patched behavior to subset of exception types
     except (
+        TypeError,
         errors.SchemaError,
         errors.SchemaError,
         errors.SchemaInitError,

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -2,12 +2,21 @@
 # pylint:disable=abstract-method,too-many-ancestors,invalid-name
 
 import inspect
-from typing import TYPE_CHECKING, Any, Generic, Optional, Type, TypeVar, Union
+from typing import (  # type: ignore[attr-defined]
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    _GenericAlias,
+)
 
 import pandas as pd
 import typing_inspect
 
-from pandera import dtypes
+from pandera import dtypes, errors
 from pandera.engines import numpy_engine, pandas_engine
 
 Bool = dtypes.Bool  #: ``"bool"`` numpy dtype
@@ -143,6 +152,38 @@ if TYPE_CHECKING:
     T = TypeVar("T")  # pragma: no cover
 else:
     T = DataFrameModel
+
+
+def __patched_generic_alias_call__(self, *args, **kwargs):
+    """
+    Patched implementation of _GenericAlias.__call__ so that validation errors
+    can be raised when instantiating an instance of pandera DataFrame generics,
+    e.g. DataFrame[A](data).
+    """
+    if not self._inst:
+        raise TypeError(
+            f"Type {self._name} cannot be instantiated; "
+            f"use {self.__origin__.__name__}() instead"
+        )
+    result = self.__origin__(*args, **kwargs)
+    try:
+        result.__orig_class__ = self
+    # Limit the patched behavior to pandera errors.
+    except (
+        errors.SchemaError,
+        errors.SchemaError,
+        errors.SchemaInitError,
+        errors.SchemaDefinitionError,
+    ):
+        raise
+    # In python 3.11.9, all exceptions when setting attributes when defining
+    # _GenericAlias subclasses are caught and ignored.
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return result
+
+
+_GenericAlias.__call__ = __patched_generic_alias_call__
 
 
 class DataFrameBase(Generic[T]):


### PR DESCRIPTION
Fixes #1559

This PR patches `typing._GenericAlias.__call__`, which was changed in python 3.11.9 such that it ignores all exceptions when the `__orig_class__` attribute is set. This is the dark magic that pandera relies on to enable the validation-on-init feature when using `pandera.typing.DataFrame[Schema](...)`.