### PR TITLE
remove pytest ignore on modin, dask. pyspark tests with pandas >= 2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@
 
 import os
 
-from pandera.engines.utils import pandas_version
-
 try:
     # pylint: disable=unused-import
     import hypothesis  # noqa F401
@@ -15,13 +13,6 @@ else:
 
 # ignore test files associated with hypothesis strategies
 collect_ignore = []
-collect_ignore_glob = []
-
-# ignore pyspark, modin and dask tests until these libraries support pandas 2
-if pandas_version().release >= (2, 0, 0):
-    collect_ignore_glob.append("pyspark/**")
-    collect_ignore_glob.append("modin/**")
-    collect_ignore_glob.append("dask/**")
 
 if not HAS_HYPOTHESIS:
     collect_ignore.append("test_strategies.py")


### PR DESCRIPTION
This PR removes the `collect_ignore_glob` list that was introduced in https://github.com/unionai-oss/pandera/pull/1175 to ignore modin, dask, and pyspark tests when pandas >= 2 is installed in the environment.