### PR TITLE
make sure check name is propagated to error report

### DIFF
--- a/pandera/api/base/error_handler.py
+++ b/pandera/api/base/error_handler.py
@@ -131,7 +131,7 @@ class ErrorHandler:
                 continue
 
             if isinstance(error.check, Check):
-                check = error.check.error
+                check = error.check.error or error.check.name
             else:
                 check = error.check
 

--- a/pandera/api/extensions.py
+++ b/pandera/api/extensions.py
@@ -288,9 +288,13 @@ def register_check_method(  # pylint:disable=too-many-branches
                 else:
                     check_kwargs[k] = v
 
+            error_stats = ", ".join(f"{k}={v}" for k, v in stats.items())
+            error = f"{check_fn.__name__}({error_stats})" if stats else None
+
             return cls(
                 partial(check_fn_wrapper, **stats),
                 name=check_fn.__name__,
+                error=error,
                 **validate_check_kwargs(check_kwargs),
             )
 

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -491,6 +491,10 @@ def test_custom_check_error_is_failure_case(extra_registered_checks):
         test_schema.validate(df, lazy=True)
     except errors.SchemaErrors as err:
         assert err.error_counts == {"CHECK_ERROR": 1}
+        assert (
+            err.message["DATA"]["CHECK_ERROR"][0]["check"]
+            == "raise_an_error_check"
+        )
 
 
 def test_check_backend_not_found():


### PR DESCRIPTION
This PR fixes a bug where the name of the custom check isn't propagated to the error reports.