### PR TITLE
Adding warning for unique in pyspark field and a test showing the issue as well as config when it works.

### DIFF
--- a/docs/source/pyspark_sql.md
+++ b/docs/source/pyspark_sql.md
@@ -334,7 +334,7 @@ This feature is available for `pyspark.sql` and `pandas` both.
 :::{warning}
 The `unique` support for PySpark-based validations to define which columns must be
 tested for unique values may incur in a performance hit, given Spark's distributed
-nature.
+nature. It only works with `Config`.
 
 Use with caution.
 :::

--- a/pandera/api/pyspark/model_components.py
+++ b/pandera/api/pyspark/model_components.py
@@ -1,4 +1,5 @@
 """DataFrameModel components"""
+
 from typing import (
     Any,
     Callable,
@@ -131,7 +132,7 @@ def Field(
     to the built-in :py:class:`~pandera.api.checks.Check` methods.
 
     :param nullable: Whether or not the column/index can contain null values.
-    :param unique: Whether column values should be unique.
+    :param unique: Whether column values should be unique. Currently Not supported
     :param coerce: coerces the data type if ``True``.
     :param regex: whether or not the field name or alias is a regex pattern.
     :param ignore_na: whether or not to ignore null values in the checks.
@@ -177,6 +178,10 @@ def Field(
         else:
             check_ = check_constructor(arg_value, **check_kwargs)
         checks.append(check_)
+    if unique is True:
+        raise SchemaInitError(
+            "unique Field argument not yet implemented for pyspark"
+        )
 
     return FieldInfo(
         checks=checks or None,
@@ -235,7 +240,7 @@ class FieldCheckInfo(CheckInfo):  # pylint:disable=too-few-public-methods
 
 
 def _to_function_and_classmethod(
-    fn: Union[AnyCallable, classmethod]
+    fn: Union[AnyCallable, classmethod],
 ) -> Tuple[AnyCallable, classmethod]:
     if isinstance(fn, classmethod):
         fn, method = fn.__func__, cast(classmethod, fn)

--- a/pandera/api/pyspark/model_components.py
+++ b/pandera/api/pyspark/model_components.py
@@ -178,7 +178,7 @@ def Field(
         else:
             check_ = check_constructor(arg_value, **check_kwargs)
         checks.append(check_)
-    if unique is True:
+    if unique:
         raise SchemaInitError(
             "unique Field argument not yet implemented for pyspark"
         )

--- a/tests/pyspark/test_pyspark_container.py
+++ b/tests/pyspark/test_pyspark_container.py
@@ -7,7 +7,7 @@ import pytest
 import pandera.pyspark as pa
 import pandera.errors
 from pandera.config import PanderaConfig, ValidationDepth
-from pandera.pyspark import DataFrameSchema, Column
+from pandera.pyspark import DataFrameSchema, Column, DataFrameModel
 
 spark = SparkSession.builder.getOrCreate()
 
@@ -231,3 +231,61 @@ def test_pyspark_nullable():
         df_out = schema_nullable_true.validate(df)
     assert isinstance(df_out, DataFrame)
     assert df_out.pandera.errors == {}
+
+
+def test_pyspark_unique_field():
+    """
+    Test that field unique True raise an error.
+    """
+    with pytest.raises(pandera.errors.SchemaInitError):
+        # pylint: disable=W0223
+        class PanderaSchema(DataFrameModel):
+            id: T.StringType() = pa.Field(unique=True)
+
+        data = [
+            ("id1"),
+        ]
+        spark_schema = T.StructType(
+            [
+                T.StructField("id", T.StringType(), False),
+            ],
+        )
+        df = spark.createDataFrame(data=data, schema=spark_schema)
+        df_out = PanderaSchema.validate(df)
+        assert len(df_out.pandera.errors) == 0
+
+
+def test_pyspark_unique_config():
+    """
+    Test the sample functionality of pyspark
+    """
+
+    # pylint: disable=W0223
+    class PanderaSchema(DataFrameModel):
+        product: T.StringType() = pa.Field()
+        price: T.IntegerType() = pa.Field()
+
+        class Config:
+            unique = "product"
+
+    data = [
+        ("Bread", 9),
+        ("Butter", 15),
+        ("Ice Cream", 10),
+        ("Cola", 12),
+        ("Chocolate", 7),
+        ("Chocolate", 7),
+    ]
+
+    spark_schema = T.StructType(
+        [
+            T.StructField("product", T.StringType(), False),
+            T.StructField("price", T.IntegerType(), False),
+        ],
+    )
+
+    df = spark.createDataFrame(data=data, schema=spark_schema)
+
+    df_out = PanderaSchema.validate(df)
+
+    assert len(df_out.pandera.errors["DATA"]["DUPLICATES"]) == 1


### PR DESCRIPTION
Following #1344 I am adding a bit of edited documentation.
I wasn't able to raise `SchemaInitError` as @cosmicBboy suggested as it turns out that if you use `pa.Field(unique=True)` it is seen as None which most likely is the issue.
In the follow up screenshot you can see the behavior when I did add the code [where](https://github.com/unionai-oss/pandera/blob/main/pandera/api/pyspark/container.py#L148) @cosmicBboy suggested.
<img width="494" alt="Screenshot 2024-04-19 at 5 39 04 PM" src="https://github.com/unionai-oss/pandera/assets/4520383/03e8027e-8092-4107-ac8f-4dbc8dc7cb3e">
As the ghost text show it is None when I put a breakpoint there so I did not add it.
