### PR TITLE
Set pandas_io.from_frictionless_schema to use a raw string for docs

### DIFF
--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -740,7 +740,7 @@ def from_frictionless_schema(
     schema: Union[str, Path, Dict, FrictionlessSchema]
 ) -> DataFrameSchema:
     # pylint: disable=line-too-long,anomalous-backslash-in-string
-    """Create a :class:`~pandera.api.pandas.container.DataFrameSchema` from either a
+    r"""Create a :class:`~pandera.api.pandas.container.DataFrameSchema` from either a
     frictionless json/yaml schema file saved on disk, or from a frictionless
     schema already loaded into memory.
 


### PR DESCRIPTION
In Python 3.12 I receive the following SyntaxWarning just by importing pandas_io:

```
.../site-packages/pandera/io/pandas_io.py:743: SyntaxWarning: invalid escape sequence '\S'
  """Create a :class:`~pandera.api.pandas.container.DataFrameSchema` from either a
```

By setting the docs to a raw string, these otherwise invalid [escape sequences](https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences) are permitted.