### PR TITLE
Clean up typing for pandas GenericDtype

### DIFF
--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -55,95 +55,55 @@ STRING = pandas_engine.STRING  #: ``"str"`` numpy dtype
 BOOL = pandas_engine.BOOL  #: ``"str"`` numpy dtype
 
 
-try:
+if pandas_engine.GEOPANDAS_INSTALLED:
     Geometry = pandas_engine.Geometry  # : ``"geometry"`` geopandas dtype
-    GEOPANDAS_INSTALLED = True
-except AttributeError:
-    GEOPANDAS_INSTALLED = False
-
-if GEOPANDAS_INSTALLED:
-    GenericDtype = TypeVar(  # type: ignore
-        "GenericDtype",
-        bound=Union[
-            bool,
-            int,
-            str,
-            float,
-            pd.core.dtypes.base.ExtensionDtype,
-            Bool,
-            Date,
-            DateTime,
-            Decimal,
-            Timedelta,
-            Category,
-            Float,
-            Float16,
-            Float32,
-            Float64,
-            Int,
-            Int8,
-            Int16,
-            Int32,
-            Int64,
-            UInt8,
-            UInt16,
-            UInt32,
-            UInt64,
-            INT8,
-            INT16,
-            INT32,
-            INT64,
-            UINT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            Object,
-            String,
-            STRING,
-            Geometry,
-        ],
-    )
 else:
-    GenericDtype = TypeVar(  # type: ignore
-        "GenericDtype",
-        bound=Union[
-            bool,
-            int,
-            str,
-            float,
-            pd.core.dtypes.base.ExtensionDtype,
-            Bool,
-            Date,
-            DateTime,
-            Decimal,
-            Timedelta,
-            Category,
-            Float,
-            Float16,
-            Float32,
-            Float64,
-            Int,
-            Int8,
-            Int16,
-            Int32,
-            Int64,
-            UInt8,
-            UInt16,
-            UInt32,
-            UInt64,
-            INT8,
-            INT16,
-            INT32,
-            INT64,
-            UINT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            Object,
-            String,
-            STRING,
-        ],
-    )
+
+    class Geometry:  # type: ignore [no-redef]  # pylint: disable=too-few-public-methods
+        ...  #  stub Geometry type
+
+
+GenericDtype = TypeVar(  # type: ignore
+    "GenericDtype",
+    bound=Union[
+        bool,
+        int,
+        str,
+        float,
+        pd.core.dtypes.base.ExtensionDtype,
+        Bool,
+        Date,
+        DateTime,
+        Decimal,
+        Timedelta,
+        Category,
+        Float,
+        Float16,
+        Float32,
+        Float64,
+        Int,
+        Int8,
+        Int16,
+        Int32,
+        Int64,
+        UInt8,
+        UInt16,
+        UInt32,
+        UInt64,
+        INT8,
+        INT16,
+        INT32,
+        INT64,
+        UINT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        Object,
+        String,
+        STRING,
+        Geometry,
+    ],
+)
 
 DataFrameModel = TypeVar("DataFrameModel", bound="DataFrameModel")  # type: ignore
 

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -59,7 +59,8 @@ if pandas_engine.GEOPANDAS_INSTALLED:
     Geometry = pandas_engine.Geometry  # : ``"geometry"`` geopandas dtype
 else:
 
-    class Geometry:  # type: ignore [no-redef]  # pylint: disable=too-few-public-methods
+    class Geometry:  # type: ignore [no-redef]
+        # pylint: disable=too-few-public-methods
         ...  #  stub Geometry type
 
 


### PR DESCRIPTION
This PR refactors the `GenericDtype` definition so that it doesn't use a conditional to define it depending on whether geopandas is installed.