### PR TITLE
fix: properly coerce dtypes for columns with regex=True

### DIFF
--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -633,9 +633,13 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                     matched_columns = pd.Index([])
 
                 for matched_colname in matched_columns:
-                    if col_schema.coerce or schema.coerce:
+                    if (
+                        col_schema.coerce or schema.coerce
+                    ) and schema.dtype is None:
+                        _col_schema = copy.deepcopy(col_schema)
+                        _col_schema.coerce = True
                         obj[matched_colname] = _try_coercion(
-                            col_schema.coerce_dtype, obj[matched_colname]
+                            _col_schema.coerce_dtype, obj[matched_colname]
                         )
             elif (
                 (col_schema.coerce or schema.coerce)

--- a/tests/core/test_schema_components.py
+++ b/tests/core/test_schema_components.py
@@ -9,10 +9,8 @@ import pytest
 from pandera import (
     Check,
     Column,
-    DataFrameModel,
     DataFrameSchema,
     DateTime,
-    Field,
     Float,
     Index,
     Int,
@@ -22,7 +20,6 @@ from pandera import (
     errors,
 )
 from pandera.engines.pandas_engine import Engine, pandas_version
-from pandera.typing import Series
 
 
 def test_column() -> None:
@@ -54,35 +51,6 @@ def test_column_coerce() -> None:
     validated = column_schema.validate(data)
     assert isinstance(validated, pd.DataFrame)
     assert Engine.dtype(validated.a.dtype) == Engine.dtype(int)
-
-
-def test_config_coerce() -> None:
-    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column."""
-
-    class Model(DataFrameModel):
-        class Config:
-            coerce = True
-
-        col: Series[bool] = Field()
-
-    df = pd.DataFrame({"col": [1, 0]})
-
-    assert isinstance(Model.validate(df), pd.DataFrame)
-
-
-def test_config_coerce_with_regex() -> None:
-    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column in the case
-    where the column has regex=True."""
-
-    class ModelWithRegex(DataFrameModel):
-        class Config:
-            coerce = True
-
-        col: Series[bool] = Field(alias="alias", regex=True)
-
-    df = pd.DataFrame({"alias": [1, 0]})
-
-    assert isinstance(ModelWithRegex.validate(df), pd.DataFrame)
 
 
 def test_column_in_dataframe_schema():

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -2421,7 +2421,7 @@ def test_drop_invalid_for_model_schema():
         MySchema.validate(actual_obj, lazy=False)
 
 
-def test_config_coerce() -> None:
+def test_schema_coerce() -> None:
     """Test that setting coerce=True for a DataFrameSchema is sufficient to coerce a column."""
 
     schema = DataFrameSchema(
@@ -2434,7 +2434,7 @@ def test_config_coerce() -> None:
     assert isinstance(schema.validate(df), pd.DataFrame)
 
 
-def test_config_coerce_with_regex() -> None:
+def test_schema_coerce_with_regex() -> None:
     """Test that setting coerce=True for a DataFrameSchema is sufficient to coerce a column in the case
     where the column has regex=True."""
 

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -29,6 +29,7 @@ from pandera import (
 from pandera.api.pandas.array import ArraySchema
 from pandera.dtypes import UniqueSettings
 from pandera.engines.pandas_engine import Engine
+from pandera.typing import Series
 
 
 def test_dataframe_schema() -> None:
@@ -2419,6 +2420,35 @@ def test_drop_invalid_for_model_schema():
 
     with pytest.raises(errors.SchemaDefinitionError):
         MySchema.validate(actual_obj, lazy=False)
+
+
+def test_config_coerce() -> None:
+    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column."""
+
+    class Model(DataFrameModel):
+        class Config:
+            coerce = True
+
+        col: Series[bool] = Field()
+
+    df = pd.DataFrame({"col": [1, 0]})
+
+    assert isinstance(Model.validate(df), pd.DataFrame)
+
+
+def test_config_coerce_with_regex() -> None:
+    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column in the case
+    where the column has regex=True."""
+
+    class ModelWithRegex(DataFrameModel):
+        class Config:
+            coerce = True
+
+        col: Series[bool] = Field(alias="alias", regex=True)
+
+    df = pd.DataFrame({"alias": [1, 0]})
+
+    assert isinstance(ModelWithRegex.validate(df), pd.DataFrame)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -29,7 +29,6 @@ from pandera import (
 from pandera.api.pandas.array import ArraySchema
 from pandera.dtypes import UniqueSettings
 from pandera.engines.pandas_engine import Engine
-from pandera.typing import Series
 
 
 def test_dataframe_schema() -> None:
@@ -2423,32 +2422,30 @@ def test_drop_invalid_for_model_schema():
 
 
 def test_config_coerce() -> None:
-    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column."""
+    """Test that setting coerce=True for a DataFrameSchema is sufficient to coerce a column."""
 
-    class Model(DataFrameModel):
-        class Config:
-            coerce = True
-
-        col: Series[bool] = Field()
+    schema = DataFrameSchema(
+        columns={"col": Column(dtype=bool)},
+        coerce=True,
+    )
 
     df = pd.DataFrame({"col": [1, 0]})
 
-    assert isinstance(Model.validate(df), pd.DataFrame)
+    assert isinstance(schema.validate(df), pd.DataFrame)
 
 
 def test_config_coerce_with_regex() -> None:
-    """Test that setting coerce=True in the Config of a DataFrameModel is sufficient to coerce a column in the case
+    """Test that setting coerce=True for a DataFrameSchema is sufficient to coerce a column in the case
     where the column has regex=True."""
 
-    class ModelWithRegex(DataFrameModel):
-        class Config:
-            coerce = True
+    schema_with_regex = DataFrameSchema(
+        columns={"col": Column(dtype=bool, regex=True)},
+        coerce=True,
+    )
 
-        col: Series[bool] = Field(alias="alias", regex=True)
+    df = pd.DataFrame({"col": [1, 0]})
 
-    df = pd.DataFrame({"alias": [1, 0]})
-
-    assert isinstance(ModelWithRegex.validate(df), pd.DataFrame)
+    assert isinstance(schema_with_regex.validate(df), pd.DataFrame)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes [#1182](https://github.com/unionai-oss/pandera/issues/1182). I ran into this bug myself, then found it was previously reported.

See the included tests for a minimal example of the bug: `test_config_coerce()` passes on `main`; `test_config_coerce_with_regex()` fails on `main`, but passes with this fix. 

The change I've submitted here is the minimal change necessary to fix the bug. With this fix, some code is duplicated between the regex and non-regex blocks of the `_coerce_dtype_helper()` function. I considered separating it into helper functions like `_should_coerce()` or `_override_and_try_coercion()`, but there are several ways one could split it up, so I figured reviewers can decide which of those would be preferred.

Also, I wasn't sure which file the tests should go in -- let me know if they should be moved.