### PR TITLE
bugfix/1607: coercion error should correctly report relevant failure cases

### DIFF
--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -57,7 +57,7 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
             try:
                 engine_dtype = pe.Engine.dtype(annotation.raw_annotation)
                 dtype = engine_dtype.type
-            except TypeError as exc:
+            except (TypeError, ValueError) as exc:
                 if annotation.metadata:
                     if field.dtype_kwargs:
                         raise TypeError(

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -158,7 +158,7 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                         failure_case=pl.Series(
                             err.failure_cases.rows(named=True)
                         )
-                    ).select(pl.col.failure_case)
+                    ).select(pl.col.failure_case.struct.json_encode())
                 else:
                     failure_cases_df = err.failure_cases.rename(
                         {err.failure_cases.columns[0]: "failure_case"}

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -156,6 +156,8 @@ class DataType(dtypes.DataType):
             is_coercible, failure_cases = polars_coerce_failure_cases(
                 data_container=data_container, type_=self.type
             )
+            if data_container.key:
+                failure_cases = failure_cases.select(data_container.key)
             raise errors.ParserError(
                 f"Could not coerce {_key} LazyFrame with schema "
                 f"{data_container.lazyframe.schema} "

--- a/tests/polars/test_polars_config.py
+++ b/tests/polars/test_polars_config.py
@@ -171,6 +171,4 @@ def test_coerce_validation_depth_none(validation_depth_none, schema):
         try:
             schema.validate(data)
         except pa.errors.SchemaError as exc:
-            assert exc.failure_cases.rows(named=True) == [
-                {"a": "foo", "b": "c"}
-            ]
+            assert exc.failure_cases.rows(named=True) == [{"a": "foo"}]


### PR DESCRIPTION
Fixes #1607.

This PR makes sure that failure cases that consist of more than one column are json encoded so that they can be cast into string columns. Coercion errors with a specific key are reported more granularly, creating a failure cases dataframe with only that column instead of the whole dataframe.