### PR TITLE
Dataframe column schema

### DIFF
--- a/docs/source/reference/dtypes.rst
+++ b/docs/source/reference/dtypes.rst
@@ -90,6 +90,8 @@ Pydantic Dtypes
 
    pandera.engines.pandas_engine.PydanticModel
 
+.. _polars-dtypes:
+
 Polars Dtypes
 -------------
 

--- a/pandera/api/dataframe/components.py
+++ b/pandera/api/dataframe/components.py
@@ -1,0 +1,259 @@
+"""Common class for dataframe component specification."""
+
+import copy
+from typing import Any, Generic, List, Optional, TypeVar, cast
+
+from pandera.api.base.schema import BaseSchema, inferred_schema_guard
+from pandera.api.base.types import CheckList, ParserList
+from pandera.api.checks import Check
+from pandera.api.hypotheses import Hypothesis
+from pandera.api.parsers import Parser
+from pandera.dtypes import DataType, UniqueSettings
+from pandera.engines import PYDANTIC_V2
+
+if PYDANTIC_V2:
+    from pydantic import GetCoreSchemaHandler
+    from pydantic_core import core_schema
+
+
+TComponentSchemaBase = TypeVar("TComponentSchemaBase", bound="ComponentSchema")
+TDataObject = TypeVar("TDataObject")
+
+
+class ComponentSchema(Generic[TDataObject], BaseSchema):
+    """Base array validator object."""
+
+    def __init__(
+        self,
+        dtype: Optional[Any] = None,
+        checks: Optional[CheckList] = None,
+        parsers: Optional[ParserList] = None,
+        nullable: bool = False,
+        unique: bool = False,
+        report_duplicates: UniqueSettings = "all",
+        coerce: bool = False,
+        name: Any = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        default: Optional[Any] = None,
+        metadata: Optional[dict] = None,
+        drop_invalid_rows: bool = False,
+    ) -> None:
+        """Initialize array schema.
+
+        :param dtype: datatype of the column.
+        :param checks: If element_wise is True, then callable signature should
+            be:
+
+            ``Callable[Any, bool]`` where the ``Any`` input is a scalar element
+            in the column. Otherwise, the input is assumed to be a the data
+            object (Series, DataFrame).
+        :param nullable: Whether or not column can contain null values.
+        :param unique: Whether or not column can contain duplicate
+            values.
+        :param report_duplicates: how to report unique errors
+            - `exclude_first`: report all duplicates except first occurence
+            - `exclude_last`: report all duplicates except last occurence
+            - `all`: (default) report all duplicates
+        :param coerce: If True, when schema.validate is called the column will
+            be coerced into the specified dtype. This has no effect on columns
+            where ``dtype=None``.
+        :param name: column name in dataframe to validate.
+        :param title: A human-readable label for the series.
+        :param description: An arbitrary textual description of the series.
+        :param metadata: An optional key-value data.
+        :param default: The default value for missing values in the series.
+        :param drop_invalid_rows: if True, drop invalid rows on validation.
+        """
+
+        super().__init__(
+            dtype=dtype,
+            checks=checks,
+            parsers=parsers,
+            coerce=coerce,
+            name=name,
+            title=title,
+            description=description,
+            metadata=metadata,
+            drop_invalid_rows=drop_invalid_rows,
+        )
+
+        if parsers is None:
+            parsers = []
+        if isinstance(parsers, Parser):
+            parsers = [parsers]
+
+        if checks is None:
+            checks = []
+        if isinstance(checks, (Check, Hypothesis)):
+            checks = [checks]
+
+        self.parsers = parsers
+        self.checks = checks
+        self.nullable = nullable
+        self.unique = unique
+        self.report_duplicates = report_duplicates
+        self.title = title
+        self.description = description
+        self.default = default
+
+        # this attribute is not meant to be accessed by users and is explicitly
+        # set to True in the case that a schema is created by infer_schema.
+        self._IS_INFERRED = False
+
+        self._validate_attributes()
+
+    def _validate_attributes(self):
+        ...
+
+    # the _is_inferred getter and setter methods are not public
+    @property
+    def _is_inferred(self):
+        return self._IS_INFERRED
+
+    @_is_inferred.setter
+    def _is_inferred(self, value: bool):
+        self._IS_INFERRED = value
+
+    @property
+    def _allow_groupby(self):
+        """Whether the schema or schema component allows groupby operations."""
+        raise NotImplementedError(  # pragma: no cover
+            "The _allow_groupby property must be implemented by subclasses "
+            "of SeriesSchemaBase"
+        )
+
+    # @property
+    # def dtype(self) -> DataType:
+    #     """Get the dtype"""
+    #     return self._dtype  # type: ignore
+
+    # @dtype.setter
+    # def dtype(self, value: Any) -> None:
+    #     """Set the dtype"""
+    #     raise NotImplementedError
+
+    def coerce_dtype(self, check_obj: TDataObject) -> TDataObject:
+        """Coerce type of the data by type specified in dtype.
+
+        :param check_obj: data to coerce
+        :returns: data of the same type as the input
+        """
+        return self.get_backend(check_obj).coerce_dtype(check_obj, schema=self)
+
+    def validate(
+        self,
+        check_obj,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ):
+        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        """Validate a series or specific column in dataframe.
+
+        :check_obj: data object to validate.
+        :param head: validate the first n rows. Rows overlapping with `tail` or
+            `sample` are de-duplicated.
+        :param tail: validate the last n rows. Rows overlapping with `head` or
+            `sample` are de-duplicated.
+        :param sample: validate a random sample of n rows. Rows overlapping
+            with `head` or `tail` are de-duplicated.
+        :param random_state: random seed for the ``sample`` argument.
+        :param lazy: if True, lazily evaluates dataframe against all validation
+            checks and raises a ``SchemaErrors``. Otherwise, raise
+            ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
+        :returns: validated DataFrame or Series.
+
+        """
+        return self.get_backend(check_obj).validate(
+            check_obj,
+            schema=self,
+            head=head,
+            tail=tail,
+            sample=sample,
+            random_state=random_state,
+            lazy=lazy,
+            inplace=inplace,
+        )
+
+    def __call__(
+        self,
+        check_obj: TDataObject,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> TDataObject:
+        """Alias for ``validate`` method."""
+        return self.validate(
+            check_obj, head, tail, sample, random_state, lazy, inplace
+        )
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    if PYDANTIC_V2:
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, _source_type: Any, _handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
+            return core_schema.no_info_plain_validator_function(
+                cls._pydantic_validate,  # type: ignore[misc]
+            )
+
+    else:
+
+        @classmethod
+        def __get_validators__(cls):
+            yield cls._pydantic_validate
+
+    @classmethod
+    def _pydantic_validate(  # type: ignore
+        cls: TComponentSchemaBase, schema: Any
+    ) -> TComponentSchemaBase:
+        """Verify that the input is a compatible Schema."""
+        if not isinstance(schema, cls):  # type: ignore
+            raise TypeError(f"{schema} is not a {cls}.")
+
+        return cast(TComponentSchemaBase, schema)
+
+    #############################
+    # Schema Transforms Methods #
+    #############################
+
+    @inferred_schema_guard
+    def update_checks(self, checks: List[Check]):
+        """Create a new SeriesSchema with a new set of Checks
+
+        :param checks: checks to set on the new schema
+        :returns: a new SeriesSchema with a new set of checks
+        """
+        schema_copy = cast(ComponentSchema, copy.deepcopy(self))
+        schema_copy.checks = checks
+        return schema_copy
+
+    def set_checks(self, checks: CheckList):
+        """Create a new SeriesSchema with a new set of Checks
+
+        .. caution::
+           This method will be deprecated in favor of ``update_checks`` in
+           v0.15.0
+
+        :param checks: checks to set on the new schema
+        :returns: a new SeriesSchema with a new set of checks
+        """
+        return self.update_checks(checks)
+
+    def __repr__(self):
+        return (
+            f"<Schema {self.__class__.__name__}"
+            f"(name={self.name}, type={self.dtype!r})>"
+        )

--- a/pandera/api/dataframe/components.py
+++ b/pandera/api/dataframe/components.py
@@ -8,7 +8,7 @@ from pandera.api.base.types import CheckList, ParserList
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
 from pandera.api.parsers import Parser
-from pandera.dtypes import DataType, UniqueSettings
+from pandera.dtypes import UniqueSettings
 from pandera.engines import PYDANTIC_V2
 
 if PYDANTIC_V2:
@@ -122,16 +122,6 @@ class ComponentSchema(Generic[TDataObject], BaseSchema):
             "The _allow_groupby property must be implemented by subclasses "
             "of SeriesSchemaBase"
         )
-
-    # @property
-    # def dtype(self) -> DataType:
-    #     """Get the dtype"""
-    #     return self._dtype  # type: ignore
-
-    # @dtype.setter
-    # def dtype(self, value: Any) -> None:
-    #     """Set the dtype"""
-    #     raise NotImplementedError
 
     def coerce_dtype(self, check_obj: TDataObject) -> TDataObject:
         """Coerce type of the data by type specified in dtype.

--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -54,7 +54,7 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         checks: Optional[CheckList] = None,
         parsers: Optional[ParserList] = None,
         index=None,
-        dtype: Any = None,
+        dtype: Optional[Any] = None,
         coerce: bool = False,
         strict: StrictType = False,
         name: Optional[str] = None,

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -1,120 +1,30 @@
 """Core pandas array specification."""
 
-import copy
 import warnings
-from typing import Any, List, Optional, TypeVar, Union, cast
+from typing import Any, Generic, Optional, TypeVar, Union, cast
 
 import pandas as pd
 
 from pandera import errors
 from pandera import strategies as st
-from pandera.api.base.schema import BaseSchema, inferred_schema_guard
 from pandera.api.base.types import CheckList, ParserList
-from pandera.api.checks import Check
-from pandera.api.hypotheses import Hypothesis
+from pandera.api.dataframe.components import ComponentSchema, TDataObject
 from pandera.api.pandas.types import PandasDtypeInputTypes, is_field
-from pandera.api.parsers import Parser
 from pandera.backends.pandas.register import register_pandas_backends
 from pandera.config import get_config_context
 from pandera.dtypes import DataType, UniqueSettings
-from pandera.engines import PYDANTIC_V2, pandas_engine
-
-if PYDANTIC_V2:
-    from pydantic import GetCoreSchemaHandler
-    from pydantic_core import core_schema
+from pandera.engines import pandas_engine
 
 
-TArraySchemaBase = TypeVar("TArraySchemaBase", bound="ArraySchema")
-
-
-class ArraySchema(BaseSchema):
+class ArraySchema(ComponentSchema[TDataObject]):
     """Base array validator object."""
 
-    def __init__(
-        self,
-        dtype: Optional[PandasDtypeInputTypes] = None,
-        checks: Optional[CheckList] = None,
-        parsers: Optional[ParserList] = None,
-        nullable: bool = False,
-        unique: bool = False,
-        report_duplicates: UniqueSettings = "all",
-        coerce: bool = False,
-        name: Any = None,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
-        default: Optional[Any] = None,
-        metadata: Optional[dict] = None,
-        drop_invalid_rows: bool = False,
-    ) -> None:
-        """Initialize array schema.
-
-        :param dtype: datatype of the column. If a string is specified,
-            then assumes one of the valid pandas string values:
-            http://pandas.pydata.org/pandas-docs/stable/basics.html#dtypes
-        :param checks: If element_wise is True, then callable signature should
-            be:
-
-            ``Callable[Any, bool]`` where the ``Any`` input is a scalar element
-            in the column. Otherwise, the input is assumed to be a
-            pandas.Series object.
-        :param nullable: Whether or not column can contain null values.
-        :param unique: Whether or not column can contain duplicate
-            values.
-        :param report_duplicates: how to report unique errors
-            - `exclude_first`: report all duplicates except first occurence
-            - `exclude_last`: report all duplicates except last occurence
-            - `all`: (default) report all duplicates
-        :param coerce: If True, when schema.validate is called the column will
-            be coerced into the specified dtype. This has no effect on columns
-            where ``dtype=None``.
-        :param name: column name in dataframe to validate.
-        :param title: A human-readable label for the series.
-        :param description: An arbitrary textual description of the series.
-        :param metadata: An optional key-value data.
-        :param default: The default value for missing values in the series.
-        :param drop_invalid_rows: if True, drop invalid rows on validation.
-        """
-
-        super().__init__(
-            dtype=dtype,
-            checks=checks,
-            parsers=parsers,
-            coerce=coerce,
-            name=name,
-            title=title,
-            description=description,
-            metadata=metadata,
-            drop_invalid_rows=drop_invalid_rows,
-        )
-
-        if parsers is None:
-            parsers = []
-        if isinstance(parsers, Parser):
-            parsers = [parsers]
-
-        if checks is None:
-            checks = []
-        if isinstance(checks, (Check, Hypothesis)):
-            checks = [checks]
-
-        self.parsers = parsers
-        self.checks = checks
-        self.nullable = nullable
-        self.unique = unique
-        self.report_duplicates = report_duplicates
-        self.title = title
-        self.description = description
-        self.default = default
-
+    def _validate_attributes(self):
         for check in self.checks:
             if check.groupby is not None and not self._allow_groupby:
                 raise errors.SchemaInitError(
                     f"Cannot use groupby checks with type {type(self)}"
                 )
-
-        # this attribute is not meant to be accessed by users and is explicitly
-        # set to True in the case that a schema is created by infer_schema.
-        self._IS_INFERRED = False
 
         if isinstance(self.dtype, pandas_engine.PydanticModel):
             raise errors.SchemaInitError(
@@ -125,23 +35,6 @@ class ArraySchema(BaseSchema):
     def _register_default_backends(self):
         register_pandas_backends()
 
-    # the _is_inferred getter and setter methods are not public
-    @property
-    def _is_inferred(self):
-        return self._IS_INFERRED
-
-    @_is_inferred.setter
-    def _is_inferred(self, value: bool):
-        self._IS_INFERRED = value
-
-    @property
-    def _allow_groupby(self):
-        """Whether the schema or schema component allows groupby operations."""
-        raise NotImplementedError(  # pragma: no cover
-            "The _allow_groupby property must be implemented by subclasses "
-            "of SeriesSchemaBase"
-        )
-
     @property
     def dtype(self) -> DataType:
         """Get the pandas dtype"""
@@ -151,129 +44,6 @@ class ArraySchema(BaseSchema):
     def dtype(self, value: Optional[PandasDtypeInputTypes]) -> None:
         """Set the pandas dtype"""
         self._dtype = pandas_engine.Engine.dtype(value) if value else None
-
-    def coerce_dtype(
-        self,
-        check_obj: Union[pd.Series, pd.Index],
-    ) -> Union[pd.Series, pd.Index]:
-        """Coerce type of a pd.Series by type specified in dtype.
-
-        :param pd.Series series: One-dimensional ndarray with axis labels
-            (including time series).
-        :returns: ``Series`` with coerced data type
-        """
-        return self.get_backend(check_obj).coerce_dtype(check_obj, schema=self)
-
-    def validate(
-        self,
-        check_obj,
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ):
-        # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-        """Validate a series or specific column in dataframe.
-
-        :check_obj: pandas DataFrame or Series to validate.
-        :param head: validate the first n rows. Rows overlapping with `tail` or
-            `sample` are de-duplicated.
-        :param tail: validate the last n rows. Rows overlapping with `head` or
-            `sample` are de-duplicated.
-        :param sample: validate a random sample of n rows. Rows overlapping
-            with `head` or `tail` are de-duplicated.
-        :param random_state: random seed for the ``sample`` argument.
-        :param lazy: if True, lazily evaluates dataframe against all validation
-            checks and raises a ``SchemaErrors``. Otherwise, raise
-            ``SchemaError`` as soon as one occurs.
-        :param inplace: if True, applies coercion to the object of validation,
-            otherwise creates a copy of the data.
-        :returns: validated DataFrame or Series.
-
-        """
-        return self.get_backend(check_obj).validate(
-            check_obj,
-            schema=self,
-            head=head,
-            tail=tail,
-            sample=sample,
-            random_state=random_state,
-            lazy=lazy,
-            inplace=inplace,
-        )
-
-    def __call__(
-        self,
-        check_obj: Union[pd.DataFrame, pd.Series],
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> Union[pd.DataFrame, pd.Series]:
-        """Alias for ``validate`` method."""
-        return self.validate(
-            check_obj, head, tail, sample, random_state, lazy, inplace
-        )
-
-    def __eq__(self, other):
-        return self.__dict__ == other.__dict__
-
-    if PYDANTIC_V2:
-
-        @classmethod
-        def __get_pydantic_core_schema__(
-            cls, _source_type: Any, _handler: GetCoreSchemaHandler
-        ) -> core_schema.CoreSchema:
-            return core_schema.no_info_plain_validator_function(
-                cls._pydantic_validate,  # type: ignore[misc]
-            )
-
-    else:
-
-        @classmethod
-        def __get_validators__(cls):
-            yield cls._pydantic_validate
-
-    @classmethod
-    def _pydantic_validate(  # type: ignore
-        cls: TArraySchemaBase, schema: Any
-    ) -> TArraySchemaBase:
-        """Verify that the input is a compatible Schema."""
-        if not isinstance(schema, cls):  # type: ignore
-            raise TypeError(f"{schema} is not a {cls}.")
-
-        return cast(TArraySchemaBase, schema)
-
-    #############################
-    # Schema Transforms Methods #
-    #############################
-
-    @inferred_schema_guard
-    def update_checks(self, checks: List[Check]):
-        """Create a new SeriesSchema with a new set of Checks
-
-        :param checks: checks to set on the new schema
-        :returns: a new SeriesSchema with a new set of checks
-        """
-        schema_copy = cast(ArraySchema, copy.deepcopy(self))
-        schema_copy.checks = checks
-        return schema_copy
-
-    def set_checks(self, checks: CheckList):
-        """Create a new SeriesSchema with a new set of Checks
-
-        .. caution::
-           This method will be deprecated in favor of ``update_checks`` in
-           v0.15.0
-
-        :param checks: checks to set on the new schema
-        :returns: a new SeriesSchema with a new set of checks
-        """
-        return self.update_checks(checks)
 
     ###########################
     # Schema Strategy Methods #
@@ -295,7 +65,7 @@ class ArraySchema(BaseSchema):
             size=size,
         )
 
-    def example(self, size=None) -> Union[pd.Series, pd.Index, pd.DataFrame]:
+    def example(self, size=None) -> TDataObject:
         """Generate an example of a particular size.
 
         :param size: number of elements in the generated array.
@@ -311,14 +81,8 @@ class ArraySchema(BaseSchema):
             )
             return self.strategy(size=size).example()
 
-    def __repr__(self):
-        return (
-            f"<Schema {self.__class__.__name__}"
-            f"(name={self.name}, type={self.dtype!r})>"
-        )
 
-
-class SeriesSchema(ArraySchema):
+class SeriesSchema(ArraySchema[pd.Series]):
     """A pandas Series validator."""
 
     def __init__(

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -1,7 +1,7 @@
 """Core pandas array specification."""
 
 import warnings
-from typing import Any, Generic, Optional, TypeVar, Union, cast
+from typing import Any, Optional, cast
 
 import pandas as pd
 

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pandera.strategies as st
 from pandera import errors
 from pandera.api.base.types import CheckList, ParserList
-from pandera.api.dataframe.components import ComponentSchema
 from pandera.api.pandas.array import ArraySchema
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.types import PandasDtypeInputTypes
@@ -144,44 +143,6 @@ class Column(ArraySchema[pd.DataFrame]):
         self.name = name
         return self
 
-    def validate(
-        self,
-        check_obj: pd.DataFrame,
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> pd.DataFrame:
-        """Validate a Column in a DataFrame object.
-
-        :param check_obj: pandas DataFrame to validate.
-        :param head: validate the first n rows. Rows overlapping with `tail` or
-            `sample` are de-duplicated.
-        :param tail: validate the last n rows. Rows overlapping with `head` or
-            `sample` are de-duplicated.
-        :param sample: validate a random sample of n rows. Rows overlapping
-            with `head` or `tail` are de-duplicated.
-        :param random_state: random seed for the ``sample`` argument.
-        :param lazy: if True, lazily evaluates dataframe against all validation
-            checks and raises a ``SchemaErrors``. Otherwise, raise
-            ``SchemaError`` as soon as one occurs.
-        :param inplace: if True, applies coercion to the object of validation,
-            otherwise creates a copy of the data.
-        :returns: validated DataFrame.
-        """
-        return self.get_backend(check_obj).validate(
-            check_obj,
-            self,
-            head=head,
-            tail=tail,
-            sample=sample,
-            random_state=random_state,
-            lazy=lazy,
-            inplace=inplace,
-        )
-
     def get_regex_columns(self, check_obj) -> Iterable:
         """Get matching column names based on regex column name pattern.
 
@@ -266,44 +227,6 @@ class Index(ArraySchema[pd.Index]):
         """Whether the schema or schema component allows groupby operations."""
         return False
 
-    def validate(
-        self,
-        check_obj: Union[pd.DataFrame, pd.Series],
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> Union[pd.DataFrame, pd.Series]:
-        """Validate DataFrameSchema or SeriesSchema Index.
-
-        :check_obj: pandas DataFrame of Series containing index to validate.
-        :param head: validate the first n rows. Rows overlapping with `tail` or
-            `sample` are de-duplicated.
-        :param tail: validate the last n rows. Rows overlapping with `head` or
-            `sample` are de-duplicated.
-        :param sample: validate a random sample of n rows. Rows overlapping
-            with `head` or `tail` are de-duplicated.
-        :param random_state: random seed for the ``sample`` argument.
-        :param lazy: if True, lazily evaluates dataframe against all validation
-            checks and raises a ``SchemaErrors``. Otherwise, raise
-            ``SchemaError`` as soon as one occurs.
-        :param inplace: if True, applies coercion to the object of validation,
-            otherwise creates a copy of the data.
-        :returns: validated DataFrame or Series.
-        """
-        return self.get_backend(check_obj).validate(
-            check_obj,
-            self,
-            head=head,
-            tail=tail,
-            sample=sample,
-            random_state=random_state,
-            lazy=lazy,
-            inplace=inplace,
-        )
-
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
@@ -354,7 +277,7 @@ class Index(ArraySchema[pd.Index]):
             return self.strategy(size=size).example()
 
 
-class MultiIndex(DataFrameSchema[Union[pd.Series, pd.DataFrame]]):
+class MultiIndex(DataFrameSchema):
     """Validate types and properties of a pandas DataFrame MultiIndex.
 
     This class inherits from :class:`~pandera.api.pandas.container.DataFrameSchema` to
@@ -461,44 +384,6 @@ class MultiIndex(DataFrameSchema[Union[pd.Series, pd.DataFrame]]):
     def coerce(self, value: bool) -> None:
         """Set coerce attribute."""
         self._coerce = value
-
-    def validate(  # type: ignore
-        self,
-        check_obj: Union[pd.DataFrame, pd.Series],
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> Union[pd.DataFrame, pd.Series]:
-        """Validate DataFrame or Series MultiIndex.
-
-        :param check_obj: pandas DataFrame of Series to validate.
-        :param head: validate the first n rows. Rows overlapping with `tail` or
-            `sample` are de-duplicated.
-        :param tail: validate the last n rows. Rows overlapping with `head` or
-            `sample` are de-duplicated.
-        :param sample: validate a random sample of n rows. Rows overlapping
-            with `head` or `tail` are de-duplicated.
-        :param random_state: random seed for the ``sample`` argument.
-        :param lazy: if True, lazily evaluates dataframe against all validation
-            checks and raises a ``SchemaErrors``. Otherwise, raise
-            ``SchemaError`` as soon as one occurs.
-        :param inplace: if True, applies coercion to the object of validation,
-            otherwise creates a copy of the data.
-        :returns: validated DataFrame or Series.
-        """
-        return self.get_backend(check_obj).validate(
-            check_obj,
-            schema=self,
-            head=head,
-            tail=tail,
-            sample=sample,
-            random_state=random_state,
-            lazy=lazy,
-            inplace=inplace,
-        )
 
     def __repr__(self):
         return (

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -8,13 +8,14 @@ import pandas as pd
 import pandera.strategies as st
 from pandera import errors
 from pandera.api.base.types import CheckList, ParserList
+from pandera.api.dataframe.components import ComponentSchema
 from pandera.api.pandas.array import ArraySchema
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.types import PandasDtypeInputTypes
 from pandera.dtypes import UniqueSettings
 
 
-class Column(ArraySchema):
+class Column(ArraySchema[pd.DataFrame]):
     """Validate types and properties of pandas DataFrame columns."""
 
     def __init__(
@@ -252,7 +253,7 @@ class Column(ArraySchema):
             )
 
 
-class Index(ArraySchema):
+class Index(ArraySchema[pd.Index]):
     """Validate types and properties of a pandas DataFrame Index."""
 
     @property
@@ -353,7 +354,7 @@ class Index(ArraySchema):
             return self.strategy(size=size).example()
 
 
-class MultiIndex(DataFrameSchema):
+class MultiIndex(DataFrameSchema[Union[pd.Series, pd.DataFrame]]):
     """Validate types and properties of a pandas DataFrame MultiIndex.
 
     This class inherits from :class:`~pandera.api.pandas.container.DataFrameSchema` to

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -1,7 +1,7 @@
 """Core pandas dataframe container specification."""
 
 import warnings
-from typing import Optional, TypeVar, Union
+from typing import Optional
 
 import pandas as pd
 
@@ -13,14 +13,8 @@ from pandera.dtypes import DataType
 from pandera.engines import pandas_engine
 
 
-TDataFrameObject = TypeVar(
-    "TDataFrameObject",
-    bound=Union[pd.DataFrame, pd.Series],
-)
-
-
 # pylint: disable=too-many-public-methods,too-many-locals
-class DataFrameSchema(_DataFrameSchema[TDataFrameObject]):
+class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
     """A light-weight pandas DataFrame validator."""
 
     def _register_default_backends(self):

--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -1,7 +1,7 @@
 """Core pandas dataframe container specification."""
 
 import warnings
-from typing import Optional
+from typing import Optional, TypeVar, Union
 
 import pandas as pd
 
@@ -13,8 +13,14 @@ from pandera.dtypes import DataType
 from pandera.engines import pandas_engine
 
 
+TDataFrameObject = TypeVar(
+    "TDataFrameObject",
+    bound=Union[pd.DataFrame, pd.Series],
+)
+
+
 # pylint: disable=too-many-public-methods,too-many-locals
-class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
+class DataFrameSchema(_DataFrameSchema[TDataFrameObject]):
     """A light-weight pandas DataFrame validator."""
 
     def _register_default_backends(self):

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import polars as pl
 
 from pandera.api.base.types import CheckList
-from pandera.api.pandas.components import Column as _Column
+from pandera.api.dataframe.components import ComponentSchema
 from pandera.api.polars.types import PolarsCheckObjects, PolarsDtypeInputTypes
 from pandera.backends.polars.register import register_polars_backends
 from pandera.config import config_context, get_config_context
@@ -16,7 +16,7 @@ from pandera.utils import is_regex
 logger = logging.getLogger(__name__)
 
 
-class Column(_Column):
+class Column(ComponentSchema[PolarsCheckObjects]):
     """Polars column schema component."""
 
     def __init__(
@@ -39,9 +39,9 @@ class Column(_Column):
         """Create column validator object.
 
         :param dtype: datatype of the column. The datatype for type-checking
-            a dataframe. If a string is specified, then assumes
-            one of the valid pandas string values:
-            http://pandas.pydata.org/pandas-docs/stable/basics.html#dtypes
+            a dataframe. All `polars datatypes <https://docs.pola.rs/py-polars/html/reference/datatypes.html>`__,
+            supported built-in python types that are supported by polars,
+            and the pandera polars engine :ref:`datatypes <polars-dtypes>`.
         :param checks: checks to verify validity of the column
         :param nullable: Whether or not column can contain null values.
         :param unique: whether column values should be unique
@@ -89,9 +89,7 @@ class Column(_Column):
             nullable=nullable,
             unique=unique,
             coerce=coerce,
-            required=required,
             name=name,
-            regex=regex,
             title=title,
             description=description,
             default=default,
@@ -99,6 +97,10 @@ class Column(_Column):
             drop_invalid_rows=drop_invalid_rows,
             **column_kwargs,
         )
+        self.required = required
+        self.regex = regex
+        self.name = name
+
         self.set_regex()
 
     def _register_default_backends(self):


### PR DESCRIPTION
This PR introduces a `pandera.api.dataframe.components` module that contains a `ComponentSchema` class. This class serves as a common base class for dataframe column components, which are used by the polars and pandas validation api. This will make it easier to add support for additional dataframe-like validation backends.