### PR TITLE
Bugfix/1616: Provide data_container to custom polars_engine dtype check 

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -42,7 +42,7 @@ class Check(BaseCheck):
     ) -> None:
         """Apply a validation function to a data object.
 
-        :param check_fn: A function to check pandas data structure. For Column
+        :param check_fn: A function to check data object. For Column
             or SeriesSchema checks, if element_wise is True, this function
             should have the signature: ``Callable[[pd.Series],
             Union[pd.Series, bool]]``, where the output series is a boolean
@@ -105,6 +105,9 @@ class Check(BaseCheck):
         :param check_kwargs: key-word arguments to pass into ``check_fn``
 
         :example:
+
+        The example below uses ``pandas``, but will apply to any of the supported
+        :ref:`dataframe libraries <dataframe-libraries>`.
 
         >>> import pandas as pd
         >>> import pandera as pa
@@ -202,9 +205,9 @@ class Check(BaseCheck):
         column: Optional[str] = None,
     ) -> CheckResult:
         # pylint: disable=too-many-branches
-        """Validate pandas DataFrame or Series.
+        """Validate DataFrame or Series.
 
-        :param check_obj: pandas DataFrame of Series to validate.
+        :param check_obj: DataFrame of Series to validate.
         :param column: for dataframe checks, apply the check function to this
             column.
         :returns: CheckResult tuple containing:
@@ -216,10 +219,10 @@ class Check(BaseCheck):
             passed overall.
 
             ``checked_object``: the checked object itself. Depending on the
-            options provided to the ``Check``, this will be a pandas Series,
-            DataFrame, or if the ``groupby`` option is specified, a
-            ``Dict[str, Series]`` or ``Dict[str, DataFrame]`` where the keys
-            are distinct groups.
+            options provided to the ``Check``, this will be a Series,
+            DataFrame, or if the ``groupby`` option is supported by the validation
+            backend and specified, a ``Dict[str, Series]`` or ``Dict[str, DataFrame]``
+            where the keys are distinct groups.
 
             ``failure_cases``: subset of the check_object that failed.
         """
@@ -230,7 +233,7 @@ class Check(BaseCheck):
     def equal_to(cls, value: Any, **kwargs) -> "Check":
         """Ensure all elements of a data container equal a certain value.
 
-        :param value: values in this pandas data structure must be
+        :param value: values in this data object must be
             equal to this value.
         """
         return cls.from_builtin_check_name(
@@ -244,8 +247,7 @@ class Check(BaseCheck):
     def not_equal_to(cls, value: Any, **kwargs) -> "Check":
         """Ensure no elements of a data container equals a certain value.
 
-        :param value: This value must not occur in the checked
-            :class:`pandas.Series`.
+        :param value: This value must not occur in the data object.
         """
         return cls.from_builtin_check_name(
             "not_equal_to",
@@ -261,7 +263,7 @@ class Check(BaseCheck):
         value.
 
         :param min_value: Lower bound to be exceeded. Must be a type comparable
-            to the dtype of the :class:`pandas.Series` to be validated (e.g. a
+            to the dtype of the data object to be validated (e.g. a
             numerical type for float or int and a datetime for datetime).
         """
         if min_value is None:
@@ -277,8 +279,8 @@ class Check(BaseCheck):
     def greater_than_or_equal_to(cls, min_value: Any, **kwargs) -> "Check":
         """Ensure all values are greater or equal a certain value.
 
-        :param min_value: Allowed minimum value for values of a series. Must be
-            a type comparable to the dtype of the :class:`pandas.Series` to be
+        :param min_value: Allowed minimum value for values of the data. Must be
+            a type comparable to the dtype of the data object to be
             validated.
         """
         if min_value is None:
@@ -296,7 +298,7 @@ class Check(BaseCheck):
 
         :param max_value: All elements of a series must be strictly smaller
             than this. Must be a type comparable to the dtype of the
-            :class:`pandas.Series` to be validated.
+            data object to be validated.
         """
         if max_value is None:
             raise ValueError("max_value must not be None")
@@ -312,7 +314,7 @@ class Check(BaseCheck):
         """Ensure values of a series are strictly below a maximum value.
 
         :param max_value: Upper bound not to be exceeded. Must be a type
-            comparable to the dtype of the :class:`pandas.Series` to be
+            comparable to the dtype of the data object to be
             validated.
         """
         if max_value is None:

--- a/pandera/backends/polars/components.py
+++ b/pandera/backends/polars/components.py
@@ -7,6 +7,7 @@ import polars as pl
 
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.api.polars.components import Column
+from pandera.api.polars.types import PolarsData
 from pandera.backends.base import CoreCheckResult
 from pandera.backends.polars.base import PolarsSchemaBackend, is_float_dtype
 from pandera.config import ValidationDepth, ValidationScope, get_config_context
@@ -322,7 +323,10 @@ class ColumnBackend(PolarsSchemaBackend):
             obj_dtype = check_obj_subset.schema[column]
             results.append(
                 CoreCheckResult(
-                    passed=schema.dtype.check(obj_dtype),
+                    passed=schema.dtype.check(
+                        obj_dtype,
+                        PolarsData(check_obj_subset, schema.selector),
+                    ),
                     check=f"dtype('{schema.dtype}')",
                     reason_code=SchemaErrorReason.WRONG_DATATYPE,
                     message=(

--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -27,9 +27,9 @@ from pydantic import validate_arguments
 
 from pandera import errors
 from pandera.api.base.error_handler import ErrorHandler
-from pandera.api.pandas.array import SeriesSchema
-from pandera.api.pandas.container import DataFrameSchema
-from pandera.api.pandas.model import DataFrameModel
+from pandera.api.dataframe.components import ComponentSchema
+from pandera.api.dataframe.container import DataFrameSchema
+from pandera.api.dataframe.model import DataFrameModel
 from pandera.inspection_utils import (
     is_classmethod_from_meta,
     is_decorated_classmethod,
@@ -37,7 +37,7 @@ from pandera.inspection_utils import (
 from pandera.typing import AnnotationInfo
 from pandera.validation_depth import validation_type
 
-Schemas = Union[DataFrameSchema, SeriesSchema]
+Schemas = Union[DataFrameSchema, ComponentSchema]
 InputGetter = Union[str, int]
 OutputGetter = Union[str, int, Callable]
 F = TypeVar("F", bound=Callable)
@@ -84,7 +84,7 @@ def _get_fn_argnames(fn: Callable) -> List[str]:
 def _handle_schema_error(
     decorator_name,
     fn: Callable,
-    schema: Union[DataFrameSchema, SeriesSchema],
+    schema: Union[DataFrameSchema, ComponentSchema],
     data_obj: Any,
     schema_error: errors.SchemaError,
 ) -> NoReturn:
@@ -110,7 +110,7 @@ def _handle_schema_error(
 def _parse_schema_error(
     decorator_name,
     fn: Callable,
-    schema: Union[DataFrameSchema, SeriesSchema],
+    schema: Union[DataFrameSchema, ComponentSchema],
     data_obj: Any,
     schema_error: errors.SchemaError,
     reason_code: errors.SchemaErrorReason,
@@ -355,7 +355,7 @@ def check_output(
     # pylint: disable=too-many-boolean-expressions
     if callable(obj_getter) and (
         schema.coerce
-        or (schema.index is not None and schema.index.coerce)
+        or (schema.index is not None and schema.index.coerce)  # type: ignore[union-attr]
         or (
             isinstance(schema, DataFrameSchema)
             and any(col.coerce for col in schema.columns.values())
@@ -490,7 +490,7 @@ def check_io(
         out_schemas = out
         if isinstance(out, list):
             out_schemas = out
-        elif isinstance(out, (DataFrameSchema, SeriesSchema)):
+        elif isinstance(out, (DataFrameSchema, ComponentSchema)):
             out_schemas = [(None, out)]  # type: ignore
         elif isinstance(out, tuple):
             out_schemas = [out]

--- a/pandera/typing/polars.py
+++ b/pandera/typing/polars.py
@@ -35,6 +35,13 @@ if POLARS_INSTALLED:
         *new in 0.19.0*
         """
 
+    class DataFrame(DataFrameBase, pl.DataFrame, Generic[T]):
+        """
+        Pandera generic for pl.LazyFrame, only used for type annotation.
+
+        *new in 0.19.0*
+        """
+
     # pylint: disable=too-few-public-methods
     class Series(SeriesBase, pl.Series, Generic[T]):
         """

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -254,5 +254,4 @@ def test_set_default(data, dtype, default):
     assert validated_data.select(pl.col("column").eq(default).any()).item()
 
 
-def test_column_schema_on_lazyframe_coerce():
-    ...
+def test_column_schema_on_lazyframe_coerce(): ...

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -254,4 +254,5 @@ def test_set_default(data, dtype, default):
     assert validated_data.select(pl.col("column").eq(default).any()).item()
 
 
-def test_column_schema_on_lazyframe_coerce(): ...
+def test_column_schema_on_lazyframe_coerce():
+    ...

--- a/tests/polars/test_polars_decorators.py
+++ b/tests/polars/test_polars_decorators.py
@@ -1,0 +1,96 @@
+"""Unit tests for using schemas with polars and function decorators."""
+
+import polars as pl
+import pytest
+
+import pandera.polars as pa
+import pandera.typing.polars as pa_typing
+
+
+@pytest.fixture
+def data() -> pl.DataFrame:
+    return pl.DataFrame({"a": [1, 2, 3]})
+
+
+@pytest.fixture
+def invalid_data(data) -> pl.DataFrame:
+    return data.rename({"a": "b"})
+
+
+def test_polars_dataframe_check_io(data, invalid_data):
+    # pylint: disable=unused-argument
+
+    schema = pa.DataFrameSchema({"a": pa.Column(int)})
+
+    @pa.check_input(schema)
+    def fn_check_input(x):
+        ...
+
+    @pa.check_output(schema)
+    def fn_check_output(x):
+        return x
+
+    @pa.check_io(x=schema, out=schema)
+    def fn_check_io(x):
+        return x
+
+    @pa.check_io(x=schema, out=schema)
+    def fn_check_io_invalid(x):
+        return x.rename({"a": "b"})
+
+    # valid data should pass
+    fn_check_input(data)
+    fn_check_output(data)
+    fn_check_io(data)
+
+    # invalid data or invalid function should not pass
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_input(invalid_data)
+
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_output(invalid_data)
+
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_io_invalid(data)
+
+
+def test_polars_dataframe_check_types(data, invalid_data):
+    # pylint: disable=unused-argument
+
+    class Model(pa.DataFrameModel):
+        a: int
+
+    @pa.check_types
+    def fn_check_input(x: pa_typing.DataFrame[Model]):
+        ...
+
+    @pa.check_types
+    def fn_check_output(x) -> pa_typing.DataFrame[Model]:
+        return x
+
+    @pa.check_types
+    def fn_check_io(
+        x: pa_typing.DataFrame[Model],
+    ) -> pa_typing.DataFrame[Model]:
+        return x
+
+    @pa.check_types
+    def fn_check_io_invalid(
+        x: pa_typing.DataFrame[Model],
+    ) -> pa_typing.DataFrame[Model]:
+        return x.rename({"a": "b"})
+
+    # valid data should pass
+    fn_check_input(data)
+    fn_check_output(data)
+    fn_check_io(data)
+
+    # invalid data or invalid function should not pass
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_input(invalid_data)
+
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_output(invalid_data)
+
+    with pytest.raises(pa.errors.SchemaError):
+        fn_check_io_invalid(data)


### PR DESCRIPTION
Adds support for polars custom dtype data level validation by passing in the check_obj
Adds test demonstrating positive and negative case