### PR TITLE
fix pandas pyarrow string validation

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1660,7 +1660,9 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
         type = pd.ArrowDtype(pyarrow.int8())
         bit_width: int = 8
 
-    @Engine.register_dtype(equivalents=[pyarrow.string])
+    @Engine.register_dtype(
+        equivalents=[pyarrow.string, pd.ArrowDtype(pyarrow.string())]
+    )
     @immutable
     class ArrowString(DataType, dtypes.String):
         """Semantic representation of a :class:`pyarrow.string`."""

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -311,6 +311,12 @@ def test_invalid_pandas_extension_dtype():
 
 def test_check_equivalent(dtype: Any, pd_dtype: Any):
     """Test that a pandas-compatible dtype can be validated by check()."""
+    if (
+        pandas_engine.PYARROW_INSTALLED
+        and pandas_engine.PANDAS_2_0_0_PLUS
+        and dtype == "string[pyarrow]"
+    ):
+        pytest.skip("`string[pyarrow]` gets parsed to type `string` by pandas")
     actual_dtype = pandas_engine.Engine.dtype(pd_dtype)
     expected_dtype = pandas_engine.Engine.dtype(dtype)
     assert actual_dtype.check(expected_dtype)


### PR DESCRIPTION
Fixes a bug where pyarrow string would give a schema validation error.

Snippet:
```py
import pandas as pd
import pandera as pa
import pyarrow

df = pd.DataFrame([{"foo": "bar"}], dtype=pd.ArrowDtype(pyarrow.string()))
df.info()

Schema = pa.DataFrameSchema({"foo": pa.Column(pyarrow.string)})
Schema.validate(df).info()
```

Before:
```sh
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1 entries, 0 to 0
Data columns (total 1 columns):
 #   Column  Non-Null Count  Dtype          
---  ------  --------------  -----          
 0   foo     1 non-null      string[pyarrow]
dtypes: string[pyarrow](1)
memory usage: 139.0 bytes
Traceback (most recent call last):
  File "/home/jovyan/work/pandera/scraps.py", line 61, in <module>
    Schema.validate(df).info()
    ^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/api/pandas/container.py", line 125, in validate
    return self._validate(
           ^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/api/pandas/container.py", line 154, in _validate
    return self.get_backend(check_obj).validate(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/backends/pandas/container.py", line 104, in validate
    error_handler = self.run_checks_and_handle_errors(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/backends/pandas/container.py", line 179, in run_checks_and_handle_errors
    error_handler.collect_error(
  File "/home/jovyan/work/pandera/pandera/api/base/error_handler.py", line 54, in collect_error
    raise schema_error from original_exc
  File "/home/jovyan/work/pandera/pandera/backends/pandas/container.py", line 200, in run_schema_component_checks
    result = schema_component.validate(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/api/dataframe/components.py", line 163, in validate
    return self.get_backend(check_obj).validate(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/backends/pandas/components.py", line 132, in validate
    validate_column(check_obj, column_name)
  File "/home/jovyan/work/pandera/pandera/backends/pandas/components.py", line 92, in validate_column
    error_handler.collect_error(
  File "/home/jovyan/work/pandera/pandera/api/base/error_handler.py", line 54, in collect_error
    raise schema_error from original_exc
  File "/home/jovyan/work/pandera/pandera/backends/pandas/components.py", line 72, in validate_column
    validated_check_obj = super(ColumnBackend, self).validate(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/backends/pandas/array.py", line 81, in validate
    error_handler = self.run_checks_and_handle_errors(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/work/pandera/pandera/backends/pandas/array.py", line 145, in run_checks_and_handle_errors
    error_handler.collect_error(
  File "/home/jovyan/work/pandera/pandera/api/base/error_handler.py", line 54, in collect_error
    raise schema_error from original_exc
pandera.errors.SchemaError: expected series 'foo' to have type string[pyarrow], got string[pyarrow]
```

After:
```sh
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1 entries, 0 to 0
Data columns (total 1 columns):
 #   Column  Non-Null Count  Dtype          
---  ------  --------------  -----          
 0   foo     1 non-null      string[pyarrow]
dtypes: string[pyarrow](1)
memory usage: 139.0 bytes
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1 entries, 0 to 0
Data columns (total 1 columns):
 #   Column  Non-Null Count  Dtype          
---  ------  --------------  -----          
 0   foo     1 non-null      string[pyarrow]
dtypes: string[pyarrow](1)
memory usage: 139.0 bytes
```