### PR TITLE
Bugfix: add missing `reason_code` for pyspark backend

### DIFF
--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -227,7 +227,7 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
                 )
             except SchemaError as err:
                 error_handler.collect_error(
-                    ErrorCategory.DATA, err.reason_code, err
+                    ErrorCategory.DATA, SchemaErrorReason.DATAFRAME_CHECK, err
                 )
             except SchemaDefinitionError:
                 raise


### PR DESCRIPTION
Fixes issue #1645. 

Please let me know what needs to be changed/added. Thank you!