### PR TITLE
Updating Old `pandas-stubs` Link in Documentation

### DIFF
--- a/docs/source/mypy_integration.md
+++ b/docs/source/mypy_integration.md
@@ -9,7 +9,7 @@
 *new in 0.8.0*
 
 Pandera integrates with mypy to provide static type-linting of dataframes,
-relying on [pandas-stubs](https://github.com/VirtusLab/pandas-stubs)
+relying on [pandas-stubs](https://github.com/pandas-dev/pandas-stubs)
 for typing information.
 
 ```bash


### PR DESCRIPTION
I noticed that a link in `docs/source/mypy_integration.md` was linking to the [old VirtusLab `pandas-stubs` repository](https://github.com/VirtusLab/pandas-stubs) that is no longer maintained. This PR updates the link to [the newer one](https://github.com/pandas-dev/pandas-stubs) that is linked elsewhere in the documentation as well.