### PR TITLE
Implement basic validation backend for Ibis tables (alternative)

### DIFF
--- a/pandera/api/ibis/components.py
+++ b/pandera/api/ibis/components.py
@@ -1,0 +1,252 @@
+"""Schema components for ibis."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import ibis.expr.types as ir
+
+
+from pandera.api.base.types import CheckList
+from pandera.api.dataframe.components import ComponentSchema
+from pandera.api.ibis.types import IbisCheckObjects, IbisDtypeInputTypes
+from pandera.backends.ibis.register import register_ibis_backends
+from pandera.config import config_context, get_config_context
+from pandera.engines import ibis_engine
+from pandera.utils import is_regex
+
+logger = logging.getLogger(__name__)
+
+
+class Column(ComponentSchema[IbisCheckObjects]):
+    """ibis column schema component."""
+
+    def __init__(
+        self,
+        dtype: IbisDtypeInputTypes = None,
+        checks: Optional[CheckList] = None,
+        nullable: bool = False,
+        unique: bool = False,
+        coerce: bool = False,
+        required: bool = True,
+        name: Optional[str] = None,
+        regex: bool = False,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        default: Optional[Any] = None,
+        metadata: Optional[dict] = None,
+        drop_invalid_rows: bool = False,
+        **column_kwargs,
+    ) -> None:
+        """Create column validator object.
+
+        :param dtype: datatype of the column. The datatype for type-checking
+            a dataframe. All `ibis datatypes <https://ibis-project.org/reference/datatypes.html>`__,
+            supported built-in python types that are supported by ibis,
+            and the pandera ibis engine :ref:`datatypes <ibis-dtypes>`.
+        :param checks: checks to verify validity of the column
+        :param nullable: Whether or not column can contain null values.
+        :param unique: whether column values should be unique
+        :param coerce: If True, when schema.validate is called the column will
+            be coerced into the specified dtype. This has no effect on columns
+            where ``dtype=None``.
+        :param required: Whether or not column is allowed to be missing
+        :param name: column name in dataframe to validate. Names in the format
+            '^{regex_pattern}$' are treated as regular expressions. During
+            validation, this schema will be applied to any columns matching this
+            pattern.
+        :param regex: whether the ``name`` attribute should be treated as a
+            regex pattern to apply to multiple columns in a dataframe. If the
+            name is a regular expression, this attribute will automatically be
+            set to True.
+        :param title: A human-readable label for the column.
+        :param description: An arbitrary textual description of the column.
+        :param default: The default value for missing values in the column.
+        :param metadata: An optional key value data.
+        :param drop_invalid_rows: if True, drop invalid rows on validation.
+
+        :raises SchemaInitError: if impossible to build schema from parameters
+
+        :example:
+
+        >>> import pandas as pd
+        >>> import pandera as pa
+        >>>
+        >>>
+        >>> schema = pa.DataFrameSchema({
+        ...     "column": pa.Column(str)
+        ... })
+        >>>
+        >>> schema.validate(ibis.memtable({"columns" :[ "foo", "bar"]}))
+          column
+        0    foo
+        1    bar
+
+        See :ref:`here<column>` for more usage details.
+        """
+
+        super().__init__(
+            dtype=dtype,
+            checks=checks,
+            nullable=nullable,
+            unique=unique,
+            coerce=coerce,
+            name=name,
+            title=title,
+            description=description,
+            default=default,
+            metadata=metadata,
+            drop_invalid_rows=drop_invalid_rows,
+            **column_kwargs,
+        )
+        self.required = required
+        self.regex = regex
+        self.name = name
+
+        self.set_regex()
+
+    def _register_default_backends(self):
+        register_ibis_backends()
+
+    def validate(
+        self,
+        check_obj: IbisCheckObjects,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> IbisCheckObjects:
+        """Validate a Column in a DataFrame object.
+
+        :param check_obj: ibis LazyFrame to validate.
+        :param head: validate the first n rows. Rows overlapping with `tail` or
+            `sample` are de-duplicated.
+        :param tail: validate the last n rows. Rows overlapping with `head` or
+            `sample` are de-duplicated.
+        :param sample: validate a random sample of n rows. Rows overlapping
+            with `head` or `tail` are de-duplicated.
+        :param random_state: random seed for the ``sample`` argument.
+        :param lazy: if True, lazily evaluates dataframe against all validation
+            checks and raises a ``SchemaErrors``. Otherwise, raise
+            ``SchemaError`` as soon as one occurs.
+        :param inplace: if True, applies coercion to the object of validation,
+            otherwise creates a copy of the data.
+        :returns: validated DataFrame.
+        """
+        is_table = isinstance(check_obj, ir.Table)
+
+        if is_table:
+            check_obj = check_obj.lazy()
+
+        config_ctx = get_config_context(validation_depth_default=None)
+        validation_depth = config_ctx.validation_depth
+        with config_context(validation_depth=validation_depth):
+            output = self.get_backend(check_obj).validate(
+                check_obj,
+                self,
+                head=head,
+                tail=tail,
+                sample=sample,
+                random_state=random_state,
+                lazy=lazy,
+                inplace=inplace,
+            )
+        return output
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Get column properties."""
+        return {
+            "dtype": self.dtype,
+            "parsers": self.parsers,
+            "checks": self.checks,
+            "nullable": self.nullable,
+            "unique": self.unique,
+            "report_duplicates": self.report_duplicates,
+            "coerce": self.coerce,
+            "required": self.required,
+            "name": self.name,
+            "regex": self.regex,
+            "title": self.title,
+            "description": self.description,
+            "default": self.default,
+            "metadata": self.metadata,
+        }
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @dtype.setter
+    def dtype(self, value) -> None:
+        self._dtype = ibis_engine.Engine.dtype(value) if value else None
+
+    @property
+    def selector(self):
+        if self.name is not None and not is_regex(self.name) and self.regex:
+            return f"^{self.name}$"
+        return self.name
+
+    def set_regex(self):
+        if self.name is None:
+            return
+
+        if is_regex(self.name) and not self.regex:
+            logger.info(
+                f"Column schema '{self.name}' is a regex expression. "
+                "Setting regex=True."
+            )
+            self.regex = True
+
+    def set_name(self, name: str):
+        """Set the name of the schema.
+
+        If the name is a regex starting with '^' and ending with '$'
+        set the regex attribute to True.
+        """
+        self.name = name
+        self.set_regex()
+        return self
+
+    def strategy(self, *, size=None):
+        """Create a ``hypothesis`` strategy for generating a Column.
+
+        :param size: number of elements to generate
+        :returns: a dataframe strategy for a single column.
+
+        .. warning::
+
+           This method is not implemented in the ibis backend.
+        """
+        raise NotImplementedError(
+            "Data synthesis is not supported in with ibis schemas."
+        )
+
+    def strategy_component(self):
+        """Generate column data object for use by DataFrame strategy.
+
+        .. warning::
+
+           This method is not implemented in the ibis backend.
+        """
+        raise NotImplementedError(
+            "Data synthesis is not supported in with ibis schemas."
+        )
+
+    def example(self, size=None):
+        """Generate an example of a particular size.
+
+        :param size: number of elements in the generated Index.
+        :returns: pandas DataFrame object.
+
+        .. warning::
+
+           This method is not implemented in the ibis backend.
+        """
+        # pylint: disable=import-outside-toplevel,cyclic-import,import-error
+        raise NotImplementedError(
+            "Data synthesis is not supported in with ibis schemas."
+        )

--- a/pandera/api/ibis/components.py
+++ b/pandera/api/ibis/components.py
@@ -70,7 +70,7 @@ class Column(ComponentSchema[IbisCheckObjects]):
 
         :example:
 
-        >>> import pandas as pd
+        >>> import ibis
         >>> import pandera as pa
         >>>
         >>>

--- a/pandera/api/ibis/types.py
+++ b/pandera/api/ibis/types.py
@@ -1,0 +1,30 @@
+"""Ibis types."""
+
+import ibis.expr.types as ir
+from typing import NamedTuple, Optional, Union
+from ibis.expr.datatypes import DataType
+
+
+
+class IbisData(NamedTuple):
+    table: ir.Table
+    key: Optional[str] = None
+
+class CheckResult(NamedTuple):
+    """Check result for user-defined checks."""
+
+    check_output: ir.Table
+    check_passed: ir.Table
+    checked_object: ir.Table
+    failure_cases: ir.Table
+
+IbisCheckObjects = Union[ir.Table]
+
+IbisDtypeInputTypes = Union[
+    str,
+    type,
+    ir.Table,
+    ir.Column,
+    ir.Literal,
+    DataType
+]

--- a/pandera/backends/ibis/__init__.py
+++ b/pandera/backends/ibis/__init__.py
@@ -1,0 +1,1 @@
+"""Ibis backend implementation for schemas and checks."""

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -1,0 +1,715 @@
+"""Polars engine and data types."""
+
+import dataclasses
+import datetime
+import decimal
+from functools import reduce
+import inspect
+import warnings
+from typing import (
+    Any,
+    Iterable,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+import polars as pl
+from polars.datatypes import py_type_to_dtype
+from polars.type_aliases import SchemaDict
+
+import ibis.expr.types as ir
+
+from pandera import dtypes, errors
+from pandera.api.ibis.types import IbisData
+from pandera.api.polars.types import PolarsData
+from pandera.constants import CHECK_OUTPUT_KEY
+from pandera.dtypes import immutable
+from pandera.engines import engine
+
+from ibis.expr.datatypes import DataType as IbisDataTypes
+import ibis
+from ibis.common.exceptions import IbisTypeError, BackendConversionError, UnsupportedOperationError
+from parsy import ParseError
+
+IbisDataContainer = Union[ir.Table, ir.PyArrowData]
+
+COERCION_ERRORS = (
+    TypeError,
+    ibis.IbisError,
+    IbisTypeError, 
+    BackendConversionError, 
+    UnsupportedOperationError
+)
+
+
+def ibis_object_coercible(
+    data_container: IbisData, type_: IbisDataTypes
+) -> ir.Table:
+    """Checks whether a Ibis object is coercible with respect to a type."""
+    key = data_container.key 
+    columns = data_container.table.columns
+    coercible = data_container.table.try_cast(
+        {key: type_} if key else {x: type_ for x in columns},
+    ).select(pl.col(key).is_not_null())
+    
+    # reduce to a single boolean column
+    single_column = ~reduce(
+        lambda x,y : x|y, 
+        [coercible[x] for x in columns]
+    )
+    return ibis.memtable(single_column).rename({"is_coercible":"col0"})
+
+
+def ibis_failure_cases_from_coercible(
+    data_container: IbisData,
+    is_coercible: ir.Table,
+) -> ir.Table:
+    """Get the failure cases resulting from trying to coerce a polars object."""
+    return data_container.table.join(is_coercible).filter(
+        ~data_container.table[CHECK_OUTPUT_KEY]
+    )
+
+
+def ibis_coerce_failure_cases(
+    data_container: IbisData,
+    type_: Any,
+) -> Tuple[ir.Table, ir.Table]:
+    """
+    Get the failure cases resulting from trying to coerce a polars object
+    into particular data type.
+    """
+    try:
+        is_coercible = ibis_object_coercible(data_container, type_).execute()
+    except (TypeError, ibis.IbisError):
+        is_coercible = data_container.table.mutate(
+            **{CHECK_OUTPUT_KEY: ibis.literal(False)}
+        ).select(CHECK_OUTPUT_KEY)
+
+    try:
+        failure_cases = ibis_failure_cases_from_coercible(
+            data_container, is_coercible
+        )
+        is_coercible = is_coercible
+    except COERCION_ERRORS:
+        # If coercion fails, all of the relevant rows are failure cases
+        failure_cases = data_container.table.select(
+            data_container.key or data_container.table.columns
+        )
+
+        is_coercible = (
+            data_container.table.mutate(
+                **{CHECK_OUTPUT_KEY: ibis.literal(False)}
+            ).select(CHECK_OUTPUT_KEY)
+        )
+
+    return is_coercible, failure_cases
+
+
+@immutable(init=True)
+class DataType(dtypes.DataType):
+    """Base `DataType` for boxing Ibis data types."""
+
+
+    type: IbisDataTypes = dataclasses.field(repr=False, init=False)
+
+    def __init__(self, dtype: Optional[Any] = None):
+        super().__init__()
+        try:
+            object.__setattr__(self, "type", IbisDataTypes.from_string(dtype))
+        except ParseError:
+            object.__setattr__(self, "type", IbisDataTypes.from_typehint(dtype))
+    
+
+#     def __post_init__(self):
+#         # this method isn't called if __init__ is defined
+#         object.__setattr__(
+#             self, "type", py_type_to_dtype(self.type)
+#         )  # pragma: no cover
+
+#     def coerce(self, data_container: IbisDataContainer) -> pl.LazyFrame:
+#         """Coerce data container to the data type."""
+#         if isinstance(data_container, pl.LazyFrame):
+#             data_container = PolarsData(data_container)
+
+#         if data_container.key is None:
+#             dtypes = self.type
+#         else:
+#             dtypes = {data_container.key: self.type}
+
+#         return data_container.lazyframe.cast(dtypes, strict=True)
+
+#     def try_coerce(self, data_container: IbisDataContainer) -> pl.LazyFrame:
+#         """Coerce data container to the data type,
+#         raises a :class:`~pandera.errors.ParserError` if the coercion fails
+#         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
+#         """
+#         if isinstance(data_container, pl.LazyFrame):
+#             data_container = PolarsData(data_container)
+
+#         try:
+#             lf = self.coerce(data_container)
+#             lf.collect()
+#             return lf
+#         except COERCION_ERRORS as exc:  # pylint:disable=broad-except
+#             _key = (
+#                 ""
+#                 if data_container.key is None
+#                 else f"'{data_container.key}' in"
+#             )
+#             is_coercible, failure_cases = ibis_coerce_failure_cases(
+#                 data_container=data_container, type_=self.type
+#             )
+#             if data_container.key:
+#                 failure_cases = failure_cases.select(data_container.key)
+#             raise errors.ParserError(
+#                 f"Could not coerce {_key} LazyFrame with schema "
+#                 f"{data_container.lazyframe.schema} "
+#                 f"into type {self.type}",
+#                 failure_cases=failure_cases,
+#                 parser_output=is_coercible,
+#             ) from exc
+
+#     def check(
+#         self,
+#         pandera_dtype: dtypes.DataType,
+#         data_container: Optional[IbisDataContainer] = None,
+#     ) -> Union[bool, Iterable[bool]]:
+#         try:
+#             pandera_dtype = Engine.dtype(pandera_dtype)
+#         except TypeError:
+#             return False
+
+#         return self.type == pandera_dtype.type and super().check(pandera_dtype)
+
+#     def __str__(self) -> str:
+#         return str(self.type)
+
+#     def __repr__(self) -> str:
+#         return f"DataType({self})"
+
+
+# class Engine(  # pylint:disable=too-few-public-methods
+#     metaclass=engine.Engine, base_pandera_dtypes=DataType
+# ):
+#     """Polars data type engine."""
+
+#     @classmethod
+#     def dtype(cls, data_type: Any) -> dtypes.DataType:
+#         """Convert input into a polars-compatible
+#         Pandera :class:`~pandera.dtypes.DataType` object."""
+#         try:
+#             return engine.Engine.dtype(cls, data_type)
+#         except TypeError:
+#             try:
+#                 pl_dtype = py_type_to_dtype(data_type)
+#             except ValueError:
+#                 raise TypeError(
+#                     f"data type '{data_type}' not understood by "
+#                     f"{cls.__name__}."
+#                 ) from None
+
+#             try:
+#                 return engine.Engine.dtype(cls, pl_dtype)
+#             except TypeError:
+#                 return DataType(data_type)
+
+
+# ###############################################################################
+# # Numeric types
+# ###############################################################################
+# @Engine.register_dtype(
+#     equivalents=["int8", pl.Int8, dtypes.Int8, dtypes.Int8()]
+# )
+# @immutable
+# class Int8(DataType, dtypes.Int8):
+#     """Polars signed 8-bit integer data type."""
+
+#     type = pl.Int8
+
+
+# @Engine.register_dtype(
+#     equivalents=["int16", pl.Int16, dtypes.Int16, dtypes.Int16()]
+# )
+# @immutable
+# class Int16(DataType, dtypes.Int16):
+#     """Polars signed 16-bit integer data type."""
+
+#     type = pl.Int16
+
+
+# @Engine.register_dtype(
+#     equivalents=["int32", pl.Int32, dtypes.Int32, dtypes.Int32()]
+# )
+# @immutable
+# class Int32(DataType, dtypes.Int32):
+#     """Polars signed 32-bit integer data type."""
+
+#     type = pl.Int32
+
+
+# @Engine.register_dtype(
+#     equivalents=["int64", int, pl.Int64, dtypes.Int64, dtypes.Int64()]
+# )
+# @immutable
+# class Int64(DataType, dtypes.Int64):
+#     """Polars signed 64-bit integer data type."""
+
+#     type = pl.Int64
+
+
+# @Engine.register_dtype(
+#     equivalents=["uint8", pl.UInt8, dtypes.UInt8, dtypes.UInt8()]
+# )
+# @immutable
+# class UInt8(DataType, dtypes.UInt8):
+#     """Polars unsigned 8-bit integer data type."""
+
+#     type = pl.UInt8
+
+
+# @Engine.register_dtype(
+#     equivalents=["uint16", pl.UInt16, dtypes.UInt16, dtypes.UInt16()]
+# )
+# @immutable
+# class UInt16(DataType, dtypes.UInt16):
+#     """Polars unsigned 16-bit integer data type."""
+
+#     type = pl.UInt16
+
+
+# @Engine.register_dtype(
+#     equivalents=["uint32", pl.UInt32, dtypes.UInt32, dtypes.UInt32()]
+# )
+# @immutable
+# class UInt32(DataType, dtypes.UInt32):
+#     """Polars unsigned 32-bit integer data type."""
+
+#     type = pl.UInt32
+
+
+# @Engine.register_dtype(
+#     equivalents=["uint64", pl.UInt64, dtypes.UInt64, dtypes.UInt64()]
+# )
+# @immutable
+# class UInt64(DataType, dtypes.UInt64):
+#     """Polars unsigned 64-bit integer data type."""
+
+#     type = pl.UInt64
+
+
+# @Engine.register_dtype(
+#     equivalents=["float32", pl.Float32, dtypes.Float32, dtypes.Float32()]
+# )
+# @immutable
+# class Float32(DataType, dtypes.Float32):
+#     """Polars 32-bit floating point data type."""
+
+#     type = pl.Float32
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "float64",
+#         float,
+#         pl.Float64,
+#         dtypes.Float64,
+#         dtypes.Float64(),
+#     ]
+# )
+# @immutable
+# class Float64(DataType, dtypes.Float64):
+#     """Polars 64-bit floating point data type."""
+
+#     type = pl.Float64
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "decimal",
+#         decimal.Decimal,
+#         pl.Decimal,
+#         dtypes.Decimal,
+#         dtypes.Decimal(),
+#     ]
+# )
+# @immutable(init=True)
+# class Decimal(DataType, dtypes.Decimal):
+#     """Polars decimal data type."""
+
+#     type = pl.Decimal
+
+#     # polars Decimal doesn't have a rounding attribute
+#     rounding = None
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         precision: int = dtypes.DEFAULT_PYTHON_PREC,
+#         scale: int = 0,
+#     ) -> None:
+#         object.__setattr__(self, "precision", precision)
+#         object.__setattr__(self, "scale", scale)
+#         object.__setattr__(
+#             self, "type", pl.Decimal(precision=precision, scale=scale)
+#         )
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.Decimal):
+#         """Convert a :class:`polars.Decimal` to
+#         a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
+#         return cls(precision=polars_dtype.precision, scale=polars_dtype.scale)
+
+#     def coerce(self, data_container: IbisDataContainer) -> pl.LazyFrame:
+#         """Coerce data container to the data type."""
+#         if isinstance(data_container, pl.LazyFrame):
+#             data_container = PolarsData(data_container)
+
+#         key = data_container.key or "*"
+#         return data_container.lazyframe.cast({key: pl.Float64}).cast(
+#             {key: pl.Decimal(scale=self.scale, precision=self.precision)},
+#             strict=True,
+#         )
+
+#     def check(
+#         self,
+#         pandera_dtype: dtypes.DataType,
+#         data_container: Optional[IbisDataContainer] = None,
+#     ) -> Union[bool, Iterable[bool]]:
+#         try:
+#             pandera_dtype = Engine.dtype(pandera_dtype)
+#             assert isinstance(
+#                 pandera_dtype, Decimal
+#             ), "The return is expected to be of Decimal class"
+#         except TypeError:  # pragma: no cover
+#             return False
+
+#         try:
+#             return (
+#                 (self.type == pandera_dtype.type)
+#                 & (self.scale == pandera_dtype.scale)
+#                 & (self.precision == pandera_dtype.precision)
+#             )
+
+#         except TypeError:  # pragma: no cover
+#             return super().check(pandera_dtype)
+
+#     def __str__(self) -> str:
+#         return f"Decimal(precision={self.precision}, scale={self.scale})"
+
+
+# ###############################################################################
+# # Temporal types
+# ###############################################################################
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "date",
+#         datetime.date,
+#         pl.Date,
+#         dtypes.Date,
+#         dtypes.Date(),
+#     ]
+# )
+# @immutable
+# class Date(DataType, dtypes.Date):
+#     """Polars date data type."""
+
+#     type = pl.Date
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "datetime",
+#         datetime.datetime,
+#         pl.Datetime,
+#         dtypes.DateTime,
+#         dtypes.DateTime(),
+#     ]
+# )
+# @immutable(init=True)
+# class DateTime(DataType, dtypes.DateTime):
+#     """Polars datetime data type."""
+
+#     type: Type[pl.Datetime] = pl.Datetime
+#     time_zone_agnostic: bool = False
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         time_zone_agnostic: bool = False,
+#         time_zone: Optional[str] = None,
+#         time_unit: Optional[str] = None,
+#     ) -> None:
+
+#         _kwargs = {}
+#         if time_unit is not None:
+#             # avoid deprecated warning when initializing pl.Datetime:
+#             # passing time_unit=None is deprecated.
+#             _kwargs["time_unit"] = time_unit
+
+#         object.__setattr__(
+#             self, "type", pl.Datetime(time_zone=time_zone, **_kwargs)
+#         )
+#         object.__setattr__(self, "time_zone_agnostic", time_zone_agnostic)
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.Datetime):
+#         """Convert a :class:`polars.Decimal` to
+#         a Pandera :class:`pandera.engines.polars_engine.Decimal`."""
+#         return cls(
+#             time_zone=polars_dtype.time_zone, time_unit=polars_dtype.time_unit
+#         )
+
+#     def check(
+#         self,
+#         pandera_dtype: dtypes.DataType,
+#         data_container: Optional[IbisDataContainer] = None,
+#     ) -> Union[bool, Iterable[bool]]:
+#         try:
+#             pandera_dtype = Engine.dtype(pandera_dtype)
+#         except TypeError:
+#             return False
+
+#         if self.time_zone_agnostic:
+#             return (
+#                 isinstance(pandera_dtype.type, pl.Datetime)
+#                 and pandera_dtype.type.time_unit == self.type.time_unit
+#             )
+
+#         return self.type == pandera_dtype.type and super().check(pandera_dtype)
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "time",
+#         datetime.time,
+#         pl.Time,
+#     ]
+# )
+# @immutable
+# class Time(DataType):
+#     """Polars time data type."""
+
+#     type = pl.Time
+
+
+# @Engine.register_dtype(
+#     equivalents=[
+#         "timedelta",
+#         datetime.timedelta,
+#         pl.Duration,
+#         dtypes.Timedelta,
+#         dtypes.Timedelta(),
+#     ]
+# )
+# @immutable(init=True)
+# class Timedelta(DataType, dtypes.Timedelta):
+#     """Polars timedelta data type."""
+
+#     type = pl.Duration
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         time_unit: Literal["ns", "us", "ms"] = "us",
+#     ) -> None:
+#         object.__setattr__(self, "type", pl.Duration(time_unit))
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.Duration):
+#         """Convert a :class:`polars.Duration` to
+#         a Pandera :class:`pandera.engines.polars_engine.Duration`."""
+#         if polars_dtype.time_unit is None:
+#             return cls()
+#         return cls(time_unit=polars_dtype.time_unit)
+
+
+# ###############################################################################
+# # Nested types
+# ###############################################################################
+
+
+# @Engine.register_dtype(equivalents=[pl.Array])
+# @immutable(init=True)
+# class Array(DataType):
+#     """Polars Array nested type."""
+
+#     type = pl.Array
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         inner: Optional[IbisDataType] = None,
+#         width: Optional[int] = None,
+#     ) -> None:
+#         if inner or width:
+#             object.__setattr__(
+#                 self, "type", pl.Array(inner=inner, width=width)
+#             )
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.Array):
+#         return cls(inner=polars_dtype.inner, width=polars_dtype.width)
+
+
+# @Engine.register_dtype(equivalents=[pl.List])
+# @immutable(init=True)
+# class List(DataType):
+#     """Polars List nested type."""
+
+#     type = pl.List
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         inner: Optional[IbisDataType] = None,
+#     ) -> None:
+#         if inner:
+#             object.__setattr__(self, "type", pl.List(inner=inner))
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.List):
+#         return cls(inner=polars_dtype.inner)
+
+
+# @Engine.register_dtype(equivalents=[pl.Struct])
+# @immutable(init=True)
+# class Struct(DataType):
+#     """Polars Struct nested type."""
+
+#     type = pl.Struct
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self,
+#         fields: Optional[Union[Sequence[pl.Field], SchemaDict]] = None,
+#     ) -> None:
+#         if fields:
+#             object.__setattr__(self, "type", pl.Struct(fields=fields))
+
+#     @classmethod
+#     def from_parametrized_dtype(cls, polars_dtype: pl.Struct):
+#         return cls(fields=polars_dtype.fields)
+
+
+# ###############################################################################
+# # Other types
+# ###############################################################################
+
+
+# @Engine.register_dtype(
+#     equivalents=["bool", bool, pl.Boolean, dtypes.Bool, dtypes.Bool()]
+# )
+# @immutable
+# class Bool(DataType, dtypes.Bool):
+#     """Polars boolean data type."""
+
+#     type = pl.Boolean
+
+
+# @Engine.register_dtype(
+#     equivalents=["string", str, pl.Utf8, dtypes.String, dtypes.String()]
+# )
+# @immutable
+# class String(DataType, dtypes.String):
+#     """Polars string data type."""
+
+#     type = pl.Utf8
+
+
+# @Engine.register_dtype(equivalents=[pl.Categorical])
+# @immutable(init=True)
+# class Categorical(DataType):
+#     """Polars categorical data type."""
+
+#     type = pl.Categorical
+
+
+# @Engine.register_dtype(
+#     equivalents=["category", dtypes.Category, dtypes.Category()]
+# )
+# @immutable(init=True)
+# class Category(DataType, dtypes.Category):
+#     """Pandera categorical data type for polars."""
+
+#     type = pl.Utf8
+
+#     def __init__(  # pylint:disable=super-init-not-called
+#         self, categories: Optional[Iterable[Any]] = None
+#     ):
+#         dtypes.Category.__init__(self, categories, ordered=False)
+
+#     def coerce(self, data_container: IbisDataContainer) -> pl.LazyFrame:
+#         """Coerce data container to the data type."""
+#         if isinstance(data_container, pl.LazyFrame):
+#             data_container = PolarsData(data_container)
+
+#         lf = data_container.lazyframe.cast(self.type, strict=True)
+
+#         key = data_container.key or "*"
+#         belongs_to_categories = self.__belongs_to_categories(lf, key=key)
+
+#         all_true = (
+#             belongs_to_categories.select(pl.all_horizontal(key))
+#             .select(pl.all().all())
+#             .collect()
+#             .item()
+#         )
+#         if not all_true:
+#             raise ValueError(
+#                 f"Could not coerce {type(lf)} data_container "
+#                 f"into type {self.type}. Invalid categories found in data_container."
+#             )
+#         return lf
+
+#     def try_coerce(self, data_container: IbisDataContainer) -> pl.LazyFrame:
+#         """Coerce data container to the data type,
+
+#         raises a :class:`~pandera.errors.ParserError` if the coercion fails
+#         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
+#         """
+#         if isinstance(data_container, pl.LazyFrame):
+#             data_container = PolarsData(data_container)
+
+#         try:
+#             return self.coerce(data_container)
+#         except Exception as exc:  # pylint:disable=broad-except
+#             is_coercible: pl.LazyFrame = ibis_object_coercible(
+#                 data_container, self.type
+#             ) & self.__belongs_to_categories(
+#                 data_container.lazyframe, key=data_container.key
+#             )
+
+#             failure_cases = ibis_failure_cases_from_coercible(
+#                 data_container, is_coercible
+#             )
+#             raise errors.ParserError(
+#                 f"Could not coerce {type(data_container)} data_container "
+#                 f"into type {self.type}. Invalid categories found in data_container.",
+#                 failure_cases=failure_cases,
+#             ) from exc
+
+#     def __belongs_to_categories(
+#         self,
+#         lf: pl.LazyFrame,
+#         key: Optional[str] = None,
+#     ) -> pl.LazyFrame:
+#         return lf.select(pl.col(key or "*").is_in(self.categories))
+
+#     def __str__(self):
+#         return "Category"
+
+
+# @Engine.register_dtype(equivalents=["null", pl.Null])
+# @immutable
+# class Null(DataType):
+#     """Polars null data type."""
+
+#     type = pl.Null
+
+
+# @Engine.register_dtype(equivalents=["object", object, pl.Object])
+# @immutable
+# class Object(DataType):
+#     """Semantic representation of a :class:`numpy.object_`."""
+
+#     type = pl.Object

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ _extras_require = {
     "fastapi": ["fastapi"],
     "geopandas": ["geopandas", "shapely"],
     "polars": ["polars >= 0.20.0"],
+    "ibis": ["ibis-framework >= 9.0.0"]
 }
 
 extras_require = {


### PR DESCRIPTION
Raising an alternative WIP approach to Ibis table (#1451) which is based on the recent Polars integration.

- Ideally I'd like to migrate Polars classes and test suite so it works 1:1
- I fear I have bitten off more than I can chew given how complicated things like `polars_engine.py` looks
- Any guidance on how to proceed or if @deepyaman original push with #1451 is still the smarter move for getting basic Ibis support in Pandera