### PR TITLE
fix mistake in pa DataFrame typing API

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -258,7 +258,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
     def from_records(  # type: ignore
         schema: Type[T],
         data: Union[  # type: ignore
-            np.ndarray, List[Tuple[Any, ...]], Dict[Any, Any], pd.DataFrame
+            np.ndarray, List[Tuple[Any, ...]], List[Dict[Any, Any]], pd.DataFrame
         ],
         **kwargs,
     ) -> "DataFrame[T]":


### PR DESCRIPTION
from records signature should be: 
- from_records(schema: Type[T], data: Union[np.ndarrray, List[Tuple[Any, ...]], List[Dict[Any, Any]], pd.DataFrame], **kwargs,) -> "DataFrame[T]"  and not : 
- from_records(schema: Type[T], data: Union[np.ndarrray, List[Tuple[Any, ...]], Dict[Any, Any], pd.DataFrame], **kwargs,) -> "DataFrame[T]" 

records are list of tuples or dict.