### PR TITLE
fix: SQLModel table model not validated

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1297,12 +1297,11 @@ if GEOPANDAS_INSTALLED:
 class PydanticModel(DataType):
     """A pydantic model datatype applying to rows in a dataframe."""
 
-    type: Type[BaseModel] = dataclasses.field(default=None, init=False)
+    type: Type[BaseModel] = dataclasses.field(default=None, init=False)  # type: ignore[assignment]
     auto_coerce = True
 
     # pylint:disable=super-init-not-called
     def __init__(self, model: Type[BaseModel]) -> None:
-        self.type: Type[BaseModel]
         object.__setattr__(self, "type", model)
 
     def coerce(self, data_container: PandasObject) -> PandasObject:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1318,9 +1318,9 @@ class PydanticModel(DataType):
             try:
                 # pylint: disable=not-callable
                 if PYDANTIC_V2:
-                    row = self.type(**row).model_dump()
+                    row = self.type.model_validate(row).model_dump()
                 else:
-                    row = self.type(**row).dict()
+                    row = self.type.parse_obj(row).dict()
                 row["failure_cases"] = np.nan
             except ValidationError as exc:
                 row["failure_cases"] = {

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1297,11 +1297,11 @@ if GEOPANDAS_INSTALLED:
 class PydanticModel(DataType):
     """A pydantic model datatype applying to rows in a dataframe."""
 
-    type: Type[BaseModel] = dataclasses.field(default=None, init=False)  # type: ignore # noqa
     auto_coerce = True
 
     # pylint:disable=super-init-not-called
     def __init__(self, model: Type[BaseModel]) -> None:
+        self.type: Type[BaseModel]
         object.__setattr__(self, "type", model)
 
     def coerce(self, data_container: PandasObject) -> PandasObject:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1316,7 +1316,6 @@ class PydanticModel(DataType):
             cases.
             """
             try:
-                # pylint: disable=not-callable
                 if PYDANTIC_V2:
                     row = self.type.model_validate(row).model_dump()
                 else:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1297,6 +1297,7 @@ if GEOPANDAS_INSTALLED:
 class PydanticModel(DataType):
     """A pydantic model datatype applying to rows in a dataframe."""
 
+    type: Type[BaseModel] = dataclasses.field(default=None, init=False)
     auto_coerce = True
 
     # pylint:disable=super-init-not-called
@@ -1316,6 +1317,7 @@ class PydanticModel(DataType):
             cases.
             """
             try:
+                # pylint: disable=no-member
                 if PYDANTIC_V2:
                     row = self.type.model_validate(row).model_dump()
                 else:


### PR DESCRIPTION
When using a SQLModel class with `table=True` as `dtype`, schema is not validated. This is because such SQLModel classes do not validate data at init time (see [here](https://github.com/tiangolo/sqlmodel/issues/453)). This PR solves this by explicitly calling `model_validate`/`parse_obj` instead of instantiating the class.

Minimal example (`python=3.8 sqlmodel=0.0.19 pandera=0.19.3`):
```python
# example.py
import pandas as pd
import pandera as pa
from pandera.engines.pandas_engine import PydanticModel
from sqlmodel import SQLModel, Field

class Record(SQLModel, table=True):
    name: str = Field(primary_key=True)

class PydanticSchema(pa.DataFrameModel):
    class Config:
        dtype = PydanticModel(Record)

df = pd.DataFrame({"name": [3]})
PydanticSchema.validate(df)
```
Without the fix, validation succeeds while only emitting a warning from `model_dump()`:
```bash
$ python example.py 
UserWarning: Pydantic serializer warnings:
  Expected `str` but got `int` - serialized value may not be as expected
```
With the fix, a SchemaError is raised:
```bash
$ python example.py 
...
pandera.errors.SchemaError: Error while coercing 'PydanticSchema' to type <class '__main__.Record'>: Could not coerce <class 'pandas.core.frame.DataFrame'> data_container into type <class '__main__.Record'>
   index failure_case
0      0  {'name': 1}
```