### PR TITLE
Docs: fix missing import in data conversion code cell

### DIFF
--- a/docs/source/data_format_conversion.md
+++ b/docs/source/data_format_conversion.md
@@ -95,6 +95,8 @@ would also be a valid input to `transform`.
 import io
 import json
 
+import pandas as pd
+
 buffer = io.BytesIO()
 data = pd.DataFrame({"str_col": [*"abc"], "int_col": range(3)})
 data.to_parquet(buffer)


### PR DESCRIPTION
Pandas is imported in doctest global setup. This dependency needs to be imported at the cell level now that documentation code snippets are handled by myst-nb.