### PR TITLE
Depend on OpenJDK>8.0.0 for PySpark support

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -242,7 +242,7 @@ jobs:
           uv pip install --system -r requirements.in
           uv pip install --system --force-reinstall "numpy<2.0.0";
           uv pip install --system install-jdk==1.1.0
-          export JAVA_HOME=$(python -c "import jdk; jdk.install('11', vendor='temurin')")
+          export JAVA_HOME=$(python -c "import jdk; print(jdk.install('11', vendor='temurin'))")
 
       - run: |
           pip list

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -236,10 +236,13 @@ jobs:
         shell: bash
         # install numpy<2 for all extras. It seems to effects most packages in
         # the ecosystem.
+        # install openjdk for pyspark extra.
         run: |
           pip install uv
           uv pip install --system -r requirements.in
           uv pip install --system --force-reinstall "numpy<2.0.0";
+          uv pip install --system install-jdk==1.1.0
+          export JAVA_HOME=$(python -c "import jdk; jdk.install('11', vendor='temurin')")
 
       - run: |
           pip list

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,9 @@ build:
       # Install numpy<v2 to avoid breaking docs. This is because the env has
       # pyspark installed, which requires numpy<2.
       - python -m pip install "numpy<2"
+      # Install OpenJDK as Java backend in env to run PySpark examples in docs.
+      - python -m pip install "install-jdk==1.1.0"
+      - export JAVA_HOME=$(python -c "import jdk; jdk.install('11', vendor='temurin')")
 
 # Build documentation in the docs/ directory with Sphinx
 conda:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,9 @@ version: 2
 
 build:
   os: ubuntu-20.04
+  apt_packages:
+    # Install OpenJDK as Java backend to run PySpark examples.
+    - openjdk-11-jre-headless
   tools:
     python: "mambaforge-4.10"
   jobs:
@@ -14,9 +17,6 @@ build:
       # Install numpy<v2 to avoid breaking docs. This is because the env has
       # pyspark installed, which requires numpy<2.
       - python -m pip install "numpy<2"
-      # Install OpenJDK as Java backend in env to run PySpark examples in docs.
-      - python -m pip install "install-jdk==1.1.0"
-      - export JAVA_HOME=$(python -c "import jdk; jdk.install('11', vendor='temurin')")
 
 # Build documentation in the docs/ directory with Sphinx
 conda:

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,6 @@ dependencies:
 
   # pyspark extra
   - pyspark >= 3.2.0
-  - openjdk >= 8.0.0
 
   # polars extra
   - polars >= 0.20.0

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
 
   # pyspark extra
   - pyspark >= 3.2.0
+  - openjdk >= 8.0.0
 
   # polars extra
   - polars >= 0.20.0

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional
 
 import yaml
 
-EXCLUDE = {"python", "openjdk"}
+EXCLUDE = {"python"}
 RENAME: Dict[str, str] = {}
 
 REPO_PATH = Path(__file__).resolve().absolute().parents[1]

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional
 
 import yaml
 
-EXCLUDE = {"python"}
+EXCLUDE = {"python", "openjdk"}
 RENAME: Dict[str, str] = {}
 
 REPO_PATH = Path(__file__).resolve().absolute().parents[1]
@@ -47,6 +47,8 @@ def conda_package_to_pip(package: str) -> Optional[str]:
         if compare not in package:
             continue
         pkg, version = package.split(compare)
+        pkg = pkg.strip()
+
         if pkg in EXCLUDE:
             return None
 


### PR DESCRIPTION
Attempt to fix #1678.

A Java implementation (8/11/17) is required to run PySpark code snippets in the documentation, see #1678 for an example of a failing snippet. This change adds OpenJDK as a Conda dependency. Added OpenJDK to the list of packages to ignore when building the list of pip dependencies.