### PR TITLE
fix: default values set before coercion

### DIFF
--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -100,6 +100,10 @@ class ColumnBackend(ArraySchemaBackend):
         )
 
         for column_name in column_keys_to_check:
+            if pd.notna(schema.default):
+                check_obj[column_name] = check_obj[column_name].fillna(
+                    schema.default
+                )
             if schema.coerce:
                 try:
                     check_obj[column_name] = self.coerce_dtype(


### PR DESCRIPTION
fixes #1641

As noted in my last message of the issue, there's still the issue of a wrong dtype for the Int64 case (and probably many other dtypes), but I marked it as an xfail since we can't make any assumption if `coerce=False`.