### PR TITLE
feat: add remaining pyarrow types

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1661,7 +1661,12 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
         bit_width: int = 8
 
     @Engine.register_dtype(
-        equivalents=[pyarrow.string, pd.ArrowDtype(pyarrow.string())]
+        equivalents=[
+            pyarrow.string,
+            pyarrow.utf8,
+            pd.ArrowDtype(pyarrow.string()),
+            pd.ArrowDtype(pyarrow.utf8()),
+        ]
     )
     @immutable
     class ArrowString(DataType, dtypes.String):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -2058,6 +2058,17 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
                 keys_sorted=pyarrow_dtype.keys_sorted,  # type: ignore
             )
 
+        def coerce_value(self, value: Any) -> Any:
+            """Coerce a value to a particular type."""
+            return pyarrow.scalar(
+                value,
+                type=(
+                    self.type.pyarrow_dtype  # pylint: disable=E1101
+                    if self.type
+                    else None
+                ),
+            )
+
     @Engine.register_dtype(
         equivalents=[
             "binary[pyarrow]",

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1754,6 +1754,20 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
         bit_width: int = 32
 
     @Engine.register_dtype(
+        equivalents=[
+            "halffloat[pyarrow]",
+            pyarrow.float16,
+            pd.ArrowDtype(pyarrow.float16()),
+        ]
+    )
+    @immutable
+    class ArrowFloat16(ArrowFloat32):
+        """Semantic representation of a :class:`pyarrow.float16`."""
+
+        type = pd.ArrowDtype(pyarrow.float16())
+        bit_width: int = 16
+
+    @Engine.register_dtype(
         equivalents=[pyarrow.decimal128, pyarrow.Decimal128Type]
     )
     @immutable(init=True)
@@ -1897,3 +1911,206 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
             return cls(
                 fields=[pyarrow_dtype.field(i) for i in range(pyarrow_dtype.num_fields)]  # type: ignore
             )
+
+    @Engine.register_dtype(
+        equivalents=[
+            "null[pyarrow]",
+            pyarrow.null,
+            pd.ArrowDtype(pyarrow.null()),
+        ]
+    )
+    @immutable
+    class ArrowNull(DataType):
+        """Semantic representation of a :class:`pyarrow.null`."""
+
+        type = pd.ArrowDtype(pyarrow.null())
+
+    @Engine.register_dtype(
+        equivalents=[
+            "date32[day][pyarrow]",
+            pyarrow.date32,
+            pd.ArrowDtype(pyarrow.date32()),
+        ]
+    )
+    @immutable
+    class ArrowDate32(DataType, dtypes.Date):
+        """Semantic representation of a :class:`pyarrow.date32`."""
+
+        type = pd.ArrowDtype(pyarrow.date32())
+
+    @Engine.register_dtype(
+        equivalents=[
+            "date64[ms][pyarrow]",
+            pyarrow.date64,
+            pd.ArrowDtype(pyarrow.date64()),
+        ]
+    )
+    @immutable
+    class ArrowDate64(DataType, dtypes.Date):
+        """Semantic representation of a :class:`pyarrow.date64`."""
+
+        type = pd.ArrowDtype(pyarrow.date64())
+
+    @Engine.register_dtype(
+        equivalents=[pyarrow.duration, pyarrow.DurationType]
+    )
+    @immutable(init=True)
+    class ArrowDuration(DataType):
+        """Semantic representation of a :class:`pyarrow.duration`."""
+
+        type: Optional[pd.ArrowDtype] = dataclasses.field(
+            default=None, init=False
+        )
+        unit: Optional[str] = "ns"
+
+        def __post_init__(self):
+            type_ = pd.ArrowDtype(pyarrow.duration(self.unit))
+            object.__setattr__(self, "type", type_)
+
+        @classmethod
+        def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.DurationType):
+            return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+    @Engine.register_dtype(equivalents=[pyarrow.time32, pyarrow.Time32Type])
+    @immutable(init=True)
+    class ArrowTime32(DataType):
+        """Semantic representation of a :class:`pyarrow.time32`."""
+
+        type: Optional[pd.ArrowDtype] = dataclasses.field(
+            default=None, init=False
+        )
+        unit: Optional[str] = "ms"
+
+        def __post_init__(self):
+            type_ = pd.ArrowDtype(pyarrow.time32(self.unit))
+            object.__setattr__(self, "type", type_)
+
+        @classmethod
+        def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.Time32Type):
+            return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+        def coerce(self, data_container: PandasObject) -> PandasObject:
+            if data_container.dtype == self.type:
+                return data_container
+            else:
+                return data_container.astype(
+                    pd.ArrowDtype(pyarrow.int32())
+                ).astype(self.type)
+
+    @Engine.register_dtype(equivalents=[pyarrow.time64, pyarrow.Time64Type])
+    @immutable(init=True)
+    class ArrowTime64(DataType):
+        """Semantic representation of a :class:`pyarrow.time64`."""
+
+        type: Optional[pd.ArrowDtype] = dataclasses.field(
+            default=None, init=False
+        )
+        unit: Optional[str] = "ns"
+
+        def __post_init__(self):
+            type_ = pd.ArrowDtype(pyarrow.time64(self.unit))
+            object.__setattr__(self, "type", type_)
+
+        @classmethod
+        def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.Time64Type):
+            return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+        def coerce(self, data_container: PandasObject) -> PandasObject:
+            if data_container.dtype == self.type:
+                return data_container
+            else:
+                return data_container.astype(
+                    pd.ArrowDtype(pyarrow.int64())
+                ).astype(self.type)
+
+    @Engine.register_dtype(equivalents=[pyarrow.map_, pyarrow.MapType])
+    @immutable(init=True)
+    class ArrowMap(DataType):
+        """Semantic representation of a :class:`pyarrow.map_`."""
+
+        type: Optional[pd.ArrowDtype] = dataclasses.field(
+            default=None, init=False
+        )
+        key_type: Optional[pyarrow.DataType] = pyarrow.int64()
+        item_type: Optional[pyarrow.DataType] = pyarrow.int64()
+        keys_sorted: bool = False
+
+        def __post_init__(self):
+            type_ = pd.ArrowDtype(
+                pyarrow.map_(
+                    self.key_type,
+                    self.item_type,
+                    self.keys_sorted,
+                )
+            )
+            object.__setattr__(self, "type", type_)
+
+        @classmethod
+        def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.MapType):
+            return cls(
+                key_type=pyarrow_dtype.key_type,  # type: ignore
+                item_type=pyarrow_dtype.item_type,  # type: ignore
+                keys_sorted=pyarrow_dtype.keys_sorted,  # type: ignore
+            )
+
+    @Engine.register_dtype(
+        equivalents=[
+            "binary[pyarrow]",
+            pyarrow.binary,
+            pyarrow.FixedSizeBinaryType,
+            pd.ArrowDtype(pyarrow.binary()),
+        ]
+    )
+    @immutable(init=True)
+    class ArrowBinary(DataType, dtypes.Binary):
+        """Semantic representation of a :class:`pyarrow.binary`."""
+
+        type: Optional[pd.ArrowDtype] = dataclasses.field(
+            default=None, init=False
+        )
+        length: Optional[int] = -1
+
+        def __post_init__(self):
+            type_ = pd.ArrowDtype(pyarrow.binary(self.length))
+            object.__setattr__(self, "type", type_)
+
+        @classmethod
+        def from_parametrized_dtype(
+            cls,
+            pyarrow_dtype: Union[
+                pyarrow.DataType, pyarrow.FixedSizeBinaryType
+            ],
+        ):
+            try:
+                _dtype = cls(length=pyarrow_dtype.byte_width)  # type: ignore
+            except (ValueError, AttributeError):
+                _dtype = cls()  # type: ignore
+            return _dtype
+
+    @Engine.register_dtype(
+        equivalents=[
+            "large_binary[pyarrow]",
+            pyarrow.large_binary,
+            pd.ArrowDtype(pyarrow.large_binary()),
+        ]
+    )
+    @immutable
+    class ArrowLargeBinary(DataType):
+        """Semantic representation of a :class:`pyarrow.large_binary`."""
+
+        type = pd.ArrowDtype(pyarrow.large_binary())
+
+    @Engine.register_dtype(
+        equivalents=[
+            "large_string[pyarrow]",
+            pyarrow.large_string,
+            pyarrow.large_utf8,
+            pd.ArrowDtype(pyarrow.large_string()),
+            pd.ArrowDtype(pyarrow.large_utf8()),
+        ]
+    )
+    @immutable
+    class ArrowLargeString(DataType, dtypes.String):
+        """Semantic representation of a :class:`pyarrow.large_string`."""
+
+        type = pd.ArrowDtype(pyarrow.large_string())

--- a/tests/core/test_pandas_engine.py
+++ b/tests/core/test_pandas_engine.py
@@ -260,10 +260,8 @@ pandas_arrow_dtype_cases = (
     ),
     (pd.Series([None, pd.NA, np.nan]), pyarrow.null),
     (pd.Series([None, date(1970, 1, 1)]), pyarrow.date32),
-    (pd.Series([None, "1970-01-01"]), pyarrow.date32),
     (pd.Series([None, date(1970, 1, 1)]), pyarrow.date64),
-    (pd.Series([None, "1970-01-01"]), pyarrow.date64),
-    (pd.Series([1, 2, None]), pyarrow.duration("ns")),
+    (pd.Series([1, 2]), pyarrow.duration("ns")),
     (pd.Series([1, 1e3, 1e6, 1e9, None]), pyarrow.time32("ms")),
     (pd.Series([1, 1e3, 1e6, 1e9, None]), pyarrow.time64("ns")),
     (
@@ -285,6 +283,10 @@ pandas_arrow_dtype_cases = (
 @pytest.mark.parametrize(("data", "dtype"), pandas_arrow_dtype_cases)
 def test_pandas_arrow_dtype(data, dtype):
     """Test pyarrow dtype."""
+    if not (
+        pandas_engine.PYARROW_INSTALLED and pandas_engine.PANDAS_2_0_0_PLUS
+    ):
+        pytest.skip("Support of pandas 2.0.0+ with pyarrow only")
     dtype = pandas_engine.Engine.dtype(dtype)
 
     dtype.coerce(data)
@@ -333,6 +335,10 @@ pandas_arrow_dtype_error_cases = (
 @pytest.mark.parametrize(("data", "dtype"), pandas_arrow_dtype_error_cases)
 def test_pandas_arrow_dtype_error(data, dtype):
     """Test pyarrow dtype raises Error on bad data."""
+    if not (
+        pandas_engine.PYARROW_INSTALLED and pandas_engine.PANDAS_2_0_0_PLUS
+    ):
+        pytest.skip("Support of pandas 2.0.0+ with pyarrow only")
     dtype = pandas_engine.Engine.dtype(dtype)
 
     with pytest.raises(

--- a/tests/core/test_pandas_engine.py
+++ b/tests/core/test_pandas_engine.py
@@ -258,6 +258,27 @@ pandas_arrow_dtype_cases = (
             ]
         ),
     ),
+    (pd.Series([None, pd.NA, np.nan]), pyarrow.null),
+    (pd.Series([None, date(1970, 1, 1)]), pyarrow.date32),
+    (pd.Series([None, "1970-01-01"]), pyarrow.date32),
+    (pd.Series([None, date(1970, 1, 1)]), pyarrow.date64),
+    (pd.Series([None, "1970-01-01"]), pyarrow.date64),
+    (pd.Series([1, 2, None]), pyarrow.duration("ns")),
+    (pd.Series([1, 1e3, 1e6, 1e9, None]), pyarrow.time32("ms")),
+    (pd.Series([1, 1e3, 1e6, 1e9, None]), pyarrow.time64("ns")),
+    (
+        pd.Series(
+            [
+                [{"key": "a", "value": 1}, {"key": "b", "value": 2}],
+                [{"key": "c", "value": 3}],
+            ]
+        ),
+        pyarrow.map_(pyarrow.string(), pyarrow.int32()),
+    ),
+    (pd.Series(["foo", "barbaz", None]), pyarrow.binary()),
+    (pd.Series(["foo", "bar", "baz", None]), pyarrow.binary(3)),
+    (pd.Series(["foo", "barbaz", None]), pyarrow.large_binary()),
+    (pd.Series(["1", "1.0", "foo", "bar", None]), pyarrow.large_string()),
 )
 
 
@@ -269,7 +290,7 @@ def test_pandas_arrow_dtype(data, dtype):
     dtype.coerce(data)
 
 
-pandas_arrow_dtype_errors_cases = (
+pandas_arrow_dtype_error_cases = (
     (
         pd.Series([["a", "b", "c"]]),
         pyarrow.list_(pyarrow.int64()),
@@ -287,13 +308,39 @@ pandas_arrow_dtype_errors_cases = (
             ]
         ),
     ),
+    (pd.Series(["a", "1"]), pyarrow.null),
+    (pd.Series(["a", date(1970, 1, 1), "1970-01-01"]), pyarrow.date32),
+    (pd.Series(["a", date(1970, 1, 1), "1970-01-01"]), pyarrow.date64),
+    (pd.Series(["a"]), pyarrow.duration("ns")),
+    (pd.Series(["a", "b"]), pyarrow.time32("ms")),
+    (pd.Series(["a", "b"]), pyarrow.time64("ns")),
+    (
+        pd.Series(
+            [
+                [{"key": "a", "value": 1}, {"key": "b", "value": 2}],
+                [{"key": "c", "value": 3}],
+            ]
+        ),
+        pyarrow.map_(pyarrow.int32(), pyarrow.string()),
+    ),
+    (pd.Series([1, "foo", None]), pyarrow.binary()),
+    (pd.Series(["foo", "bar", "baz", None]), pyarrow.binary(2)),
+    (pd.Series([1, "foo", "barbaz", None]), pyarrow.large_binary()),
+    (pd.Series([1, 1.0, "foo", "bar", None]), pyarrow.large_string()),
 )
 
 
-@pytest.mark.parametrize(("data", "dtype"), pandas_arrow_dtype_errors_cases)
-def test_pandas_arrow_dtype_errors(data, dtype):
-    """Test pyarrow dtype raises ArrowInvalid or ArrowTypeError on bad data."""
+@pytest.mark.parametrize(("data", "dtype"), pandas_arrow_dtype_error_cases)
+def test_pandas_arrow_dtype_error(data, dtype):
+    """Test pyarrow dtype raises Error on bad data."""
     dtype = pandas_engine.Engine.dtype(dtype)
 
-    with pytest.raises((pyarrow.ArrowInvalid, pyarrow.ArrowTypeError)):
+    with pytest.raises(
+        (
+            pyarrow.ArrowInvalid,
+            pyarrow.ArrowTypeError,
+            NotImplementedError,
+            ValueError,
+        )
+    ):
         dtype.coerce(data)

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -52,6 +52,7 @@ if pandas_engine.PYARROW_INSTALLED and pandas_engine.PANDAS_2_0_0_PLUS:
             pandas_engine.ArrowBool,
             pandas_engine.ArrowDecimal128,
             pandas_engine.ArrowDictionary,
+            pandas_engine.ArrowFloat16,
             pandas_engine.ArrowFloat32,
             pandas_engine.ArrowFloat64,
             pandas_engine.ArrowInt8,
@@ -66,6 +67,16 @@ if pandas_engine.PYARROW_INSTALLED and pandas_engine.PANDAS_2_0_0_PLUS:
             pandas_engine.ArrowUInt64,
             pandas_engine.ArrowList,
             pandas_engine.ArrowStruct,
+            pandas_engine.ArrowNull,
+            pandas_engine.ArrowDate32,
+            pandas_engine.ArrowDate64,
+            pandas_engine.ArrowDuration,
+            pandas_engine.ArrowTime32,
+            pandas_engine.ArrowTime64,
+            pandas_engine.ArrowMap,
+            pandas_engine.ArrowBinary,
+            pandas_engine.ArrowLargeBinary,
+            pandas_engine.ArrowLargeString,
         ]
     )
 


### PR DESCRIPTION
Add the remaining pyarrow types as per the conversation in #1676.

Below types are added:

- null
- date32
- date64
- duration
- float16
- time32
- time64
- map_
- binary
- large_binary
- large_string

Note: `null` requires field `nullable` option to be set to `True` for successful validation.