### PR TITLE
Bugfix/1732: Fix misleading error when columns are missing and lazy=True

### DIFF
--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -180,6 +180,7 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                 ).cast(
                     {
                         "failure_case": pl.Utf8,
+                        "column": pl.String,
                         "index": pl.Int32,
                         "check_number": pl.Int32,
                     }
@@ -196,7 +197,11 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                 scalar_failure_cases["check_number"].append(err.check_index)
                 scalar_failure_cases["index"].append(None)
                 failure_cases_df = pl.DataFrame(scalar_failure_cases).cast(
-                    {"check_number": pl.Int32, "index": pl.Int32}
+                    {
+                        "check_number": pl.Int32,
+                        "column": pl.String,
+                        "index": pl.Int32,
+                    }
                 )
 
             failure_case_collection.append(failure_cases_df)

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -230,6 +230,28 @@ def test_required_columns():
         ldf.drop("a").pipe(schema.validate).collect()
 
 
+def test_missing_required_column_when_lazy_is_true():
+    """Test missing required columns when lazy=True."""
+    schema = DataFrameSchema(
+        {
+            "a": Column(pl.Int32),
+            "b": Column(pl.Int32),
+        }
+    )
+
+    df = pl.DataFrame({"a": [1, 2, 3]})
+
+    with pytest.raises(pa.errors.SchemaErrors) as exc:
+        schema.validate(df, lazy=True)
+
+    first_error = exc.value.schema_errors[0]
+
+    assert (
+        first_error.reason_code
+        == pa.errors.SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME
+    )
+
+
 def test_unique_column_names():
     """Test unique column names."""
     with pytest.warns(


### PR DESCRIPTION
PR to address [Issue 1732](https://github.com/unionai-oss/pandera/issues/1732)

Full details are available on the issue, but the error previously being raised was a SchemaError parroting a polars error from concatenating mismatching DFs `SchemaError: type String is incompatible with expected type Null`

The error was caused by the column `"column"` not being typed, and so when it only contained null values, the column was assigned null type.

To fix it, I just added typing to that column, and a test to ensure no regression.