### PR TITLE
Bugfix/1644: refactor geopandas and pyarrow dtypes to avoid top-level import

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -14,7 +14,6 @@ from typing import (
 
 from pandera import errors
 from pandera.api.base.checks import BaseCheck, CheckResult
-from pandera.strategies.base_strategies import SearchStrategy
 
 T = TypeVar("T")
 
@@ -37,7 +36,7 @@ class Check(BaseCheck):
         title: Optional[str] = None,
         description: Optional[str] = None,
         statistics: Optional[Dict[str, Any]] = None,
-        strategy: Optional[SearchStrategy] = None,
+        strategy: Optional[Any] = None,
         **check_kwargs,
     ) -> None:
         """Apply a validation function to a data object.

--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 from pandera import errors
-from pandera import strategies as st
+from pandera.import_utils import strategy_import_error
 from pandera.api.base.schema import BaseSchema, inferred_schema_guard
 from pandera.api.base.types import CheckList, ParserList, StrictType
 from pandera.api.checks import Check
@@ -1289,7 +1289,7 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
     # Schema Strategy Methods #
     ###########################
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy(
         self, *, size: Optional[int] = None, n_regex_columns: int = 1
     ):
@@ -1299,6 +1299,8 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         :param n_regex_columns: number of regex columns to generate.
         :returns: a strategy that generates pandas DataFrame objects.
         """
+        from pandera import strategies as st
+
         return st.dataframe_strategy(
             self.dtype,
             columns=self.columns,

--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -39,7 +39,7 @@ from pandera.api.dataframe.model_config import BaseConfig
 from pandera.api.parsers import Parser
 from pandera.engines import PYDANTIC_V2
 from pandera.errors import SchemaInitError
-from pandera.strategies import base_strategies as st
+from pandera.import_utils import strategy_import_error
 from pandera.typing import AnnotationInfo
 from pandera.typing.common import DataFrameBase
 from pandera.utils import docstring_substitution
@@ -293,7 +293,7 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
 
     # TODO: add docstring_substitution using generic class
     @classmethod
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy(cls: Type[TDataFrameModel], **kwargs):
         """Create a ``hypothesis`` strategy for generating a DataFrame.
 
@@ -305,7 +305,7 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
 
     # TODO: add docstring_substitution using generic class
     @classmethod
-    @st.strategy_import_error
+    @strategy_import_error
     def example(
         cls: Type[TDataFrameModel],
         **kwargs,

--- a/pandera/api/extensions.py
+++ b/pandera/api/extensions.py
@@ -12,7 +12,6 @@ import typing_inspect
 
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
-from pandera.strategies.base_strategies import STRATEGY_DISPATCHER
 
 
 class BuiltinCheckRegistrationError(Exception):
@@ -35,6 +34,7 @@ def register_builtin_check(
     This is the primary way for extending the Check api to define additional
     built-in checks.
     """
+    from pandera.strategies.base_strategies import STRATEGY_DISPATCHER
 
     if fn is None:
         return partial(

--- a/pandera/api/hypotheses.py
+++ b/pandera/api/hypotheses.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 from pandera import errors
 from pandera.api.checks import Check
-from pandera.strategies import SearchStrategy
 
 DEFAULT_ALPHA = 0.01
 
@@ -34,7 +33,7 @@ class Hypothesis(Check):
         title: Optional[str] = None,
         description: Optional[str] = None,
         statistics: Optional[Dict[str, Any]] = None,
-        strategy: Optional[SearchStrategy] = None,
+        strategy: Optional[Any] = None,
         **check_kwargs,
     ) -> None:
         """Perform a hypothesis test on a Series or DataFrame.

--- a/pandera/api/pandas/array.py
+++ b/pandera/api/pandas/array.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, cast
 import pandas as pd
 
 from pandera import errors
-from pandera import strategies as st
+from pandera.import_utils import strategy_import_error
 from pandera.api.base.types import CheckList, ParserList
 from pandera.api.dataframe.components import ComponentSchema, TDataObject
 from pandera.api.pandas.types import PandasDtypeInputTypes, is_field
@@ -50,13 +50,15 @@ class ArraySchema(ComponentSchema[TDataObject]):
     # Schema Strategy Methods #
     ###########################
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy(self, *, size=None):
         """Create a ``hypothesis`` strategy for generating a Series.
 
         :param size: number of elements to generate
         :returns: a strategy that generates pandas Series objects.
         """
+        from pandera import strategies as st
+
         return st.series_strategy(
             self.dtype,
             checks=self.checks,

--- a/pandera/api/pandas/components.py
+++ b/pandera/api/pandas/components.py
@@ -5,13 +5,13 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import pandas as pd
 
-import pandera.strategies as st
 from pandera import errors
 from pandera.api.base.types import CheckList, ParserList
 from pandera.api.pandas.array import ArraySchema
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.types import PandasDtypeInputTypes
 from pandera.dtypes import UniqueSettings
+from pandera.import_utils import strategy_import_error
 
 
 class Column(ArraySchema[pd.DataFrame]):
@@ -172,7 +172,7 @@ class Column(ArraySchema[pd.DataFrame]):
     # Schema Transform Methods #
     ############################
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy(self, *, size=None):
         """Create a ``hypothesis`` strategy for generating a Column.
 
@@ -181,9 +181,11 @@ class Column(ArraySchema[pd.DataFrame]):
         """
         return super().strategy(size=size).map(lambda x: x.to_frame())
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy_component(self):
         """Generate column data object for use by DataFrame strategy."""
+        import pandera.strategies as st
+
         return st.column_strategy(
             self.dtype,
             checks=self.checks,
@@ -234,13 +236,15 @@ class Index(ArraySchema[pd.Index]):
     # Schema Strategy Methods #
     ###########################
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy(self, *, size: Optional[int] = None):
         """Create a ``hypothesis`` strategy for generating an Index.
 
         :param size: number of elements to generate.
         :returns: index strategy.
         """
+        import pandera.strategies as st
+
         return st.index_strategy(
             self.dtype,  # type: ignore
             checks=self.checks,
@@ -250,9 +254,11 @@ class Index(ArraySchema[pd.Index]):
             size=size,
         )
 
-    @st.strategy_import_error
+    @strategy_import_error
     def strategy_component(self):
         """Generate column data object for use by MultiIndex strategy."""
+        import pandera.strategies as st
+
         return st.column_strategy(
             self.dtype,
             checks=self.checks,
@@ -421,11 +427,13 @@ class MultiIndex(DataFrameSchema):
     # Schema Strategy Methods #
     ###########################
 
-    @st.strategy_import_error
+    @strategy_import_error
     # NOTE: remove these ignore statements as part of
     # https://github.com/pandera-dev/pandera/issues/403
     # pylint: disable=arguments-differ
     def strategy(self, *, size=None):  # type: ignore
+        import pandera.strategies as st
+
         return st.multiindex_strategy(indexes=self.indexes, size=size)
 
     # NOTE: remove these ignore statements as part of

--- a/pandera/backends/pandas/hypotheses.py
+++ b/pandera/backends/pandas/hypotheses.py
@@ -11,6 +11,7 @@ from pandera.api.hypotheses import Hypothesis
 from pandera.api.pandas.types import is_field, is_table
 from pandera.backends.pandas.checks import PandasCheckBackend
 
+print(">>>>>")
 try:
     from scipy import stats  # pylint: disable=unused-import
 except ImportError:  # pragma: no cover

--- a/pandera/engines/geopandas_engine.py
+++ b/pandera/engines/geopandas_engine.py
@@ -1,5 +1,5 @@
 # pylint: disable=cyclic-import
-"""Geopandas type engine."""
+"""Geopandas data types for the pandas type engine."""
 
 from typing import Any, Iterable, Optional, Union
 
@@ -27,18 +27,13 @@ GeoPandasObject = Union[
 ]
 
 
-def register_geopandas_dtypes():
-    """Register geopandas-specific dtypes with the pandas engine."""
-    pandas_engine.Engine.register_dtype(
-        Geometry,
-        equivalents=[
-            "geometry",
-            GeometryDtype,
-            GeometryDtype(),
-        ],
-    )
-
-
+@pandas_engine.Engine.register_dtype(
+    equivalents=[
+        "geometry",
+        GeometryDtype,
+        GeometryDtype(),
+    ],
+)
 @dtypes.immutable(init=True)
 class Geometry(pandas_engine.DataType):
     """Semantic representation of geopandas :class:`geopandas.array.GeometryDtype`.

--- a/pandera/engines/geopandas_engine.py
+++ b/pandera/engines/geopandas_engine.py
@@ -1,0 +1,209 @@
+# pylint: disable=cyclic-import
+"""Geopandas type engine."""
+
+from typing import Any, Iterable, Optional, Union
+
+try:
+    import geopandas as gpd
+
+    GEOPANDAS_INSTALLED = True
+except ImportError:
+    GEOPANDAS_INSTALLED = False
+
+
+import dataclasses
+import numpy as np
+import pandas as pd
+import pyproj
+import shapely
+import shapely.geometry
+from geopandas.array import GeometryArray, GeometryDtype, from_shapely
+
+from pandera import dtypes, errors
+from pandera.engines import pandas_engine
+
+GeoPandasObject = Union[
+    pd.Series, pd.DataFrame, gpd.GeoSeries, gpd.GeoDataFrame
+]
+
+
+def register_geopandas_dtypes():
+    """Register geopandas-specific dtypes with the pandas engine."""
+    pandas_engine.Engine.register_dtype(
+        Geometry,
+        equivalents=[
+            "geometry",
+            GeometryDtype,
+            GeometryDtype(),
+        ],
+    )
+
+
+@dtypes.immutable(init=True)
+class Geometry(pandas_engine.DataType):
+    """Semantic representation of geopandas :class:`geopandas.array.GeometryDtype`.
+
+    Extends the native GeometryDtype by allowing designation of a coordinate
+    reference system (CRS) as found on GeometryArray, GeoSeries, and GeoDataFrame.
+    When the CRS is defined, validator will check for matching CRS, and coerce
+    will transform coordinate values via GeoPandas' 'to_crs' method. Otherwise, CRS
+    of data is ignored.
+    """
+
+    type = GeometryDtype()
+
+    crs: Optional[str] = dataclasses.field(default=None)
+    """Coordinate Reference System of the geometry objects.
+    """
+
+    # define __init__ to please mypy
+    def __init__(  # pylint:disable=super-init-not-called
+        self,
+        crs: Optional[Any] = None,
+    ) -> None:
+        if crs is not None:
+            try:
+                pyproj.CRS.from_user_input(crs)
+            except pyproj.exceptions.CRSError as exc:
+                raise TypeError(f"Invalid CRS: {str(crs)}") from exc
+
+            object.__setattr__(self, "crs", crs)
+
+    def _coerce_values(self, obj: GeoPandasObject) -> GeoPandasObject:
+        if isinstance(obj, gpd.GeoSeries) or (
+            isinstance(obj, (pd.DataFrame, gpd.GeoDataFrame))
+            and all(v == str(self) for v in obj.dtypes.to_dict().values())
+        ):
+            # Return as-is if we already have the proper underlying dtype
+            return obj
+
+        # Shapely objects
+        try:
+            return from_shapely(obj)
+        except TypeError:
+            ...
+
+        # Well-known Text (WKT) strings
+        try:
+            return from_shapely(shapely.from_wkt(obj))
+        except (TypeError, shapely.errors.GEOSException):
+            ...
+
+        # Well-known Binary (WKB) strings
+        try:
+            return from_shapely(shapely.from_wkb(obj))
+        except (TypeError, shapely.errors.GEOSException):
+            ...
+
+        # JSON/GEOJSON dictionary
+        return from_shapely(obj.map(self._coerce_element))  # type: ignore[operator]
+
+    def _coerce_element(self, element: Any) -> Any:
+        try:
+            return shapely.geometry.shape(element)
+        except (
+            AttributeError,
+            TypeError,
+            shapely.errors.GeometryTypeError,
+            shapely.errors.GEOSException,
+        ):
+            return np.nan
+
+    def _coerce_crs(self, value: GeoPandasObject) -> GeoPandasObject:
+        if self.crs is not None:
+            if value.crs is None:
+                # Allow assignment of CRS if currently
+                # null and a non-null value is designated.
+                # This will only work in the context of
+                # geopandas because assinging geometry
+                # CRS to a pandas dataframe isn't supported.
+                value.crs = self.crs
+            elif isinstance(value, gpd.GeoSeries) and self.crs != value.crs:
+                value = value.to_crs(self.crs)  # type: ignore[operator]
+            elif isinstance(value, gpd.GeoDataFrame) and any(
+                self.crs != value[col].crs for col in value.columns
+            ):
+                for col in value.columns:
+                    if self.crs != value[col].crs:
+                        value[col] = value[col].to_crs(self.crs)
+        return value
+
+    def coerce(self, data_container: GeoPandasObject) -> GeoPandasObject:
+        """Coerce data container to the specified data type."""
+        # pylint: disable=import-outside-toplevel
+        from pandera.backends.pandas import error_formatters
+
+        orig_isna = data_container.isna()
+
+        # Copy so we don't directly modify container due
+        # to CRS re-projection, etc.)
+        data_container = data_container.copy()
+
+        # Coerce container data
+        coerced_data = self._coerce_values(data_container)
+
+        # Coerce container type
+        if isinstance(coerced_data, (GeometryArray, pd.DataFrame)):
+            if isinstance(data_container, (pd.Series, gpd.GeoSeries)):
+                coerced_data = gpd.GeoSeries(coerced_data)
+            else:
+                coerced_data = gpd.GeoDataFrame(coerced_data)
+
+        failed_selector = coerced_data.isna() & ~orig_isna
+
+        if np.any(failed_selector.any()):
+            failure_cases = coerced_data[failed_selector]
+            raise errors.ParserError(
+                f"Could not coerce {type(data_container)} data_container "
+                f"into type {self.type}",
+                failure_cases=error_formatters.reshape_failure_cases(
+                    failure_cases, ignore_na=False
+                ),
+            )
+        coerced = self._coerce_crs(coerced_data)
+        return coerced
+
+    def check(  # type: ignore
+        self,
+        pandera_dtype: pandas_engine.DataType,
+        data_container: Optional[GeoPandasObject] = None,
+    ) -> Union[bool, Iterable[bool]]:
+        """Check data container to the specified data type."""
+        # Type check
+        if not super().check(pandera_dtype, data_container):
+            if data_container is None:
+                return False
+            else:
+                return np.full_like(data_container, False, dtype=bool)
+        if self.crs != pandera_dtype.crs and data_container is None:  # type: ignore[attr-defined]
+            return False
+
+        # CRS check extends into container
+        if self.crs is not None:
+            if (
+                isinstance(data_container, gpd.GeoSeries)
+                and data_container.crs != self.crs
+            ):
+                # GeoSeries
+                raise TypeError(
+                    f"CRS mismatch; actual {str(data_container.crs)}, expected {str(self.crs)}"
+                )
+            if isinstance(data_container, gpd.GeoDataFrame):
+                # GeoDataFrame
+                col_results = []
+                for col in data_container.columns:
+                    if data_container[col].crs != self.crs:
+                        col_err = f"CRS mismatch on column {col}; actual {str(data_container[col].crs)}, expected {str(self.crs)}"
+                        col_results.append(col_err)
+                if col_results:
+                    raise TypeError("\n".join(col_results))
+
+        return np.full_like(data_container, True, dtype=bool)
+
+    def __eq__(self, obj: object) -> bool:
+        if isinstance(obj, type(self)):
+            return obj.crs == self.crs
+        return super().__eq__(obj)
+
+    def __str__(self) -> str:
+        return "geometry"

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -113,6 +113,21 @@ def is_pyarrow_dtype(
     return isinstance(pd_dtype, pd.ArrowDtype)
 
 
+def is_geopandas_dtype(
+    pd_dtype: Union[PandasDataType, str],
+) -> Union[bool, Iterable[bool]]:
+    """Check if a value is a geopandas extension type or instance of one."""
+    try:
+        from geopandas.array import GeometryDtype
+    except ImportError:
+        return False
+
+    if pd_dtype == "geometry":
+        return True
+
+    return isinstance(pd_dtype, GeometryDtype)
+
+
 @immutable(init=True)
 class DataType(dtypes.DataType):
     """Base `DataType` for boxing Pandas data types."""
@@ -232,6 +247,15 @@ class Engine(  # pylint:disable=too-few-public-methods
                         "Usage Tip: Use an instance or a string "
                         "representation."
                     ) from None
+            elif is_geopandas_dtype(data_type):
+                # pylint: disable=cyclic-import
+                # register geopandas datatypes
+                from pandera.engines.geopandas_engine import (
+                    register_geopandas_dtypes,
+                )
+
+                register_geopandas_dtypes()
+                np_or_pd_dtype = data_type
             elif is_pyarrow_dtype(data_type):
                 np_or_pd_dtype = data_type.pyarrow_dtype
             else:
@@ -1084,207 +1108,6 @@ class Interval(DataType):
         """Convert a :class:`pandas.IntervalDtype` to
         a Pandera :class:`pandera.engines.pandas_engine.Interval`."""
         return cls(subtype=pd_dtype.subtype)  # type: ignore
-
-
-# ###############################################################################
-# # geopandas
-# ###############################################################################
-
-try:
-    import geopandas as gpd
-
-    GEOPANDAS_INSTALLED = True
-except ImportError:  # pragma: no cover
-    GEOPANDAS_INSTALLED = False
-
-if GEOPANDAS_INSTALLED:
-
-    import pyproj
-    import shapely
-    import shapely.geometry
-    from geopandas.array import GeometryArray, GeometryDtype, from_shapely
-
-    GeoPandasObject = Union[
-        pd.Series, pd.DataFrame, gpd.GeoSeries, gpd.GeoDataFrame
-    ]
-
-    @Engine.register_dtype(
-        equivalents=[
-            "geometry",
-            GeometryDtype,
-            GeometryDtype(),
-        ]
-    )
-    @dtypes.immutable(init=True)
-    class Geometry(DataType):
-        """Semantic representation of geopandas :class:`geopandas.array.GeometryDtype`.
-
-        Extends the native GeometryDtype by allowing designation of a coordinate
-        reference system (CRS) as found on GeometryArray, GeoSeries, and GeoDataFrame.
-        When the CRS is defined, validator will check for matching CRS, and coerce
-        will transform coordinate values via GeoPandas' 'to_crs' method. Otherwise, CRS
-        of data is ignored.
-        """
-
-        type = GeometryDtype()
-
-        crs: Optional[str] = dataclasses.field(default=None)
-        """Coordinate Reference System of the geometry objects.
-        """
-
-        # define __init__ to please mypy
-        def __init__(  # pylint:disable=super-init-not-called
-            self,
-            crs: Optional[Any] = None,
-        ) -> None:
-            if crs is not None:
-                try:
-                    pyproj.CRS.from_user_input(crs)
-                except pyproj.exceptions.CRSError as exc:
-                    raise TypeError(f"Invalid CRS: {str(crs)}") from exc
-
-                object.__setattr__(self, "crs", crs)
-
-        def _coerce_values(self, obj: GeoPandasObject) -> GeoPandasObject:
-            if isinstance(obj, gpd.GeoSeries) or (
-                isinstance(obj, (pd.DataFrame, gpd.GeoDataFrame))
-                and all(v == str(self) for v in obj.dtypes.to_dict().values())
-            ):
-                # Return as-is if we already have the proper underlying dtype
-                return obj
-
-            # Shapely objects
-            try:
-                return from_shapely(obj)
-            except TypeError:
-                ...
-
-            # Well-known Text (WKT) strings
-            try:
-                return from_shapely(shapely.from_wkt(obj))
-            except (TypeError, shapely.errors.GEOSException):
-                ...
-
-            # Well-known Binary (WKB) strings
-            try:
-                return from_shapely(shapely.from_wkb(obj))
-            except (TypeError, shapely.errors.GEOSException):
-                ...
-
-            # JSON/GEOJSON dictionary
-            return from_shapely(obj.map(self._coerce_element))  # type: ignore[operator]
-
-        def _coerce_element(self, element: Any) -> Any:
-            try:
-                return shapely.geometry.shape(element)
-            except (
-                AttributeError,
-                TypeError,
-                shapely.errors.GeometryTypeError,
-                shapely.errors.GEOSException,
-            ):
-                return np.nan
-
-        def _coerce_crs(self, value: GeoPandasObject) -> GeoPandasObject:
-            if self.crs is not None:
-                if value.crs is None:
-                    # Allow assignment of CRS if currently
-                    # null and a non-null value is designated.
-                    # This will only work in the context of
-                    # geopandas because assinging geometry
-                    # CRS to a pandas dataframe isn't supported.
-                    value.crs = self.crs
-                elif (
-                    isinstance(value, gpd.GeoSeries) and self.crs != value.crs
-                ):
-                    value = value.to_crs(self.crs)  # type: ignore[operator]
-                elif isinstance(value, gpd.GeoDataFrame) and any(
-                    self.crs != value[col].crs for col in value.columns
-                ):
-                    for col in value.columns:
-                        if self.crs != value[col].crs:
-                            value[col] = value[col].to_crs(self.crs)
-            return value
-
-        def coerce(self, data_container: GeoPandasObject) -> GeoPandasObject:
-            """Coerce data container to the specified data type."""
-            # pylint: disable=import-outside-toplevel
-            from pandera.backends.pandas import error_formatters
-
-            orig_isna = data_container.isna()
-
-            # Copy so we don't directly modify container due
-            # to CRS re-projection, etc.)
-            data_container = data_container.copy()
-
-            # Coerce container data
-            coerced_data = self._coerce_values(data_container)
-
-            # Coerce container type
-            if isinstance(coerced_data, (GeometryArray, pd.DataFrame)):
-                if isinstance(data_container, (pd.Series, gpd.GeoSeries)):
-                    coerced_data = gpd.GeoSeries(coerced_data)
-                else:
-                    coerced_data = gpd.GeoDataFrame(coerced_data)
-
-            failed_selector = coerced_data.isna() & ~orig_isna
-
-            if np.any(failed_selector.any()):
-                failure_cases = coerced_data[failed_selector]
-                raise errors.ParserError(
-                    f"Could not coerce {type(data_container)} data_container "
-                    f"into type {self.type}",
-                    failure_cases=error_formatters.reshape_failure_cases(
-                        failure_cases, ignore_na=False
-                    ),
-                )
-            coerced = self._coerce_crs(coerced_data)
-            return coerced
-
-        def check(  # type: ignore
-            self,
-            pandera_dtype: DataType,
-            data_container: Optional[GeoPandasObject] = None,
-        ) -> Union[bool, Iterable[bool]]:
-            """Check data container to the specified data type."""
-            # Type check
-            if not super().check(pandera_dtype, data_container):
-                if data_container is None:
-                    return False
-                else:
-                    return np.full_like(data_container, False, dtype=bool)
-            if self.crs != pandera_dtype.crs and data_container is None:  # type: ignore[attr-defined]
-                return False
-
-            # CRS check extends into container
-            if self.crs is not None:
-                if (
-                    isinstance(data_container, gpd.GeoSeries)
-                    and data_container.crs != self.crs
-                ):
-                    # GeoSeries
-                    raise TypeError(
-                        f"CRS mismatch; actual {str(data_container.crs)}, expected {str(self.crs)}"
-                    )
-                if isinstance(data_container, gpd.GeoDataFrame):
-                    # GeoDataFrame
-                    col_results = []
-                    for col in data_container.columns:
-                        if data_container[col].crs != self.crs:
-                            col_err = f"CRS mismatch on column {col}; actual {str(data_container[col].crs)}, expected {str(self.crs)}"
-                            col_results.append(col_err)
-                    if col_results:
-                        raise TypeError("\n".join(col_results))
-
-            return np.full_like(data_container, True, dtype=bool)
-
-        def __eq__(self, obj: object) -> bool:
-            if isinstance(obj, type(self)):
-                return obj.crs == self.crs
-            return super().__eq__(obj)
-
-        def __str__(self) -> str:
-            return "geometry"
 
 
 ###############################################################################

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -248,15 +248,16 @@ class Engine(  # pylint:disable=too-few-public-methods
                         "representation."
                     ) from None
             elif is_geopandas_dtype(data_type):
-                # pylint: disable=cyclic-import
+                # pylint: disable=cyclic-import,unused-import
                 # register geopandas datatypes
-                from pandera.engines.geopandas_engine import (
-                    register_geopandas_dtypes,
-                )
+                import pandera.engines.geopandas_engine
 
-                register_geopandas_dtypes()
                 np_or_pd_dtype = data_type
             elif is_pyarrow_dtype(data_type):
+                # pylint: disable=cyclic-import
+                # register pyarrow datatypes
+                import pandera.engines.pyarrow_engine
+
                 np_or_pd_dtype = data_type.pyarrow_dtype
             else:
                 # let pandas transform any acceptable value

--- a/pandera/engines/pyarrow_engine.py
+++ b/pandera/engines/pyarrow_engine.py
@@ -1,0 +1,550 @@
+# pylint: disable=cyclic-import,unexpected-keyword-arg,no-value-for-parameter
+"""Pyarrow data types for the pandas type engine."""
+
+import dataclasses
+import datetime
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
+
+import pandas as pd
+import pyarrow
+
+from pandera import dtypes
+from pandera.dtypes import immutable
+from pandera.engines.pandas_engine import Engine, DataType, BOOL
+from pandera.engines.type_aliases import PandasObject
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "bool[pyarrow]",
+        pyarrow.bool_,
+        pd.ArrowDtype(pyarrow.bool_()),
+    ]
+)
+@immutable
+class ArrowBool(BOOL):
+    """Semantic representation of a :class:`pyarrow.bool_`."""
+
+    type = pd.ArrowDtype(pyarrow.bool_())
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "int64[pyarrow]",
+        pyarrow.int64,
+        pd.ArrowDtype(pyarrow.int64()),
+    ]
+)
+@immutable
+class ArrowInt64(DataType, dtypes.Int):
+    """Semantic representation of a :class:`pyarrow.int64`."""
+
+    type = pd.ArrowDtype(pyarrow.int64())
+    bit_width: int = 64
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "int32[pyarrow]",
+        pyarrow.int32,
+        pd.ArrowDtype(pyarrow.int32()),
+    ]
+)
+@immutable
+class ArrowInt32(ArrowInt64):
+    """Semantic representation of a :class:`pyarrow.int32`."""
+
+    type = pd.ArrowDtype(pyarrow.int32())
+    bit_width: int = 32
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "int16[pyarrow]",
+        pyarrow.int16,
+        pd.ArrowDtype(pyarrow.int16()),
+    ]
+)
+@immutable
+class ArrowInt16(ArrowInt32):
+    """Semantic representation of a :class:`pyarrow.int16`."""
+
+    type = pd.ArrowDtype(pyarrow.int16())
+    bit_width: int = 16
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "int8[pyarrow]",
+        pyarrow.int8,
+        pd.ArrowDtype(pyarrow.int8()),
+    ]
+)
+@immutable
+class ArrowInt8(ArrowInt16):
+    """Semantic representation of a :class:`pyarrow.int8`."""
+
+    type = pd.ArrowDtype(pyarrow.int8())
+    bit_width: int = 8
+
+
+@Engine.register_dtype(
+    equivalents=[
+        pyarrow.string,
+        pyarrow.utf8,
+        pd.ArrowDtype(pyarrow.string()),
+        pd.ArrowDtype(pyarrow.utf8()),
+    ]
+)
+@immutable
+class ArrowString(DataType, dtypes.String):
+    """Semantic representation of a :class:`pyarrow.string`."""
+
+    type = pd.ArrowDtype(pyarrow.string())
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "uint64[pyarrow]",
+        pyarrow.uint64,
+        pd.ArrowDtype(pyarrow.uint64()),
+    ]
+)
+@immutable
+class ArrowUInt64(DataType, dtypes.UInt):
+    """Semantic representation of a :class:`pyarrow.uint64`."""
+
+    type = pd.ArrowDtype(pyarrow.uint64())
+    bit_width: int = 64
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "uint32[pyarrow]",
+        pyarrow.uint32,
+        pd.ArrowDtype(pyarrow.uint32()),
+    ]
+)
+@immutable
+class ArrowUInt32(ArrowUInt64):
+    """Semantic representation of a :class:`pyarrow.uint32`."""
+
+    type = pd.ArrowDtype(pyarrow.uint32())
+    bit_width: int = 32
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "uint16[pyarrow]",
+        pyarrow.uint16,
+        pd.ArrowDtype(pyarrow.uint16()),
+    ]
+)
+@immutable
+class ArrowUInt16(ArrowUInt32):
+    """Semantic representation of a :class:`pyarrow.uint16`."""
+
+    type = pd.ArrowDtype(pyarrow.uint16())
+    bit_width: int = 16
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "uint8[pyarrow]",
+        pyarrow.uint8,
+        pd.ArrowDtype(pyarrow.uint8()),
+    ]
+)
+@immutable
+class ArrowUInt8(ArrowUInt16):
+    """Semantic representation of a :class:`pyarrow.uint8`."""
+
+    type = pd.ArrowDtype(pyarrow.uint8())
+    bit_width: int = 8
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "double[pyarrow]",
+        pyarrow.float64,
+        pd.ArrowDtype(pyarrow.float64()),
+    ]
+)
+@immutable
+class ArrowFloat64(DataType, dtypes.Float):
+    """Semantic representation of a :class:`pyarrow.float64`."""
+
+    type = pd.ArrowDtype(pyarrow.float64())
+    bit_width: int = 64
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "float[pyarrow]",
+        pyarrow.float32,
+        pd.ArrowDtype(pyarrow.float32()),
+    ]
+)
+@immutable
+class ArrowFloat32(ArrowFloat64):
+    """Semantic representation of a :class:`pyarrow.float32`."""
+
+    type = pd.ArrowDtype(pyarrow.float32())
+    bit_width: int = 32
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "halffloat[pyarrow]",
+        pyarrow.float16,
+        pd.ArrowDtype(pyarrow.float16()),
+    ]
+)
+@immutable
+class ArrowFloat16(ArrowFloat32):
+    """Semantic representation of a :class:`pyarrow.float16`."""
+
+    type = pd.ArrowDtype(pyarrow.float16())
+    bit_width: int = 16
+
+
+@Engine.register_dtype(
+    equivalents=[pyarrow.decimal128, pyarrow.Decimal128Type]
+)
+@immutable(init=True)
+class ArrowDecimal128(DataType, dtypes.Decimal):
+    """Semantic representation of a :class:`pyarrow.decimal128`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    precision: int = 28
+    scale: int = 0
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.decimal128(self.precision, self.scale))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(
+        cls,
+        pyarrow_dtype: pyarrow.Decimal128Type,
+    ):
+        return cls(precision=pyarrow_dtype.precision, scale=pyarrow_dtype.scale)  # type: ignore
+
+
+@Engine.register_dtype(equivalents=[pyarrow.timestamp, pyarrow.TimestampType])
+@immutable(init=True)
+class ArrowTimestamp(DataType, dtypes.Timestamp):
+    """Semantic representation of a :class:`pyarrow.timestamp`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    unit: Optional[str] = "ns"
+    tz: Optional[datetime.tzinfo] = None
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.timestamp(self.unit, self.tz))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.TimestampType):
+        return cls(unit=pyarrow_dtype.unit, tz=pyarrow_dtype.tz)  # type: ignore
+
+
+@Engine.register_dtype(
+    equivalents=[pyarrow.dictionary, pyarrow.DictionaryType]
+)
+@immutable(init=True)
+class ArrowDictionary(DataType, dtypes.Category):
+    """Semantic representation of a :class:`pyarrow.dictionary`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    index_type: Optional[pyarrow.DataType] = pyarrow.int64()
+    value_type: Optional[pyarrow.DataType] = pyarrow.int64()
+    ordered: bool = False
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(
+            pyarrow.dictionary(
+                self.index_type,
+                self.value_type,
+                self.ordered,
+            )
+        )
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.DictionaryType):
+        return cls(
+            index_type=pyarrow_dtype.index_type,  # type: ignore
+            value_type=pyarrow_dtype.value_type,  # type: ignore
+            ordered=pyarrow_dtype.ordered,  # type: ignore
+        )
+
+
+@Engine.register_dtype(
+    equivalents=[
+        pyarrow.list_,
+        pyarrow.ListType,
+        pyarrow.FixedSizeListType,
+    ]
+)
+@immutable(init=True)
+class ArrowList(DataType):
+    """Semantic representation of a :class:`pyarrow.list_`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    value_type: Optional[Union[pyarrow.DataType, pyarrow.Field]] = (
+        pyarrow.string()
+    )
+    list_size: Optional[int] = -1
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.list_(self.value_type, self.list_size))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(
+        cls,
+        pyarrow_dtype: Union[pyarrow.ListType, pyarrow.FixedSizeListType],
+    ):
+        try:
+            _dtype = cls(
+                value_type=pyarrow_dtype.value_type,  # type: ignore
+                list_size=pyarrow_dtype.list_size,  # type: ignore
+            )
+        except AttributeError:
+            _dtype = cls(value_type=pyarrow_dtype.value_type)  # type: ignore
+        return _dtype
+
+
+@Engine.register_dtype(equivalents=[pyarrow.struct, pyarrow.StructType])
+@immutable(init=True)
+class ArrowStruct(DataType):
+    """Semantic representation of a :class:`pyarrow.struct`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    fields: Optional[
+        Union[
+            Iterable[Union[pyarrow.Field, Tuple[str, pyarrow.DataType]]],
+            Dict[str, pyarrow.DataType],
+        ]
+    ] = tuple()
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.struct(self.fields))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.StructType):
+        return cls(
+            fields=[pyarrow_dtype.field(i) for i in range(pyarrow_dtype.num_fields)]  # type: ignore
+        )
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "null[pyarrow]",
+        pyarrow.null,
+        pd.ArrowDtype(pyarrow.null()),
+    ]
+)
+@immutable
+class ArrowNull(DataType):
+    """Semantic representation of a :class:`pyarrow.null`."""
+
+    type = pd.ArrowDtype(pyarrow.null())
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "date32[day][pyarrow]",
+        pyarrow.date32,
+        pd.ArrowDtype(pyarrow.date32()),
+    ]
+)
+@immutable
+class ArrowDate32(DataType, dtypes.Date):
+    """Semantic representation of a :class:`pyarrow.date32`."""
+
+    type = pd.ArrowDtype(pyarrow.date32())
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "date64[ms][pyarrow]",
+        pyarrow.date64,
+        pd.ArrowDtype(pyarrow.date64()),
+    ]
+)
+@immutable
+class ArrowDate64(DataType, dtypes.Date):
+    """Semantic representation of a :class:`pyarrow.date64`."""
+
+    type = pd.ArrowDtype(pyarrow.date64())
+
+
+@Engine.register_dtype(equivalents=[pyarrow.duration, pyarrow.DurationType])
+@immutable(init=True)
+class ArrowDuration(DataType):
+    """Semantic representation of a :class:`pyarrow.duration`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    unit: Optional[str] = "ns"
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.duration(self.unit))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.DurationType):
+        return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+
+@Engine.register_dtype(equivalents=[pyarrow.time32, pyarrow.Time32Type])
+@immutable(init=True)
+class ArrowTime32(DataType):
+    """Semantic representation of a :class:`pyarrow.time32`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    unit: Optional[str] = "ms"
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.time32(self.unit))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.Time32Type):
+        return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+    def coerce(self, data_container: PandasObject) -> PandasObject:
+        if data_container.dtype == self.type:
+            return data_container
+        else:
+            return data_container.astype(
+                pd.ArrowDtype(pyarrow.int32())
+            ).astype(self.type)
+
+
+@Engine.register_dtype(equivalents=[pyarrow.time64, pyarrow.Time64Type])
+@immutable(init=True)
+class ArrowTime64(DataType):
+    """Semantic representation of a :class:`pyarrow.time64`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    unit: Optional[str] = "ns"
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.time64(self.unit))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.Time64Type):
+        return cls(unit=pyarrow_dtype.unit)  # type: ignore
+
+    def coerce(self, data_container: PandasObject) -> PandasObject:
+        if data_container.dtype == self.type:
+            return data_container
+        else:
+            return data_container.astype(
+                pd.ArrowDtype(pyarrow.int64())
+            ).astype(self.type)
+
+
+@Engine.register_dtype(equivalents=[pyarrow.map_, pyarrow.MapType])
+@immutable(init=True)
+class ArrowMap(DataType):
+    """Semantic representation of a :class:`pyarrow.map_`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    key_type: Optional[pyarrow.DataType] = pyarrow.int64()
+    item_type: Optional[pyarrow.DataType] = pyarrow.int64()
+    keys_sorted: bool = False
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(
+            pyarrow.map_(
+                self.key_type,
+                self.item_type,
+                self.keys_sorted,
+            )
+        )
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(cls, pyarrow_dtype: pyarrow.MapType):
+        return cls(
+            key_type=pyarrow_dtype.key_type,  # type: ignore
+            item_type=pyarrow_dtype.item_type,  # type: ignore
+            keys_sorted=pyarrow_dtype.keys_sorted,  # type: ignore
+        )
+
+    def coerce_value(self, value: Any) -> Any:
+        """Coerce a value to a particular type."""
+        return pyarrow.scalar(
+            value,
+            type=(
+                self.type.pyarrow_dtype  # pylint: disable=E1101
+                if self.type
+                else None
+            ),
+        )
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "binary[pyarrow]",
+        pyarrow.binary,
+        pyarrow.FixedSizeBinaryType,
+        pd.ArrowDtype(pyarrow.binary()),
+    ]
+)
+@immutable(init=True)
+class ArrowBinary(DataType, dtypes.Binary):
+    """Semantic representation of a :class:`pyarrow.binary`."""
+
+    type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)
+    length: Optional[int] = -1
+
+    def __post_init__(self):
+        type_ = pd.ArrowDtype(pyarrow.binary(self.length))
+        object.__setattr__(self, "type", type_)
+
+    @classmethod
+    def from_parametrized_dtype(
+        cls,
+        pyarrow_dtype: Union[pyarrow.DataType, pyarrow.FixedSizeBinaryType],
+    ):
+        try:
+            _dtype = cls(length=pyarrow_dtype.byte_width)  # type: ignore
+        except (ValueError, AttributeError):
+            _dtype = cls()  # type: ignore
+        return _dtype
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "large_binary[pyarrow]",
+        pyarrow.large_binary,
+        pd.ArrowDtype(pyarrow.large_binary()),
+    ]
+)
+@immutable
+class ArrowLargeBinary(DataType):
+    """Semantic representation of a :class:`pyarrow.large_binary`."""
+
+    type = pd.ArrowDtype(pyarrow.large_binary())
+
+
+@Engine.register_dtype(
+    equivalents=[
+        "large_string[pyarrow]",
+        pyarrow.large_string,
+        pyarrow.large_utf8,
+        pd.ArrowDtype(pyarrow.large_string()),
+        pd.ArrowDtype(pyarrow.large_utf8()),
+    ]
+)
+@immutable
+class ArrowLargeString(DataType, dtypes.String):
+    """Semantic representation of a :class:`pyarrow.large_string`."""
+
+    type = pd.ArrowDtype(pyarrow.large_string())

--- a/pandera/import_utils.py
+++ b/pandera/import_utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for importing optional dependencies."""
+
+from functools import wraps
+from typing import Callable, TypeVar, cast
+
+
+F = TypeVar("F", bound=Callable)
+
+
+def strategy_import_error(fn: F) -> F:
+    """Decorator to generate input error if dependency is missing."""
+
+    @wraps(fn)
+    def _wrapper(*args, **kwargs):
+
+        try:
+            # pylint: disable=unused-import
+            import hypothesis
+        except ImportError as exc:
+            raise ImportError(
+                'Strategies for generating data requires "hypothesis" to be \n'
+                "installed. You can install pandera together with the strategies \n"
+                "dependencies with:\n"
+                "pip install pandera[strategies]"
+            ) from exc
+
+        return fn(*args, **kwargs)
+
+    return cast(F, _wrapper)

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -56,15 +56,6 @@ STRING = pandas_engine.STRING  #: ``"str"`` numpy dtype
 BOOL = pandas_engine.BOOL  #: ``"str"`` numpy dtype
 
 
-if pandas_engine.GEOPANDAS_INSTALLED:
-    Geometry = pandas_engine.Geometry  # : ``"geometry"`` geopandas dtype
-else:
-
-    class Geometry:  # type: ignore [no-redef]
-        # pylint: disable=too-few-public-methods
-        ...  #  stub Geometry type
-
-
 GenericDtype = TypeVar(  # type: ignore
     "GenericDtype",
     bound=Union[
@@ -103,7 +94,6 @@ GenericDtype = TypeVar(  # type: ignore
         Object,
         String,
         STRING,
-        Geometry,
     ],
 )
 

--- a/pandera/typing/geopandas.py
+++ b/pandera/typing/geopandas.py
@@ -39,7 +39,7 @@ except ImportError:  # pragma: no cover
 
 if GEOPANDAS_INSTALLED:
     # pylint: disable=import-outside-toplevel,ungrouped-imports
-    from pandera.engines.pandas_engine import Geometry
+    from pandera.engines.geopandas_engine import Geometry
 
     # pylint:disable=invalid-name
     if TYPE_CHECKING:

--- a/tests/core/test_dtypes.py
+++ b/tests/core/test_dtypes.py
@@ -204,7 +204,7 @@ if GEOPANDAS_INSTALLED:
     from shapely.geometry import Polygon
 
     # pylint:disable=ungrouped-imports
-    from pandera.engines.pandas_engine import Geometry
+    from pandera.engines.geopandas_engine import Geometry
 
     geometry_dtypes = {Geometry: "geometry"}
     dtype_fixtures.append(

--- a/tests/geopandas/test_engine.py
+++ b/tests/geopandas/test_engine.py
@@ -8,7 +8,8 @@ import shapely
 from shapely.geometry import Point
 
 import pandera as pa
-from pandera.engines.pandas_engine import DateTime, Geometry
+from pandera.engines.pandas_engine import DateTime
+from pandera.engines.geopandas_engine import Geometry
 
 
 def test_engine_geometry_simple():

--- a/tests/geopandas/test_geopandas.py
+++ b/tests/geopandas/test_geopandas.py
@@ -6,7 +6,7 @@ import pytest
 from shapely.geometry import Point, Polygon
 
 import pandera as pa
-from pandera.engines.pandas_engine import Geometry
+from pandera.engines.geopandas_engine import Geometry
 from pandera.typing import Series
 from pandera.typing.geopandas import GeoDataFrame, GeoSeries
 

--- a/tests/modin/test_schemas_on_modin.py
+++ b/tests/modin/test_schemas_on_modin.py
@@ -9,7 +9,7 @@ import pytest
 
 import pandera as pa
 from pandera import extensions
-from pandera.engines import numpy_engine, pandas_engine
+from pandera.engines import numpy_engine, pandas_engine, geopandas_engine
 from pandera.typing.modin import DataFrame, Index, Series, modin_version
 from tests.strategies.test_strategies import NULLABLE_DTYPES
 from tests.strategies.test_strategies import (
@@ -40,8 +40,8 @@ for dtype_cls in pandas_engine.Engine.get_registered_dtypes():
             not in SUPPORTED_STRATEGY_DTYPES
         )
         or not (
-            pandas_engine.GEOPANDAS_INSTALLED
-            and dtype_cls == pandas_engine.Geometry
+            geopandas_engine.GEOPANDAS_INSTALLED
+            and dtype_cls == geopandas_engine.Geometry
         )
     ):
         continue
@@ -167,8 +167,8 @@ def test_index_dtypes(
         # pylint: disable=no-value-for-parameter
         if dt in NULLABLE_DTYPES
         and not (
-            pandas_engine.GEOPANDAS_INSTALLED
-            and dt == pandas_engine.Engine.dtype(pandas_engine.Geometry)
+            geopandas_engine.GEOPANDAS_INSTALLED
+            and dt == pandas_engine.Engine.dtype(geopandas_engine.Geometry)
         )
     ],
 )

--- a/tests/pyspark/test_schemas_on_pyspark_pandas.py
+++ b/tests/pyspark/test_schemas_on_pyspark_pandas.py
@@ -13,7 +13,7 @@ from pyspark import SparkContext
 
 import pandera as pa
 from pandera import dtypes, extensions, system
-from pandera.engines import numpy_engine, pandas_engine
+from pandera.engines import numpy_engine, pandas_engine, geopandas_engine
 from pandera.typing import DataFrame, Index, Series
 from tests.strategies.test_strategies import NULLABLE_DTYPES
 from tests.strategies.test_strategies import (
@@ -35,8 +35,8 @@ DTYPES = [
     dtype_cls
     for dtype_cls in pandas_engine.Engine.get_registered_dtypes()
     if not (
-        pandas_engine.GEOPANDAS_INSTALLED
-        and dtype_cls == pandas_engine.Geometry
+        geopandas_engine.GEOPANDAS_INSTALLED
+        and dtype_cls == geopandas_engine.Geometry
     )
 ]
 UNSUPPORTED_STRATEGY_DTYPE_CLS = set(UNSUPPORTED_STRATEGY_DTYPE_CLS)
@@ -280,8 +280,8 @@ def test_index_dtypes(
             pandas_engine.DateTime(tz="UTC"),  # type: ignore[call-arg]
         }
         and not (
-            pandas_engine.GEOPANDAS_INSTALLED
-            and dt == pandas_engine.Engine.dtype(pandas_engine.Geometry)
+            geopandas_engine.GEOPANDAS_INSTALLED
+            and dt == pandas_engine.Engine.dtype(geopandas_engine.Geometry)
         )
     ],
 )

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -16,7 +16,7 @@ from pandera import strategies
 from pandera.api.checks import Check
 from pandera.api.extensions import register_check_statistics
 from pandera.dtypes import is_category, is_complex, is_float
-from pandera.engines import pandas_engine
+from pandera.engines import pandas_engine, geopandas_engine
 
 try:
     import hypothesis
@@ -88,8 +88,8 @@ for data_type in pandas_engine.Engine.get_registered_dtypes():
         or is_category(data_type)
         or data_type in UNSUPPORTED_DTYPE_CLS
         or (
-            pandas_engine.GEOPANDAS_INSTALLED
-            and data_type == pandas_engine.Geometry
+            geopandas_engine.GEOPANDAS_INSTALLED
+            and data_type == geopandas_engine.Geometry
         )
     ):
         continue


### PR DESCRIPTION
Fixes #1644.

This PR refactors the import structure of `geopandas` and `pyarrow` imports in the `pandas_engine` module so that optional dependencies are not imported at a top-level `pandera` import.

Before this and prior changes to refactor import structure, the time-to-import and memory usage (assuming all optional dependencies are installed) was:

https://github.com/unionai-oss/pandera/issues/1644#issuecomment-2127064445
```
❯ /usr/bin/time -l python -c 'import pandera' 2>&1
        1.80 real 👈         4.17 user         2.46 sys
           215072768  maximum resident set size  👈
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               21716  page reclaims
                3210  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1733  voluntary context switches
               10253  involuntary context switches
         36530415133  instructions retired
         20643165531  cycles elapsed
           159648640  peak memory footprint
```

After this PR:
```
        0.79 real         0.99 user         1.78 sys
           124059648  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               33227  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   1  messages sent
                   0  messages received
                   0  signals received
                 205  voluntary context switches
              115644  involuntary context switches
         12080288170  instructions retired
          8630608809  cycles elapsed
            88068224  peak memory footprint
```

This is still slower than a base pandera installation (with no extras installed)
```
        0.51 real         0.38 user         0.07 sys
            94597120  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               25420  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                   1  voluntary context switches
                 374  involuntary context switches
          4127362462  instructions retired
          1485986618  cycles elapsed
            71821888  peak memory footprint
```

As far as I can tell there are no more optional dependency imports in the top-level pandera import execution path, will need to do further profiling to uncover the source of the difference.