### PR TITLE
Update Polars dtype test to generate more examples

### DIFF
--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -83,7 +83,6 @@ def get_dataframe_strategy(type_: pl.DataType) -> st.SearchStrategy:
         cols=2,
         lazy=True,
         allowed_dtypes=type_,
-        include_nulls=0.1,
         min_size=10,
         max_size=10,
     )
@@ -92,7 +91,7 @@ def get_dataframe_strategy(type_: pl.DataType) -> st.SearchStrategy:
 # Hypothesis slow if test is failing
 @pytest.mark.parametrize("dtype", all_types)
 @given(st.data())
-@settings(max_examples=1)
+@settings(max_examples=10)
 def test_coerce_no_cast(dtype, data):
     """Test that dtypes can be coerced without casting."""
     if dtype is pe.Categorical:


### PR DESCRIPTION
Otherwise, it's always testing all-null dataframes, as far as I can tell (see https://discord.com/channels/897120336003334214/1160076741394563102/1268358149400690719).

Also dropped the `include_nulls` keyword, which I don't think does anything (see https://github.com/pola-rs/polars/pull/17969).