### PR TITLE
Add missing `type` field for the `Int32` data type

### DIFF
--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -80,6 +80,8 @@ class Engine(
 class Int32(DataType, dtypes.Int32):
     """Semantic representation of a :class:`dt.Int32`."""
 
+    type = dt.int32
+
 
 @Engine.register_dtype(
     equivalents=[


### PR DESCRIPTION
Just noticed this bug as I was working on type tests, just in case anybody runs into issue with it