### PR TITLE
Do not test Ibis below py3.9, add DuckDB for tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,10 +53,10 @@ jobs:
           python -m pip install nox pre_commit \
             mypy==0.982 \
             types-click \
+            types-pytz \
             types-pyyaml \
-            types-pkg_resources \
             types-requests \
-            types-pytz
+            types-setuptools
       - name: Pip info
         run: python -m pip list
 
@@ -153,11 +153,11 @@ jobs:
         uses: codecov/codecov-action@v4
 
       # - name: Check Docstrings
-      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pandas-version == '2.2.0' }}
+      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pandas-version == '2.2.2' }}
       #   run: nox ${{ env.NOX_FLAGS }} --session doctests
 
       # - name: Check Docs
-      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pydantic-version == '2.2.0' }}
+      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pydantic-version == '2.2.2' }}
       #   run: nox ${{ env.NOX_FLAGS }} --session docs
 
   extras-tests:
@@ -208,7 +208,7 @@ jobs:
           pip-cache: ~/AppData/Local/pip/Cache
         exclude:
         - python-version: "3.8"
-          pandas-version: "2.2.0"
+          pandas-version: "2.2.2"
         - python-version: "3.11"
           pandas-version: "1.5.3"
           # mypy tests hang on windows

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -237,6 +237,8 @@ jobs:
         - extra: modin-ray
           polars-version: "0.20.31"
         - extra: ibis
+          python-version: "3.8"
+        - extra: ibis
           polars-version: "0.20.31"
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-yaml
         description: Attempts to load all yaml files to verify syntax
       - id: debug-statements
-        description: Check for debugger imports and py37+  calls in python source
+        description: Check for debugger imports and py37+ breakpoint() calls in python source
       - id: end-of-file-fixer
         description: Makes sure files end in a newline and only a newline
       - id: trailing-whitespace
@@ -50,10 +50,10 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-click
-          - types-pkg_resources
           - types-pytz
           - types-pyyaml
           - types-requests
+          - types-setuptools
         args: ["pandera", "tests", "scripts"]
         exclude: (^docs/|^tests/mypy/modules/)
         pass_filenames: false

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -3,44 +3,39 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,11 +64,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -82,16 +79,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -102,9 +96,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -112,6 +105,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,35 +114,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -166,23 +154,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -204,7 +194,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -232,7 +222,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -241,16 +232,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -268,11 +260,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -282,6 +275,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   black
     #   build
     #   dask
@@ -290,18 +284,18 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -314,26 +308,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -346,8 +342,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -356,6 +355,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -364,33 +364,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   asv
     #   dask
     #   distributed
@@ -400,15 +405,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 referencing==0.35.1
     # via
     #   jsonschema
@@ -416,7 +422,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -429,16 +434,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -447,12 +454,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -463,6 +467,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   furo
     #   myst-nb
     #   myst-parser
@@ -473,26 +478,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -533,8 +542,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -546,19 +553,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
     #   anyio
     #   astroid
     #   black
@@ -574,16 +588,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -591,18 +604,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -13,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -31,7 +31,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +68,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -79,13 +79,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -97,7 +99,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -105,7 +107,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -115,17 +117,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -136,7 +138,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -155,7 +157,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -172,7 +174,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -222,7 +224,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -232,16 +234,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -260,12 +262,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -275,7 +278,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   black
     #   build
     #   dask
@@ -290,12 +293,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -309,7 +313,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -321,14 +325,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   ray
 psutil==6.0.0
     # via
@@ -342,10 +346,14 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   fastapi
 pygments==2.18.0
     # via
@@ -355,7 +363,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -365,19 +373,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -385,17 +393,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   asv
     #   dask
     #   distributed
@@ -410,11 +418,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 referencing==0.35.1
     # via
     #   jsonschema
@@ -434,6 +442,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -441,10 +450,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -467,7 +476,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   furo
     #   myst-nb
     #   myst-parser
@@ -478,15 +487,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -553,26 +562,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   anyio
     #   astroid
     #   black
@@ -588,7 +597,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 urllib3==2.2.2
     # via
     #   distributed
@@ -596,7 +605,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -608,10 +617,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu7la974g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpt44o24jy
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -15,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -33,7 +33,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -81,13 +81,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -99,7 +101,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -107,7 +109,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -117,17 +119,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -138,7 +140,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -157,7 +159,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -174,7 +176,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -224,7 +226,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -234,16 +236,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -262,12 +264,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -277,7 +280,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   black
     #   build
     #   dask
@@ -292,12 +295,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -311,7 +315,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -323,14 +327,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   ray
 psutil==6.0.0
     # via
@@ -344,10 +348,14 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -359,7 +367,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -369,19 +377,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -389,17 +397,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   asv
     #   dask
     #   distributed
@@ -414,11 +422,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 referencing==0.35.1
     # via
     #   jsonschema
@@ -438,6 +446,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -445,10 +454,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -471,7 +480,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,15 +491,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -557,26 +566,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   anyio
     #   astroid
     #   black
@@ -593,7 +602,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 urllib3==2.2.2
     # via
     #   distributed
@@ -601,7 +610,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -613,10 +622,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpekr8yr1d
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -5,44 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,11 +66,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,16 +81,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +98,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +107,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,35 +116,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -168,23 +156,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -206,7 +196,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -234,7 +224,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -243,16 +234,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -270,11 +262,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -284,6 +277,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   black
     #   build
     #   dask
@@ -292,18 +286,18 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -316,26 +310,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -348,8 +344,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -360,6 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -368,33 +368,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   asv
     #   dask
     #   distributed
@@ -404,15 +409,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 referencing==0.35.1
     # via
     #   jsonschema
@@ -420,7 +426,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -433,16 +438,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -451,12 +458,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -467,6 +471,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   furo
     #   myst-nb
     #   myst-parser
@@ -477,26 +482,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -537,8 +546,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -550,19 +557,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
     #   anyio
     #   astroid
     #   black
@@ -579,16 +593,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -596,18 +609,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpyj5ihv9t
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -13,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -31,7 +31,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +68,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -82,13 +82,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -100,7 +102,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,7 +110,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,17 +120,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -139,7 +141,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -158,7 +160,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -175,7 +177,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -225,7 +227,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -235,16 +237,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -263,12 +265,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 numpy==2.0.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -278,7 +281,7 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   black
     #   build
     #   dask
@@ -293,13 +296,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -313,7 +317,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -325,14 +329,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   ray
 psutil==6.0.0
     # via
@@ -347,11 +351,14 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   fastapi
 pygments==2.18.0
     # via
@@ -361,7 +368,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -371,19 +378,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -391,17 +398,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   asv
     #   dask
     #   distributed
@@ -416,11 +423,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 referencing==0.35.1
     # via
     #   jsonschema
@@ -440,6 +447,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -447,10 +455,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -473,7 +481,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   furo
     #   myst-nb
     #   myst-parser
@@ -484,15 +492,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -559,26 +567,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   anyio
     #   astroid
     #   black
@@ -594,7 +602,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -604,7 +612,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -616,10 +624,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzmwi4gmg
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -3,46 +3,39 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,16 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -88,18 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -110,10 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -121,7 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -130,41 +117,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -183,25 +158,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -223,7 +197,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -251,8 +225,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -261,19 +235,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -291,13 +263,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-numpy==1.26.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -307,7 +278,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   black
     #   build
     #   dask
@@ -316,21 +287,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -343,30 +312,27 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   ray
 psutil==6.0.0
     # via
@@ -381,11 +347,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   fastapi
 pygments==2.18.0
     # via
@@ -395,7 +361,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -404,42 +370,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   asv
     #   dask
     #   distributed
@@ -449,17 +411,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 referencing==0.35.1
     # via
     #   jsonschema
@@ -467,7 +428,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -480,18 +440,17 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -501,12 +460,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -517,7 +473,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   furo
     #   myst-nb
     #   myst-parser
@@ -528,30 +484,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -592,8 +548,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -605,28 +559,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   anyio
     #   astroid
     #   black
@@ -642,7 +594,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -651,12 +603,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -664,21 +612,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8_4bqqu2
-xxhash==3.4.1
-    # via pooch
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp5pr15cqu
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -15,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -33,7 +33,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -84,13 +84,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -102,7 +104,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,7 +112,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,17 +122,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -141,7 +143,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -160,7 +162,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -177,7 +179,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -227,7 +229,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -237,16 +239,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -265,12 +267,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 numpy==2.0.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -280,7 +283,7 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   black
     #   build
     #   dask
@@ -295,13 +298,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -315,7 +319,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -327,14 +331,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   ray
 psutil==6.0.0
     # via
@@ -349,11 +353,14 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -365,7 +372,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -375,19 +382,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -395,17 +402,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   asv
     #   dask
     #   distributed
@@ -420,11 +427,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 referencing==0.35.1
     # via
     #   jsonschema
@@ -444,6 +451,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -451,10 +459,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -477,7 +485,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   furo
     #   myst-nb
     #   myst-parser
@@ -488,15 +496,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -563,26 +571,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   anyio
     #   astroid
     #   black
@@ -599,7 +607,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -609,7 +617,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -621,10 +629,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpe0yi3u9b
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -5,46 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -73,16 +66,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -90,18 +83,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -112,10 +101,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,7 +110,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,41 +119,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -185,25 +160,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -225,7 +199,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -253,8 +227,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -263,19 +237,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -293,13 +265,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-numpy==1.26.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -309,7 +280,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   black
     #   build
     #   dask
@@ -318,21 +289,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -345,30 +314,27 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   ray
 psutil==6.0.0
     # via
@@ -383,11 +349,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -399,7 +365,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -408,42 +374,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   asv
     #   dask
     #   distributed
@@ -453,17 +415,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 referencing==0.35.1
     # via
     #   jsonschema
@@ -471,7 +432,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -484,18 +444,17 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -505,12 +464,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -521,7 +477,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   furo
     #   myst-nb
     #   myst-parser
@@ -532,30 +488,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -596,8 +552,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -609,28 +563,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   anyio
     #   astroid
     #   black
@@ -647,7 +599,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -656,12 +608,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -669,21 +617,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0091hv2f
-xxhash==3.4.1
-    # via pooch
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4muhcmsq
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -3,44 +3,39 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,11 +64,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -82,23 +79,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -106,6 +99,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -114,35 +108,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -160,23 +148,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -198,7 +188,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -226,7 +216,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -235,16 +226,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -262,11 +254,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -276,6 +269,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   black
     #   build
     #   dask
@@ -284,18 +278,18 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -308,26 +302,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -340,8 +336,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -350,6 +349,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -358,33 +358,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   asv
     #   dask
     #   distributed
@@ -394,15 +399,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 referencing==0.35.1
     # via
     #   jsonschema
@@ -410,7 +416,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -423,16 +428,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -441,12 +448,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -457,6 +461,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   furo
     #   myst-nb
     #   myst-parser
@@ -467,26 +472,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -518,8 +527,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -531,19 +538,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -555,16 +569,15 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -572,18 +585,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -13,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -31,7 +31,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +68,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -79,19 +79,21 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -99,7 +101,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -109,17 +111,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -130,7 +132,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -149,7 +151,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -166,7 +168,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -216,7 +218,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -226,16 +228,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -254,12 +256,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -269,7 +272,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   black
     #   build
     #   dask
@@ -284,12 +287,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -303,7 +307,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -315,14 +319,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   ray
 psutil==6.0.0
     # via
@@ -336,10 +340,14 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   fastapi
 pygments==2.18.0
     # via
@@ -349,7 +357,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -359,19 +367,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -379,17 +387,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   asv
     #   dask
     #   distributed
@@ -404,11 +412,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 referencing==0.35.1
     # via
     #   jsonschema
@@ -428,6 +436,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -435,10 +444,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -461,7 +470,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   furo
     #   myst-nb
     #   myst-parser
@@ -472,15 +481,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -538,26 +547,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -569,7 +578,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 urllib3==2.2.2
     # via
     #   distributed
@@ -577,7 +586,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -589,10 +598,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprh2vww2y
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzhski4j5
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -15,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -33,7 +33,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -81,19 +81,21 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -101,7 +103,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -111,17 +113,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -132,7 +134,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -151,7 +153,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -168,7 +170,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -218,7 +220,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -228,16 +230,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -256,12 +258,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -271,7 +274,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   black
     #   build
     #   dask
@@ -286,12 +289,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -305,7 +309,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -317,14 +321,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   ray
 psutil==6.0.0
     # via
@@ -338,10 +342,14 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -353,7 +361,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -363,19 +371,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -383,17 +391,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   asv
     #   dask
     #   distributed
@@ -408,11 +416,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 referencing==0.35.1
     # via
     #   jsonschema
@@ -432,6 +440,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -439,10 +448,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -465,7 +474,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   furo
     #   myst-nb
     #   myst-parser
@@ -476,15 +485,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -542,26 +551,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -574,7 +583,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 urllib3==2.2.2
     # via
     #   distributed
@@ -582,7 +591,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -594,10 +603,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp88esncf_
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -5,44 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,11 +66,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,23 +81,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +101,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,35 +110,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -162,23 +150,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -200,7 +190,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -228,7 +218,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -237,16 +228,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -264,11 +256,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -278,6 +271,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   black
     #   build
     #   dask
@@ -286,18 +280,18 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -310,26 +304,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -342,8 +338,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -354,6 +353,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -362,33 +362,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   asv
     #   dask
     #   distributed
@@ -398,15 +403,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 referencing==0.35.1
     # via
     #   jsonschema
@@ -414,7 +420,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -427,16 +432,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -445,12 +452,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -461,6 +465,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   furo
     #   myst-nb
     #   myst-parser
@@ -471,26 +476,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -522,8 +531,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -535,19 +542,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -560,16 +574,15 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -577,18 +590,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwp75x9_k
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -13,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -31,7 +31,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +68,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -82,19 +82,21 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -102,7 +104,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -112,17 +114,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -133,7 +135,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -152,7 +154,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -169,7 +171,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -219,7 +221,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -229,16 +231,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -257,12 +259,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 numpy==2.0.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -272,7 +275,7 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   black
     #   build
     #   dask
@@ -287,13 +290,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -307,7 +311,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -319,14 +323,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   ray
 psutil==6.0.0
     # via
@@ -341,11 +345,14 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   fastapi
 pygments==2.18.0
     # via
@@ -355,7 +362,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -365,19 +372,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -385,17 +392,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   asv
     #   dask
     #   distributed
@@ -410,11 +417,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 referencing==0.35.1
     # via
     #   jsonschema
@@ -434,6 +441,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -441,10 +449,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -467,7 +475,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   furo
     #   myst-nb
     #   myst-parser
@@ -478,15 +486,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -544,26 +552,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -575,7 +583,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -585,7 +593,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -597,10 +605,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7j3c77ue
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -3,46 +3,39 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,16 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -88,26 +81,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -115,7 +102,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -124,41 +111,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -177,25 +152,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -217,7 +191,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -245,8 +219,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -255,19 +229,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -285,13 +257,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-numpy==1.26.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -301,7 +272,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   black
     #   build
     #   dask
@@ -310,21 +281,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -337,30 +306,27 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   ray
 psutil==6.0.0
     # via
@@ -375,11 +341,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   fastapi
 pygments==2.18.0
     # via
@@ -389,7 +355,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -398,42 +364,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   asv
     #   dask
     #   distributed
@@ -443,17 +405,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 referencing==0.35.1
     # via
     #   jsonschema
@@ -461,7 +422,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -474,18 +434,17 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -495,12 +454,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -511,7 +467,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   furo
     #   myst-nb
     #   myst-parser
@@ -522,30 +478,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -577,8 +533,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -590,28 +544,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -623,7 +575,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -632,12 +584,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -645,21 +593,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpkydlmtr9
-xxhash==3.4.1
-    # via pooch
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpfrv9of6g
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -5,46 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -73,16 +66,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -90,26 +83,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -117,7 +104,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,41 +113,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+ibis-framework==9.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -179,25 +154,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -219,7 +193,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -247,8 +221,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -257,19 +231,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -287,13 +259,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-numpy==1.26.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -303,7 +274,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   black
     #   build
     #   dask
@@ -312,21 +283,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -339,30 +308,27 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   ray
 psutil==6.0.0
     # via
@@ -377,11 +343,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -393,7 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -402,42 +368,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   asv
     #   dask
     #   distributed
@@ -447,17 +409,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 referencing==0.35.1
     # via
     #   jsonschema
@@ -465,7 +426,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -478,18 +438,17 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -499,12 +458,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -515,7 +471,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   furo
     #   myst-nb
     #   myst-parser
@@ -526,30 +482,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -581,8 +537,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -594,28 +548,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -628,7 +580,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -637,12 +589,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -650,21 +598,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp8o4w9chu
-xxhash==3.4.1
-    # via pooch
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -15,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 asv-runner==0.2.1
     # via asv
 atpublic==5.0
@@ -33,7 +33,7 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -84,19 +84,21 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -104,7 +106,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -114,17 +116,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 ibis-framework==9.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -135,7 +137,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -154,7 +156,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -171,7 +173,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -221,7 +223,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -231,16 +233,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
@@ -259,12 +261,13 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 numpy==2.0.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -274,7 +277,7 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   black
     #   build
     #   dask
@@ -289,13 +292,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -309,7 +313,7 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -321,14 +325,14 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   ray
 psutil==6.0.0
     # via
@@ -343,11 +347,14 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -359,7 +366,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -369,19 +376,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -389,17 +396,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   asv
     #   dask
     #   distributed
@@ -414,11 +421,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 referencing==0.35.1
     # via
     #   jsonschema
@@ -438,6 +445,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -445,10 +453,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -471,7 +479,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,15 +490,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -548,26 +556,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -580,7 +588,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -590,7 +598,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -602,10 +610,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp4nsvnwvv
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp7stj62sh
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -3,33 +3,31 @@ aiosignal==1.3.1
 alabaster==0.7.13
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -39,14 +37,13 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -81,11 +78,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -94,16 +93,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -113,9 +109,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -125,6 +120,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -134,34 +130,28 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 ibis-framework==5.1.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   asv-runner
     #   build
     #   dask
@@ -190,23 +180,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -228,7 +220,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -256,7 +248,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -265,15 +258,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -292,8 +288,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 numpy==1.24.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   dask
     #   ibis-framework
     #   modin
@@ -303,6 +301,7 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   black
     #   build
     #   dask
@@ -317,11 +316,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -336,7 +337,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -350,14 +352,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pooch==1.8.2
     # via ibis-framework
 pre-commit==3.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -370,8 +376,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -380,40 +389,46 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pympler==1.1
     # via asv
 pyproj==3.5.0
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   babel
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   asv
     #   dask
     #   distributed
@@ -423,15 +438,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 referencing==0.35.1
     # via
     #   jsonschema
@@ -455,13 +471,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -474,9 +493,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -487,6 +504,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   furo
     #   myst-nb
     #   myst-parser
@@ -497,11 +515,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 sphinx-design==0.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -514,7 +536,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -556,7 +578,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -569,19 +591,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
     #   anyio
     #   astroid
     #   black
@@ -601,16 +630,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -618,20 +646,19 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -15,10 +15,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==2.3
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -35,12 +35,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 build==1.2.1
     # via asv
+cached-property==1.5.2
+    # via ibis-framework
 certifi==2024.7.4
     # via
     #   fiona
@@ -82,7 +82,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -93,7 +93,7 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 docutils==0.19
     # via
     #   myst-parser
@@ -110,7 +110,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -120,7 +120,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -130,17 +130,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 geopandas==0.13.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
+ibis-framework==2.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -151,7 +151,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   asv-runner
     #   build
     #   dask
@@ -163,9 +163,8 @@ importlib-metadata==8.2.0
     #   sphinx
     #   twine
     #   typeguard
-importlib-resources==5.13.0
+importlib-resources==6.4.0
     # via
-    #   ibis-framework
     #   jsonschema
     #   jsonschema-specifications
     #   keyring
@@ -181,7 +180,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -198,7 +197,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -248,7 +247,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -258,18 +257,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -288,10 +287,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 numpy==1.24.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   dask
     #   ibis-framework
     #   modin
@@ -301,7 +300,7 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   black
     #   build
     #   dask
@@ -310,22 +309,21 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.0.3.230814
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 parso==0.8.4
     # via jedi
-parsy==2.1
+parsy==1.4.0
     # via ibis-framework
 partd==1.4.1
     # via dask
@@ -338,7 +336,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -347,22 +345,19 @@ platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pre-commit==3.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   ray
 psutil==6.0.0
     # via
@@ -376,10 +371,10 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   fastapi
 pygments==2.18.0
     # via
@@ -389,7 +384,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -397,38 +392,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
-    #   ibis-framework
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   babel
-    #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   asv
     #   dask
     #   distributed
@@ -443,19 +436,20 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
+regex==2021.11.10
+    # via ibis-framework
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -468,7 +462,6 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -476,10 +469,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.10.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -504,7 +497,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   furo
     #   myst-nb
     #   myst-parser
@@ -515,15 +508,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 sphinx-design==0.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -538,8 +531,6 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
-    # via ibis-framework
 stack-data==0.6.3
     # via ipython
 starlette==0.37.2
@@ -567,7 +558,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.13.0
     # via pylint
-toolz==0.12.1
+toolz==0.11.2
     # via
     #   dask
     #   distributed
@@ -578,8 +569,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -591,31 +580,30 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   anyio
     #   astroid
     #   black
     #   fastapi
-    #   ibis-framework
     #   ipython
     #   mypy
     #   myst-nb
@@ -630,7 +618,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 urllib3==2.2.2
     # via
     #   distributed
@@ -638,7 +626,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -650,12 +638,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpj203ses8
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6whgp6j8
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -17,10 +17,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==2.3
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -37,12 +37,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 build==1.2.1
     # via asv
+cached-property==1.5.2
+    # via ibis-framework
 certifi==2024.7.4
     # via
     #   fiona
@@ -84,7 +84,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -95,7 +95,7 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 docutils==0.19
     # via
     #   myst-parser
@@ -112,7 +112,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -122,7 +122,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,17 +132,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 geopandas==0.13.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
+ibis-framework==2.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -153,7 +153,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   asv-runner
     #   build
     #   dask
@@ -165,9 +165,8 @@ importlib-metadata==8.2.0
     #   sphinx
     #   twine
     #   typeguard
-importlib-resources==5.13.0
+importlib-resources==6.4.0
     # via
-    #   ibis-framework
     #   jsonschema
     #   jsonschema-specifications
     #   keyring
@@ -183,7 +182,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -200,7 +199,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -250,7 +249,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -260,18 +259,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -290,10 +289,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 numpy==1.24.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   dask
     #   ibis-framework
     #   modin
@@ -303,7 +302,7 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   black
     #   build
     #   dask
@@ -312,22 +311,21 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.0.3.230814
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 parso==0.8.4
     # via jedi
-parsy==2.1
+parsy==1.4.0
     # via ibis-framework
 partd==1.4.1
     # via dask
@@ -340,7 +338,7 @@ pexpect==4.9.0
 pickleshare==0.7.5
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -349,22 +347,19 @@ platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pre-commit==3.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   ray
 psutil==6.0.0
     # via
@@ -378,10 +373,10 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -393,7 +388,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -401,38 +396,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
-    #   ibis-framework
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   babel
-    #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   asv
     #   dask
     #   distributed
@@ -447,19 +440,20 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
+regex==2021.11.10
+    # via ibis-framework
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -472,7 +466,6 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -480,10 +473,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.10.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -508,7 +501,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   furo
     #   myst-nb
     #   myst-parser
@@ -519,15 +512,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 sphinx-design==0.5.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -542,8 +535,6 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
-    # via ibis-framework
 stack-data==0.6.3
     # via ipython
 starlette==0.37.2
@@ -571,7 +562,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.13.0
     # via pylint
-toolz==0.12.1
+toolz==0.11.2
     # via
     #   dask
     #   distributed
@@ -582,8 +573,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -595,32 +584,31 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   annotated-types
     #   anyio
     #   astroid
     #   black
     #   fastapi
-    #   ibis-framework
     #   ipython
     #   mypy
     #   myst-nb
@@ -636,7 +624,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 urllib3==2.2.2
     # via
     #   distributed
@@ -644,7 +632,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -656,12 +644,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp2dpwjpst
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -5,33 +5,31 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -41,14 +39,13 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -83,11 +80,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -96,16 +95,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -115,9 +111,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -127,6 +122,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -136,34 +132,28 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 ibis-framework==5.1.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   asv-runner
     #   build
     #   dask
@@ -192,23 +182,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -230,7 +222,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -258,7 +250,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -267,15 +260,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -294,8 +290,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 numpy==1.24.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   dask
     #   ibis-framework
     #   modin
@@ -305,6 +303,7 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   black
     #   build
     #   dask
@@ -319,11 +318,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -338,7 +339,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -352,14 +354,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pooch==1.8.2
     # via ibis-framework
 pre-commit==3.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -372,8 +378,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -384,40 +393,46 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pympler==1.1
     # via asv
 pyproj==3.5.0
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   babel
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   asv
     #   dask
     #   distributed
@@ -427,15 +442,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 referencing==0.35.1
     # via
     #   jsonschema
@@ -459,13 +475,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -478,9 +497,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -491,6 +508,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   furo
     #   myst-nb
     #   myst-parser
@@ -501,11 +519,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 sphinx-design==0.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -518,7 +540,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -560,7 +582,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -573,19 +595,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
     #   annotated-types
     #   anyio
     #   astroid
@@ -607,16 +636,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -624,20 +652,19 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpl30b_y47
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -13,10 +13,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==4.1.0
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -33,7 +33,7 @@ beautifulsoup4==4.12.3
 bidict==0.23.1
     # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -81,13 +81,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==0.10.3
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -99,7 +101,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -107,7 +109,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -117,17 +119,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
+ibis-framework==9.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -138,7 +140,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   asv-runner
     #   build
     #   dask
@@ -161,7 +163,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -178,7 +180,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -228,7 +230,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -238,18 +240,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -268,10 +268,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   dask
     #   geopandas
     #   ibis-framework
@@ -284,7 +284,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   black
     #   build
     #   dask
@@ -293,20 +293,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -320,29 +319,26 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   ray
 psutil==6.0.0
     # via
@@ -355,11 +351,15 @@ pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+pyarrow==16.1.0
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   fastapi
 pygments==2.18.0
     # via
@@ -369,7 +369,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -379,19 +379,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -399,17 +399,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   asv
     #   dask
     #   distributed
@@ -424,11 +424,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 referencing==0.35.1
     # via
     #   jsonschema
@@ -436,7 +436,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -457,10 +456,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -470,7 +469,6 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -484,7 +482,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   furo
     #   myst-nb
     #   myst-parser
@@ -495,15 +493,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -518,7 +516,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==23.12.2
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -559,8 +557,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -572,26 +568,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   anyio
     #   astroid
     #   black
@@ -609,7 +605,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 urllib3==2.2.2
     # via
     #   distributed
@@ -617,7 +613,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -629,12 +625,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp8d4maryy
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -3,30 +3,28 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -34,13 +32,12 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,11 +66,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -82,16 +81,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -102,9 +98,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -112,6 +107,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,35 +116,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 ibis-framework==5.1.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   asv-runner
     #   build
     #   dask
@@ -170,23 +160,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -208,7 +200,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -236,7 +228,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -245,15 +238,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -272,8 +268,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   dask
     #   geopandas
     #   ibis-framework
@@ -286,6 +284,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   black
     #   build
     #   dask
@@ -301,11 +300,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -318,7 +319,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -330,14 +332,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pooch==1.8.2
     # via ibis-framework
-pre-commit==3.7.1
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -350,8 +356,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -360,6 +369,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -368,33 +378,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   asv
     #   dask
     #   distributed
@@ -404,15 +419,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 referencing==0.35.1
     # via
     #   jsonschema
@@ -436,13 +452,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -454,9 +473,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -467,6 +484,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   furo
     #   myst-nb
     #   myst-parser
@@ -477,24 +495,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -537,7 +559,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -550,19 +572,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
     #   anyio
     #   astroid
     #   black
@@ -580,16 +609,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -597,18 +625,17 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp3_llmc5j
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -15,10 +15,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==4.1.0
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -35,7 +35,7 @@ beautifulsoup4==4.12.3
 bidict==0.23.1
     # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -72,7 +72,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   distributed
 debugpy==1.8.5
     # via ipykernel
@@ -83,13 +83,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==0.10.3
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -101,7 +103,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -109,7 +111,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -119,17 +121,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
+ibis-framework==9.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -140,7 +142,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   asv-runner
     #   build
     #   dask
@@ -163,7 +165,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -180,7 +182,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -230,7 +232,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -240,18 +242,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -270,10 +270,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   dask
     #   geopandas
     #   ibis-framework
@@ -286,7 +286,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   black
     #   build
     #   dask
@@ -295,20 +295,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -322,29 +321,26 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   ray
 psutil==6.0.0
     # via
@@ -357,11 +353,15 @@ pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==17.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+pyarrow==16.1.0
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -373,7 +373,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -383,19 +383,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -403,17 +403,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   asv
     #   dask
     #   distributed
@@ -428,11 +428,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 referencing==0.35.1
     # via
     #   jsonschema
@@ -440,7 +440,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -461,10 +460,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -474,7 +473,6 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -488,7 +486,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   furo
     #   myst-nb
     #   myst-parser
@@ -499,15 +497,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -522,7 +520,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==23.12.2
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -563,8 +561,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -576,26 +572,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   anyio
     #   astroid
     #   black
@@ -614,7 +610,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 urllib3==2.2.2
     # via
     #   distributed
@@ -622,7 +618,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -634,12 +630,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmphvtcjztq
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -5,30 +5,28 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -36,13 +34,12 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,11 +68,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,16 +83,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +100,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +109,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,35 +118,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 ibis-framework==5.1.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   asv-runner
     #   build
     #   dask
@@ -172,23 +162,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -210,7 +202,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -238,7 +230,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -247,15 +240,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -274,8 +270,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   dask
     #   geopandas
     #   ibis-framework
@@ -288,6 +286,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   black
     #   build
     #   dask
@@ -303,11 +302,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -320,7 +321,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -332,14 +334,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pooch==1.8.2
     # via ibis-framework
-pre-commit==3.7.1
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -352,8 +358,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -364,6 +373,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -372,33 +382,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   asv
     #   dask
     #   distributed
@@ -408,15 +423,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 referencing==0.35.1
     # via
     #   jsonschema
@@ -440,13 +456,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -458,9 +477,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -471,6 +488,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   furo
     #   myst-nb
     #   myst-parser
@@ -481,24 +499,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -541,7 +563,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -554,19 +576,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
     #   anyio
     #   astroid
     #   black
@@ -585,16 +614,15 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -602,18 +630,17 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmps_7hk2eu
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -3,31 +3,28 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -35,14 +32,12 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,16 +66,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -88,18 +83,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -110,10 +101,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -121,7 +110,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -130,41 +119,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   asv-runner
     #   build
     #   dask
@@ -187,25 +164,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -227,7 +203,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -255,8 +231,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -265,18 +241,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -295,10 +271,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 numpy==1.26.4
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   dask
     #   geopandas
     #   ibis-framework
@@ -311,7 +287,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   black
     #   build
     #   dask
@@ -327,14 +303,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   dask
     #   dask-expr
     #   geopandas
     #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -347,8 +323,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -360,17 +336,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 pooch==1.8.2
     # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   ray
 psutil==6.0.0
     # via
@@ -385,11 +361,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   fastapi
 pygments==2.18.0
     # via
@@ -399,7 +375,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -408,42 +384,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   asv
     #   dask
     #   distributed
@@ -453,17 +425,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 referencing==0.35.1
     # via
     #   jsonschema
@@ -487,15 +458,15 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -508,9 +479,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -521,7 +490,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   furo
     #   myst-nb
     #   myst-parser
@@ -532,28 +501,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -596,7 +565,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -609,28 +578,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   anyio
     #   astroid
     #   black
@@ -648,7 +615,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -657,12 +624,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -670,21 +633,17 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpcn1rd475
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -13,10 +13,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==4.1.0
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -33,7 +33,7 @@ beautifulsoup4==4.12.3
 bidict==0.23.1
     # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -70,7 +70,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -84,13 +84,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==0.10.3
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -102,7 +104,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,7 +112,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,17 +122,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
+ibis-framework==9.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -141,7 +143,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   asv-runner
     #   build
     #   dask
@@ -164,7 +166,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -181,7 +183,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -231,7 +233,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -241,18 +243,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -271,10 +271,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   dask
     #   geopandas
     #   ibis-framework
@@ -287,7 +287,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   black
     #   build
     #   dask
@@ -296,21 +296,20 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   dask
     #   dask-expr
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -324,29 +323,26 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   ray
 psutil==6.0.0
     # via
@@ -359,13 +355,16 @@ pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==17.0.0
+pyarrow==16.1.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   fastapi
 pygments==2.18.0
     # via
@@ -375,7 +374,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -385,19 +384,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -405,17 +404,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   asv
     #   dask
     #   distributed
@@ -430,11 +429,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 referencing==0.35.1
     # via
     #   jsonschema
@@ -442,7 +441,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -463,10 +461,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -476,7 +474,6 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -490,7 +487,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   furo
     #   myst-nb
     #   myst-parser
@@ -501,15 +498,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -524,7 +521,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==23.12.2
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -565,8 +562,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -578,26 +573,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   anyio
     #   astroid
     #   black
@@ -615,7 +610,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -625,7 +620,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -637,12 +632,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpkuvrgjc7
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpnxi8zg5n
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -5,31 +5,28 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -37,14 +34,12 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -73,16 +68,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -90,18 +85,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -112,10 +103,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,7 +112,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,41 +121,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+hypothesis==6.111.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 ibis-framework==5.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   asv-runner
     #   build
     #   dask
@@ -189,25 +166,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -229,7 +205,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -257,8 +233,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -267,18 +243,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -297,10 +273,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 numpy==1.26.4
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   dask
     #   geopandas
     #   ibis-framework
@@ -313,7 +289,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   black
     #   build
     #   dask
@@ -329,14 +305,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   dask
     #   dask-expr
     #   geopandas
     #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -349,8 +325,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -362,17 +338,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 pooch==1.8.2
     # via ibis-framework
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   ray
 psutil==6.0.0
     # via
@@ -387,11 +363,11 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -403,7 +379,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -412,42 +388,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   asv
     #   dask
     #   distributed
@@ -457,17 +429,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 referencing==0.35.1
     # via
     #   jsonschema
@@ -491,15 +462,15 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -512,9 +483,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -525,7 +494,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   furo
     #   myst-nb
     #   myst-parser
@@ -536,28 +505,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -600,7 +569,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -613,28 +582,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   anyio
     #   astroid
     #   black
@@ -653,7 +620,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -662,12 +629,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -675,21 +638,17 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpnt4iu85d
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -15,10 +15,10 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==4.1.0
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -35,7 +35,7 @@ beautifulsoup4==4.12.3
 bidict==0.23.1
     # via ibis-framework
 black==24.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -72,7 +72,7 @@ coverage==7.6.1
     # via pytest-cov
 dask==2024.8.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   dask-expr
     #   distributed
 dask-expr==1.1.10
@@ -86,13 +86,15 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==0.10.3
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,7 +106,7 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -112,7 +114,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,17 +124,17 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.8.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 geopandas==1.0.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 grpcio==1.65.4
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
-ibis-framework==5.1.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
+ibis-framework==9.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -143,7 +145,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   asv-runner
     #   build
     #   dask
@@ -166,7 +168,7 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -183,7 +185,7 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -233,7 +235,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 more-itertools==10.4.0
     # via
     #   jaraco-classes
@@ -243,18 +245,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 mypy==1.10.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -273,10 +273,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 numpy==1.26.4
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   dask
     #   geopandas
     #   ibis-framework
@@ -289,7 +289,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   black
     #   build
     #   dask
@@ -298,21 +298,20 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   dask
     #   dask-expr
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -326,29 +325,26 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
-pooch==1.8.2
-    # via ibis-framework
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pre-commit==3.8.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   ray
 psutil==6.0.0
     # via
@@ -361,13 +357,16 @@ pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==17.0.0
+pyarrow==16.1.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -379,7 +378,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -389,19 +388,19 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pytest==8.3.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pytest-cov==5.0.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 pytest-xdist==3.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
@@ -409,17 +408,17 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   ibis-framework
     #   pandas
 pyyaml==6.0.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   asv
     #   dask
     #   distributed
@@ -434,11 +433,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 referencing==0.35.1
     # via
     #   jsonschema
@@ -446,7 +445,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -467,10 +465,10 @@ rpds-py==0.20.0
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 shapely==2.0.5
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -480,7 +478,6 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -494,7 +491,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   furo
     #   myst-nb
     #   myst-parser
@@ -505,15 +502,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 sphinx-design==0.6.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -528,7 +525,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==23.12.2
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -569,8 +566,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -582,26 +577,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 typeguard==4.3.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 types-setuptools==71.1.0.20240806
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   anyio
     #   astroid
     #   black
@@ -620,7 +615,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -630,7 +625,7 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -642,12 +637,10 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpbo6_ffnl
-xxhash==3.4.1
-    # via pooch
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpxwqqtip1
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -91,6 +91,8 @@ docutils==0.21.2
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -271,6 +273,7 @@ numpy==2.0.1
     #   -r requirements.in
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -299,6 +302,7 @@ pandas==2.2.2
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
     # via -r requirements.in
@@ -351,6 +355,9 @@ pyarrow==17.0.0
     # via
     #   -r requirements.in
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.8.2
     # via
     #   -r requirements.in
@@ -444,6 +451,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -5,44 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,15 +66,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -87,17 +83,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,9 +101,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -118,6 +110,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,35 +119,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r requirements.in
+ibis-framework==9.3.0
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -172,23 +159,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -210,7 +199,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -238,7 +227,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -247,16 +237,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r requirements.in
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -274,11 +265,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==1.26.4
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -288,6 +280,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -296,19 +289,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -321,26 +314,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -353,9 +348,13 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via dask-expr
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -366,6 +365,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -374,33 +374,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -410,15 +415,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -426,7 +432,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -439,16 +444,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -457,12 +464,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -473,6 +477,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -483,26 +488,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -543,8 +552,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -556,19 +563,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -585,6 +599,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -593,10 +608,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r requirements.in
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -604,18 +617,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -5,44 +5,39 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==5.0
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,15 +66,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -87,24 +83,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -112,6 +104,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,35 +113,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
-ibis-framework==5.1.0
+hypothesis==6.111.0
+    # via -r requirements.in
+ibis-framework==9.3.0
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -166,23 +153,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -204,7 +193,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -232,7 +221,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -241,16 +231,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-multipledispatch==0.6.0
-    # via ibis-framework
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r requirements.in
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -268,11 +259,12 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==1.26.4
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
-    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -282,6 +274,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -290,19 +283,19 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
-    #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -315,26 +308,28 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
-pooch==1.8.2
-    # via ibis-framework
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -347,9 +342,13 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via dask-expr
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -360,6 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -368,33 +368,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -404,15 +409,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -420,7 +426,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -433,16 +438,18 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -451,12 +458,9 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -467,6 +471,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -477,26 +482,30 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==25.9.0
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -528,8 +537,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -541,19 +548,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   fastapi
     #   ibis-framework
     #   ipython
@@ -566,6 +580,7 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -574,10 +589,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r requirements.in
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -585,18 +598,15 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
-xxhash==3.4.1
-    # via pooch
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -91,6 +91,8 @@ docutils==0.21.2
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==1.0.0
+    # via ibis-framework
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
@@ -265,6 +267,7 @@ numpy==2.0.1
     #   -r requirements.in
     #   dask
     #   geopandas
+    #   ibis-framework
     #   modin
     #   pandas
     #   pandas-stubs
@@ -293,6 +296,7 @@ pandas==2.2.2
     #   dask
     #   dask-expr
     #   geopandas
+    #   ibis-framework
     #   modin
 pandas-stubs==2.2.2.240807
     # via -r requirements.in
@@ -345,6 +349,9 @@ pyarrow==17.0.0
     # via
     #   -r requirements.in
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.8.2
     # via
     #   -r requirements.in
@@ -438,6 +445,7 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
+    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -20,8 +20,6 @@ asv==0.6.3
     # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
-    # via ibis-framework
 attrs==24.2.0
     # via
     #   fiona
@@ -37,12 +35,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-bidict==0.23.1
-    # via ibis-framework
 black==24.8.0
     # via -r requirements.in
 build==1.2.1
     # via asv
+cached-property==1.5.2
+    # via ibis-framework
 certifi==2024.7.4
     # via
     #   fiona
@@ -141,7 +139,7 @@ h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
     # via -r requirements.in
-ibis-framework==5.1.0
+ibis-framework==2.0.0
     # via -r requirements.in
 identify==2.6.0
     # via pre-commit
@@ -165,9 +163,8 @@ importlib-metadata==8.2.0
     #   sphinx
     #   twine
     #   typeguard
-importlib-resources==5.13.0
+importlib-resources==6.4.0
     # via
-    #   ibis-framework
     #   jsonschema
     #   jsonschema-specifications
     #   keyring
@@ -261,7 +258,7 @@ msgpack==1.0.8
     #   ray
 multimethod==1.10
     # via -r requirements.in
-multipledispatch==0.6.0
+multipledispatch==1.0.0
     # via ibis-framework
 mypy==1.10.0
     # via -r requirements.in
@@ -312,7 +309,6 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pytest
     #   ray
     #   sphinx
@@ -349,15 +345,12 @@ platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
     # via -r requirements.in
-pooch==1.8.2
-    # via ibis-framework
 pre-commit==3.5.0
     # via -r requirements.in
 prompt-toolkit==3.0.47
@@ -417,7 +410,6 @@ pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
-    #   ibis-framework
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
@@ -456,10 +448,11 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
+regex==2024.7.24
+    # via ibis-framework
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -472,7 +465,6 @@ rfc3986==2.0.0
     #   twine
 rich==13.7.1
     # via
-    #   ibis-framework
     #   twine
     #   typer
 rpds-py==0.20.0
@@ -481,6 +473,8 @@ rpds-py==0.20.0
     #   referencing
 scipy==1.10.1
     # via -r requirements.in
+setuptools==72.1.0
+    # via ibis-framework
 shapely==2.0.5
     # via
     #   -r requirements.in
@@ -494,7 +488,6 @@ six==1.16.0
     #   asttokens
     #   fiona
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -542,8 +535,6 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
-    # via ibis-framework
 stack-data==0.6.3
     # via ipython
 starlette==0.37.2
@@ -582,8 +573,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -620,7 +609,6 @@ typing-extensions==4.12.2
     #   astroid
     #   black
     #   fastapi
-    #   ibis-framework
     #   ipython
     #   mypy
     #   myst-nb
@@ -662,8 +650,6 @@ wrapt==1.16.0
     #   astroid
 xdoctest==1.1.6
     # via -r requirements.in
-xxhash==3.4.1
-    # via pooch
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -5,33 +5,31 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -41,14 +39,13 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -83,11 +80,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r requirements.in
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -96,16 +95,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r requirements.in
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -115,9 +111,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -127,6 +122,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -136,34 +132,28 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r requirements.in
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r requirements.in
 ibis-framework==5.1.0
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -192,23 +182,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -230,7 +222,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -258,7 +250,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.23.1.post0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -267,15 +260,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r requirements.in
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -294,8 +290,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r requirements.in
 numpy==1.24.4
     # via
+    #   -r requirements.in
     #   dask
     #   ibis-framework
     #   modin
@@ -305,6 +303,7 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -319,11 +318,13 @@ packaging==24.1
     #   sphinx
 pandas==2.0.3
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   ibis-framework
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -338,7 +339,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -352,14 +354,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r requirements.in
 pooch==1.8.2
     # via ibis-framework
 pre-commit==3.5.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -372,8 +378,11 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
+    # via -r requirements.in
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -384,40 +393,46 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyproj==3.5.0
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   babel
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -427,15 +442,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r requirements.in
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -459,13 +475,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -478,9 +497,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -491,6 +508,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -501,11 +519,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r requirements.in
 sphinx-design==0.5.0
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -518,7 +540,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -560,7 +582,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -573,19 +595,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   annotated-types
     #   anyio
     #   astroid
@@ -607,6 +636,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -615,10 +645,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r requirements.in
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -626,20 +654,19 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -18,7 +18,7 @@ asv==0.6.3
     # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-atpublic==3.1.2
+atpublic==4.1.0
     # via ibis-framework
 attrs==24.2.0
     # via
@@ -93,6 +93,8 @@ docutils==0.21.2
     #   readme-renderer
     #   recommonmark
     #   sphinx
+duckdb==0.10.3
+    # via ibis-framework
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -131,7 +133,7 @@ h11==0.14.0
     # via uvicorn
 hypothesis==6.111.0
     # via -r requirements.in
-ibis-framework==5.1.0
+ibis-framework==9.0.0
     # via -r requirements.in
 identify==2.6.0
     # via pre-commit
@@ -244,8 +246,6 @@ msgpack==1.0.8
     #   ray
 multimethod==1.10
     # via -r requirements.in
-multipledispatch==0.6.0
-    # via ibis-framework
 mypy==1.10.0
     # via -r requirements.in
 mypy-extensions==1.0.0
@@ -298,7 +298,6 @@ packaging==24.1
     #   ipykernel
     #   modin
     #   nox
-    #   pooch
     #   pyogrio
     #   pytest
     #   ray
@@ -333,15 +332,12 @@ platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
-    #   pooch
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
 polars==1.4.1
     # via -r requirements.in
-pooch==1.8.2
-    # via ibis-framework
 pre-commit==3.8.0
     # via -r requirements.in
 prompt-toolkit==3.0.47
@@ -361,10 +357,13 @@ pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==17.0.0
+pyarrow==16.1.0
     # via
     #   -r requirements.in
     #   dask-expr
+    #   ibis-framework
+pyarrow-hotfix==0.6
+    # via ibis-framework
 pydantic==2.8.2
     # via
     #   -r requirements.in
@@ -446,7 +445,6 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   frictionless
-    #   pooch
     #   ray
     #   requests-toolbelt
     #   sphinx
@@ -480,7 +478,6 @@ six==1.16.0
     # via
     #   asttokens
     #   isodate
-    #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -528,7 +525,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.32
     # via jupyter-cache
-sqlglot==11.7.1
+sqlglot==23.12.2
     # via ibis-framework
 stack-data==0.6.3
     # via ipython
@@ -569,8 +566,6 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
-    # via pooch
 traitlets==5.14.3
     # via
     #   comm
@@ -646,8 +641,6 @@ wrapt==1.16.0
     #   astroid
 xdoctest==1.1.6
     # via -r requirements.in
-xxhash==3.4.1
-    # via pooch
 zict==3.0.0
     # via distributed
 zipp==3.20.0

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -5,30 +5,28 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 atpublic==3.1.2
     # via ibis-framework
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
@@ -36,13 +34,12 @@ beautifulsoup4==4.12.3
     # via furo
 bidict==0.23.1
     # via ibis-framework
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,15 +68,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.1
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.9
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -87,17 +85,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.1
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,9 +103,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -118,6 +112,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,35 +121,29 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.7.18
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.65.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.3
+hypothesis==6.111.0
+    # via -r requirements.in
 ibis-framework==5.1.0
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -176,23 +165,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -214,7 +205,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -242,7 +233,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -251,15 +243,18 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 multipledispatch==0.6.0
     # via ibis-framework
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r requirements.in
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -278,8 +273,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r requirements.in
 numpy==1.26.4
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   ibis-framework
@@ -292,6 +289,7 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -307,12 +305,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   ibis-framework
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 parsy==2.1
@@ -325,7 +325,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -337,14 +338,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.4.1
+    # via -r requirements.in
 pooch==1.8.2
     # via ibis-framework
-pre-commit==3.7.1
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -357,9 +362,13 @@ pure-eval==0.2.3
 py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
-    # via dask-expr
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -370,6 +379,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -378,33 +388,38 @@ pyproj==3.6.1
     # via geopandas
 pyproject-hooks==1.1.0
     # via build
-pyspark==3.5.1
-pytest==8.3.1
+pyspark==3.5.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   ibis-framework
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   ibis-framework
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -414,15 +429,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -446,13 +462,16 @@ rich==13.7.1
     #   ibis-framework
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -464,9 +483,7 @@ six==1.16.0
     #   multipledispatch
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -477,6 +494,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -487,24 +505,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 sqlglot==11.7.1
     # via ibis-framework
@@ -547,7 +569,7 @@ tornado==6.4.1
     #   distributed
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.4
+tqdm==4.66.5
     # via pooch
 traitlets==5.14.3
     # via
@@ -560,19 +582,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -591,6 +620,7 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -599,10 +629,8 @@ urllib3==2.2.2
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.5
+    # via -r requirements.in
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -610,18 +638,17 @@ virtualenv==20.26.3
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 xxhash==3.4.1
     # via pooch
 zict==3.0.0
     # via distributed
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/environment.yml
+++ b/environment.yml
@@ -94,7 +94,7 @@ dependencies:
       - ray
       - typeguard
       - types-click
-      - types-pyyaml
-      - types-pkg_resources
-      - types-requests
       - types-pytz
+      - types-pyyaml
+      - types-requests
+      - types-setuptools

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - typing_inspect >= 0.6.0
   - typing_extensions >= 3.7.4.3
   - frictionless <= 4.40.8  # v5.* introduces breaking changes
-  - pyarrow
+  - pyarrow >= 13 # https://github.com/apache/arrow/pull/35113
   - pydantic
   - multimethod <= 1.10.0
 
@@ -33,9 +33,6 @@ dependencies:
   # modin extra
   - modin
   - protobuf
-
-  # ibis extra
-  - ibis-framework >= 3.1.0
 
   # geopandas extra
   - geopandas
@@ -60,6 +57,9 @@ dependencies:
   - xdoctest
   - nox
   - importlib_metadata # required if python < 3.8
+
+  # ibis testing
+  - ibis-duckdb
 
   # fastapi testing
   - uvicorn
@@ -86,6 +86,9 @@ dependencies:
       # dask extra
       - dask[dataframe]
       - distributed
+
+      # ibis extra
+      - ibis-framework >= 3.1.0 ; python_version >= '3.9'
 
       # docs
       - furo

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,11 +37,11 @@ PACKAGE = "pandera"
 SOURCE_PATHS = PACKAGE, "tests", "noxfile.py"
 REQUIREMENT_PATH = "requirements.in"
 ALWAYS_USE_PIP = {
-    "ray",
     "furo",
+    "ray",
     "types-click",
     "types-pyyaml",
-    "types-pkg_resources",
+    "types-setuptools",
 }
 
 CI_RUN = os.environ.get("CI") == "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ log_cli_level = 20
 [tool.black]
 line-length = 79
 target-version = [
-  'py37',
   'py38',
   'py39',
   'py310',

--- a/requirements.in
+++ b/requirements.in
@@ -56,7 +56,7 @@ grpcio
 ray
 typeguard
 types-click
-types-pyyaml
-types-pkg_resources
-types-requests
 types-pytz
+types-pyyaml
+types-requests
+types-setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ pyyaml >=5.1
 typing_inspect >= 0.6.0
 typing_extensions >= 3.7.4.3
 frictionless <= 4.40.8
-pyarrow
+pyarrow >= 13
 pydantic
 multimethod <= 1.10.0
 pandas-stubs
@@ -20,7 +20,6 @@ pyspark >= 3.2.0
 polars >= 0.20.0
 modin
 protobuf
-ibis-framework >= 3.1.0
 geopandas
 shapely
 fastapi
@@ -37,6 +36,7 @@ pytz
 xdoctest
 nox
 importlib_metadata
+ibis-framework[duckdb]
 uvicorn
 python-multipart
 sphinx
@@ -50,6 +50,7 @@ asv >= 0.5.1
 pre_commit
 dask[dataframe]
 distributed
+ibis-framework >= 3.1.0 ; python_version >= '3.9'
 furo
 sphinx-docsearch
 grpcio

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional
 import yaml
 
 EXCLUDE = {"python"}
-RENAME: Dict[str, str] = {}
+RENAME: Dict[str, str] = {"ibis-duckdb": "ibis-framework[duckdb]"}
 
 REPO_PATH = Path(__file__).resolve().absolute().parents[1]
 CONDA_REQUIREMENTS_FILE = REPO_PATH / "environment.yml"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ _extras_require = {
     "mypy": ["pandas-stubs"],
     "fastapi": ["fastapi"],
     "geopandas": ["geopandas", "shapely"],
-    "ibis": ["ibis-framework >= 3.1.0"],
+    "ibis": ["ibis-framework >= 3.1.0 ; python_version >= '3.9'"],
     "polars": ["polars >= 0.20.0"],
 }
 

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -129,7 +129,7 @@ PANDAS_INDEX_ERRORS = [
     {"msg": "Incompatible types in assignment", "errcode": "assignment"},
 ] * 3
 
-PANDAS_SERIES_ERRORS = [
+PANDAS_SERIES_ERRORS_NO_PLUGIN = [
     {
         "msg": (
             'Argument 1 to "fn" has incompatible type "Series[float]"; '
@@ -137,6 +137,23 @@ PANDAS_SERIES_ERRORS = [
         ),
         "errcode": "arg-type",
     }
+]
+
+PANDAS_SERIES_ERRORS_PLUGIN = [
+    {
+        "msg": (
+            'Argument "s" to "fn" has incompatible type "Series[float]"; '
+            'expected "Series[str]"'
+        ),
+        "errcode": "arg-type",
+    },
+    {
+        "msg": (
+            'Argument 1 to "fn" has incompatible type "Series[float]"; '
+            'expected "Series[str]"'
+        ),
+        "errcode": "arg-type",
+    },
 ]
 
 
@@ -159,8 +176,8 @@ PANDAS_SERIES_ERRORS = [
         ["python_slice.py", "plugin_mypy.ini", PYTHON_SLICE_ERRORS],
         ["pandas_index.py", "no_plugin.ini", []],
         ["pandas_index.py", "plugin_mypy.ini", []],
-        ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS],
-        ["pandas_series.py", "plugin_mypy.ini", PANDAS_SERIES_ERRORS],
+        ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS_NO_PLUGIN],
+        ["pandas_series.py", "plugin_mypy.ini", PANDAS_SERIES_ERRORS_PLUGIN],
     ],
 )
 def test_pandas_stubs_false_positives(


### PR DESCRIPTION
Ibis follows NEP-29 much more aggressively than Pandera, ~so not going to bother with anything older than Python 3.10~ but still trying to run with 3.10 (for now). Hopefully this will make some of the CI issues go away.

See also: https://github.com/unionai-oss/pandera/pull/1451#issuecomment-2194816898