### PR TITLE
feature: add reorder flag to select_columns method

### DIFF
--- a/tests/core/test_schemas.py
+++ b/tests/core/test_schemas.py
@@ -1214,7 +1214,7 @@ def test_rename_columns() -> None:
 
 
 @pytest.mark.parametrize(
-    "select_columns, schema",
+    "select_columns, schema, reorder, expected_order",
     [
         (
             ["col1", "col2"],
@@ -1225,6 +1225,20 @@ def test_rename_columns() -> None:
                     "col3": Column(int),
                 }
             ),
+            False,
+            ["col1", "col2"],
+        ),
+        (
+            ["col2", "col1"],
+            DataFrameSchema(
+                columns={
+                    "col1": Column(int),
+                    "col2": Column(int),
+                    "col3": Column(int),
+                }
+            ),
+            True,
+            ["col2", "col1"],
         ),
         (
             [("col1", "col1b"), ("col2", "col2b")],
@@ -1236,20 +1250,42 @@ def test_rename_columns() -> None:
                     ("col2", "col2b"): Column(int),
                 }
             ),
+            False,
+            [("col1", "col1b"), ("col2", "col2b")],
+        ),
+        (
+            [("col2", "col2b"), ("col1", "col1b")],
+            DataFrameSchema(
+                columns={
+                    ("col1", "col1a"): Column(int),
+                    ("col1", "col1b"): Column(int),
+                    ("col2", "col2a"): Column(int),
+                    ("col2", "col2b"): Column(int),
+                }
+            ),
+            True,
+            [("col2", "col2b"), ("col1", "col1b")],
         ),
     ],
 )
 def test_select_columns(
-    select_columns: List[Union[str, Tuple[str, str]]], schema: DataFrameSchema
+    select_columns: List[Union[str, Tuple[str, str]]],
+    schema: DataFrameSchema,
+    reorder: bool,
+    expected_order: List[Union[str, Tuple[str, str]]],
 ) -> None:
     """Check that select_columns method correctly creates new subset schema."""
     original_columns = list(schema.columns)
-    schema_selected = schema.select_columns(select_columns)
+    schema_selected = schema.select_columns(select_columns, reorder=reorder)
+
     assert all(x in select_columns for x in schema_selected.columns)
     assert all(x in original_columns for x in schema.columns)
 
+    assert list(schema_selected.columns) == expected_order
+    assert schema_selected.ordered == reorder
+
     with pytest.raises(errors.SchemaInitError):
-        schema.select_columns(["foo", "bar"])
+        schema.select_columns(["foo", "bar"], reorder=reorder)
 
 
 def test_lazy_dataframe_validation_error() -> None:


### PR DESCRIPTION
I was using pandera to create schemas from source -> raw -> bronze -> silver -> gold and the `.add_columns` and `.remove_columns` made this nice and easy to work with. I am using these predefined schemas to create the corresponding Delta Tables.

One thing which bothered me was that I could not order the columns explicitly. For example, `created_at` is a column in the raw data and I add `created_at_utc` or `date` in the bronze schema - these columns would be appended to the end of the schema as would any metadata columns I add. 

I added a `reorder` flag to the `select_columns` method which is False by default. It will reorder the schema based on the order of the columns list. Here is an example of how I would use it after adding new computed columns to the schema to ensure that they are placed in the "correct" order instead of at the end of the table. I can then use the `pl.select(schema.columns.keys())` to reorganize my dataframe as well before writing the data.

```python
def bronze_schema() -> DataFrameSchema:
    """Bronze schema for Employee data."""
    input_schema: DataFrameSchema = raw_schema()

    output_schema: DataFrameSchema = (
        input_schema.rename_columns(rename_dict=get_custom_mapping())
        .add_columns(
            extra_schema_cols={
                "row_processed_at": Column(dtype=pl.Datetime(time_zone="UTC")),
                "row_deleted_at": Column(dtype=pl.Datetime(time_zone="UTC")),
                "unique_row_hash": Column(dtype=pl.String),
                ...
            }
        )
        .select_columns(
            reorder=True,
            columns=[
                "row_extracted_at",
                "row_processed_at",
                "row_deleted_at",
                "unique_row_hash",
                "date",
                "employee_id",    
                ...   
```

This sets the schema to `ordered=True` as well - not sure if that is desired though or not but it seemed to make sense.

Signed-off-by: Lance Dacey <lance.dacey@gmail.com>

