### PR TITLE
Add support for Spark Connect dataframes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,7 +54,7 @@ jobs:
             mypy==0.982 \
             types-click \
             types-pyyaml \
-            types-pkg_resources \
+            types-setuptools \
             types-requests \
             types-pytz
       - name: Pip info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-click
-          - types-pkg_resources
+          - types-setuptools
           - types-pytz
           - types-pyyaml
           - types-requests

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,6 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -30,13 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -68,8 +65,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,16 +77,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -98,9 +94,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +103,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +112,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -161,23 +159,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -227,6 +227,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -236,13 +237,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -261,8 +265,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   dask
     #   geopandas
     #   modin
@@ -270,12 +276,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   black
     #   build
     #   dask
@@ -290,10 +296,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -304,7 +313,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -315,12 +325,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -328,13 +344,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   pyspark
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -343,6 +364,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -352,29 +374,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   asv
     #   dask
     #   distributed
@@ -384,15 +412,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 referencing==0.35.1
     # via
     #   jsonschema
@@ -414,13 +443,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -431,9 +463,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -444,6 +474,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   furo
     #   myst-nb
     #   myst-parser
@@ -454,22 +485,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -522,19 +557,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   anyio
     #   astroid
     #   black
@@ -549,34 +591,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -1,563 +1,194 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -77,7 +74,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 docutils==0.21.2
     # via
     #   myst-parser
@@ -95,7 +91,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -103,7 +98,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -113,16 +107,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -130,7 +121,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -141,7 +131,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -160,7 +149,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -177,7 +165,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -199,7 +186,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -227,7 +214,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -237,16 +223,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -265,10 +248,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   dask
     #   geopandas
     #   modin
@@ -281,7 +262,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   black
     #   build
     #   dask
@@ -296,13 +276,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -314,7 +292,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -326,14 +303,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -350,11 +324,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   fastapi
 pygments==2.18.0
     # via
@@ -364,7 +336,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -374,35 +345,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   asv
     #   dask
     #   distributed
@@ -417,11 +380,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 referencing==0.35.1
     # via
     #   jsonschema
@@ -448,10 +409,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -474,7 +433,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   furo
     #   myst-nb
     #   myst-parser
@@ -485,15 +443,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -557,26 +511,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   anyio
     #   astroid
     #   black
@@ -591,7 +537,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 urllib3==2.2.2
     # via
     #   distributed
@@ -599,7 +544,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -611,10 +555,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp03c67mfg
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -1,568 +1,196 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -70,8 +67,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,16 +79,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -100,9 +96,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,6 +105,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,34 +114,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -163,23 +161,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -229,6 +229,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -238,13 +239,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -263,8 +267,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   dask
     #   geopandas
     #   modin
@@ -272,12 +278,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   black
     #   build
     #   dask
@@ -292,10 +298,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -306,7 +315,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -317,12 +327,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -330,13 +346,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   pyspark
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -347,6 +368,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +378,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   asv
     #   dask
     #   distributed
@@ -388,15 +416,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +447,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +467,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +478,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,22 +489,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -526,19 +561,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   anyio
     #   astroid
     #   black
@@ -554,34 +596,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -79,7 +76,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 docutils==0.21.2
     # via
     #   myst-parser
@@ -97,7 +93,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -105,7 +100,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -115,16 +109,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -132,7 +123,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -143,7 +133,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -162,7 +151,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -179,7 +167,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -201,7 +188,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -229,7 +216,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -239,16 +225,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -267,10 +250,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   dask
     #   geopandas
     #   modin
@@ -283,7 +264,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   black
     #   build
     #   dask
@@ -298,13 +278,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -316,7 +294,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -328,14 +305,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -352,11 +326,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -368,7 +340,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -378,35 +349,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   asv
     #   dask
     #   distributed
@@ -421,11 +384,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 referencing==0.35.1
     # via
     #   jsonschema
@@ -452,10 +413,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -478,7 +437,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   furo
     #   myst-nb
     #   myst-parser
@@ -489,15 +447,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -561,26 +515,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   anyio
     #   astroid
     #   black
@@ -596,7 +542,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 urllib3==2.2.2
     # via
     #   distributed
@@ -604,7 +549,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -616,10 +560,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpy2iquree
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -1,570 +1,196 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,14 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,14 +64,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,18 +79,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -106,10 +97,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -117,7 +106,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,39 +115,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -177,25 +163,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -245,7 +230,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -255,16 +240,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -283,10 +268,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask
     #   geopandas
     #   modin
@@ -294,13 +279,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   black
     #   build
     #   dask
@@ -315,13 +299,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -332,8 +317,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -344,15 +329,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -361,17 +348,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask-expr
+    #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   fastapi
 pygments==2.18.0
     # via
@@ -381,7 +369,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -391,39 +379,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   asv
     #   dask
     #   distributed
@@ -433,17 +417,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 referencing==0.35.1
     # via
     #   jsonschema
@@ -465,15 +448,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -485,9 +468,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -498,7 +479,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   furo
     #   myst-nb
     #   myst-parser
@@ -509,26 +490,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -581,28 +562,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   anyio
     #   astroid
     #   black
@@ -617,42 +596,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -80,7 +77,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 docutils==0.21.2
     # via
     #   myst-parser
@@ -98,7 +94,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -106,7 +101,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,16 +110,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -133,7 +124,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -144,7 +134,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -163,7 +152,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -180,7 +168,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -202,7 +189,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -230,7 +217,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -240,16 +226,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -268,10 +251,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask
     #   geopandas
     #   modin
@@ -284,7 +265,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   black
     #   build
     #   dask
@@ -299,14 +279,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -318,7 +296,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -330,14 +307,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -354,12 +328,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   dask-expr
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   fastapi
 pygments==2.18.0
     # via
@@ -369,7 +341,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -379,35 +350,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   asv
     #   dask
     #   distributed
@@ -422,11 +385,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 referencing==0.35.1
     # via
     #   jsonschema
@@ -453,10 +414,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -479,7 +438,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   furo
     #   myst-nb
     #   myst-parser
@@ -490,15 +448,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -562,26 +516,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   anyio
     #   astroid
     #   black
@@ -596,7 +542,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -606,7 +551,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -618,10 +562,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpq4tuffs1
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -1,575 +1,198 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -82,7 +79,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 docutils==0.21.2
     # via
     #   myst-parser
@@ -100,7 +96,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,7 +103,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,16 +112,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -135,7 +126,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -146,7 +136,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -165,7 +154,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -182,7 +170,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -204,7 +191,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -232,7 +219,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -242,16 +228,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -270,10 +253,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask
     #   geopandas
     #   modin
@@ -286,7 +267,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   black
     #   build
     #   dask
@@ -301,14 +281,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -320,7 +298,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -332,14 +309,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -356,12 +330,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask-expr
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -373,7 +345,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -383,35 +354,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   asv
     #   dask
     #   distributed
@@ -426,11 +389,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 referencing==0.35.1
     # via
     #   jsonschema
@@ -457,10 +418,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -483,7 +442,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   furo
     #   myst-nb
     #   myst-parser
@@ -494,15 +452,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -566,26 +520,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   anyio
     #   astroid
     #   black
@@ -601,7 +547,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -611,7 +556,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -623,10 +567,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -33,14 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,14 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,18 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,10 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -119,7 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -128,39 +117,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -179,25 +165,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -247,7 +232,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -257,16 +242,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -285,10 +270,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask
     #   geopandas
     #   modin
@@ -296,13 +281,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   black
     #   build
     #   dask
@@ -317,13 +301,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -334,8 +319,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -346,15 +331,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -363,17 +350,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   dask-expr
+    #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -385,7 +373,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -395,39 +383,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   asv
     #   dask
     #   distributed
@@ -437,17 +421,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 referencing==0.35.1
     # via
     #   jsonschema
@@ -469,15 +452,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -489,9 +472,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -502,7 +483,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   furo
     #   myst-nb
     #   myst-parser
@@ -513,26 +494,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -585,28 +566,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   anyio
     #   astroid
     #   black
@@ -622,42 +601,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpbecaaxr0
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -77,7 +74,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 docutils==0.21.2
     # via
     #   myst-parser
@@ -89,7 +85,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -97,7 +92,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -107,16 +101,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -124,7 +115,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -135,7 +125,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -154,7 +143,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -171,7 +159,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -193,7 +180,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -221,7 +208,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -231,16 +217,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -259,10 +242,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   dask
     #   geopandas
     #   modin
@@ -275,7 +256,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   black
     #   build
     #   dask
@@ -290,13 +270,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -308,7 +286,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -320,14 +297,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -344,11 +318,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   fastapi
 pygments==2.18.0
     # via
@@ -358,7 +330,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -368,35 +339,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   asv
     #   dask
     #   distributed
@@ -411,11 +374,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 referencing==0.35.1
     # via
     #   jsonschema
@@ -442,10 +403,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -468,7 +427,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   furo
     #   myst-nb
     #   myst-parser
@@ -479,15 +437,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -542,26 +496,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   fastapi
     #   ipython
     #   mypy
@@ -572,7 +518,6 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 urllib3==2.2.2
     # via
     #   distributed
@@ -580,7 +525,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -592,10 +536,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -1,544 +1,193 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via asv
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,6 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -30,13 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -68,8 +65,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,23 +77,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -102,6 +97,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -110,34 +106,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -155,23 +153,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -221,6 +221,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -230,13 +231,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -255,8 +259,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   dask
     #   geopandas
     #   modin
@@ -264,12 +270,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   black
     #   build
     #   dask
@@ -284,10 +290,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -298,7 +307,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -309,12 +319,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -322,13 +338,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   pyspark
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -337,6 +358,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -346,29 +368,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   asv
     #   dask
     #   distributed
@@ -378,15 +406,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 referencing==0.35.1
     # via
     #   jsonschema
@@ -408,13 +437,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -425,9 +457,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -438,6 +468,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   furo
     #   myst-nb
     #   myst-parser
@@ -448,22 +479,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -507,19 +542,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
     #   fastapi
     #   ipython
     #   mypy
@@ -530,34 +572,30 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp5eek_wum
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -79,7 +76,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 docutils==0.21.2
     # via
     #   myst-parser
@@ -91,7 +87,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -99,7 +94,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -109,16 +103,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -126,7 +117,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -137,7 +127,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -156,7 +145,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -173,7 +161,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -195,7 +182,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -223,7 +210,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -233,16 +219,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -261,10 +244,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   dask
     #   geopandas
     #   modin
@@ -277,7 +258,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   black
     #   build
     #   dask
@@ -292,13 +272,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -310,7 +288,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -322,14 +299,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -346,11 +320,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -362,7 +334,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -372,35 +343,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   asv
     #   dask
     #   distributed
@@ -415,11 +378,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 referencing==0.35.1
     # via
     #   jsonschema
@@ -446,10 +407,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -472,7 +431,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   furo
     #   myst-nb
     #   myst-parser
@@ -483,15 +441,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -546,26 +500,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   fastapi
     #   ipython
     #   mypy
@@ -577,7 +523,6 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 urllib3==2.2.2
     # via
     #   distributed
@@ -585,7 +530,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -597,10 +541,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -1,549 +1,195 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via asv
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -70,8 +67,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,23 +79,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -104,6 +99,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -112,34 +108,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -157,23 +155,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -223,6 +223,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -232,13 +233,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -257,8 +261,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   dask
     #   geopandas
     #   modin
@@ -266,12 +272,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   black
     #   build
     #   dask
@@ -286,10 +292,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -300,7 +309,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -311,12 +321,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -324,13 +340,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   pyspark
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -341,6 +362,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -350,29 +372,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   asv
     #   dask
     #   distributed
@@ -382,15 +410,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 referencing==0.35.1
     # via
     #   jsonschema
@@ -412,13 +441,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -429,9 +461,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -442,6 +472,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   furo
     #   myst-nb
     #   myst-parser
@@ -452,22 +483,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -511,19 +546,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
     #   fastapi
     #   ipython
     #   mypy
@@ -535,34 +577,30 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmppwp92ah1
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -1,551 +1,195 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via asv
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -80,7 +77,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 docutils==0.21.2
     # via
     #   myst-parser
@@ -92,7 +88,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -100,7 +95,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -110,16 +104,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -127,7 +118,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -138,7 +128,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -157,7 +146,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -174,7 +162,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -196,7 +183,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -224,7 +211,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -234,16 +220,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -262,10 +245,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask
     #   geopandas
     #   modin
@@ -278,7 +259,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   black
     #   build
     #   dask
@@ -293,14 +273,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -312,7 +290,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -324,14 +301,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -348,12 +322,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask-expr
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   fastapi
 pygments==2.18.0
     # via
@@ -363,7 +335,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -373,35 +344,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   asv
     #   dask
     #   distributed
@@ -416,11 +379,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 referencing==0.35.1
     # via
     #   jsonschema
@@ -447,10 +408,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -473,7 +432,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   furo
     #   myst-nb
     #   myst-parser
@@ -484,15 +442,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -547,26 +501,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   fastapi
     #   ipython
     #   mypy
@@ -577,7 +523,6 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -587,7 +532,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -599,10 +543,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,14 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,14 +64,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,26 +79,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -111,7 +100,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,39 +109,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -171,25 +157,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -239,7 +224,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -249,16 +234,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -277,10 +262,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask
     #   geopandas
     #   modin
@@ -288,13 +273,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   black
     #   build
     #   dask
@@ -309,13 +293,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -326,8 +311,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -338,15 +323,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -355,17 +342,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   dask-expr
+    #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   fastapi
 pygments==2.18.0
     # via
@@ -375,7 +363,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -385,39 +373,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   asv
     #   dask
     #   distributed
@@ -427,17 +411,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 referencing==0.35.1
     # via
     #   jsonschema
@@ -459,15 +442,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -479,9 +462,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -492,7 +473,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   furo
     #   myst-nb
     #   myst-parser
@@ -503,26 +484,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -566,28 +547,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   fastapi
     #   ipython
     #   mypy
@@ -598,42 +577,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmprcp5os8n
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -82,7 +79,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 docutils==0.21.2
     # via
     #   myst-parser
@@ -94,7 +90,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -102,7 +97,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -112,16 +106,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -129,7 +120,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -140,7 +130,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -159,7 +148,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -176,7 +164,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -198,7 +185,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -226,7 +213,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -236,16 +222,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -264,10 +247,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask
     #   geopandas
     #   modin
@@ -280,7 +261,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   black
     #   build
     #   dask
@@ -295,14 +275,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -314,7 +292,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -326,14 +303,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -350,12 +324,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask-expr
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -367,7 +339,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -377,35 +348,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   asv
     #   dask
     #   distributed
@@ -420,11 +383,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 referencing==0.35.1
     # via
     #   jsonschema
@@ -451,10 +412,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -477,7 +436,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   furo
     #   myst-nb
     #   myst-parser
@@ -488,15 +446,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -551,26 +505,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   fastapi
     #   ipython
     #   mypy
@@ -582,7 +528,6 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -592,7 +537,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -604,10 +548,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -1,556 +1,197 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via asv
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -33,14 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,14 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,26 +81,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -113,7 +102,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,39 +111,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -173,25 +159,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -241,7 +226,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -251,16 +236,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -279,10 +264,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask
     #   geopandas
     #   modin
@@ -290,13 +275,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   black
     #   build
     #   dask
@@ -311,13 +295,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -328,8 +313,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -340,15 +325,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -357,17 +344,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   dask-expr
+    #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -379,7 +367,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -389,39 +377,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   asv
     #   dask
     #   distributed
@@ -431,17 +415,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 referencing==0.35.1
     # via
     #   jsonschema
@@ -463,15 +446,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -483,9 +466,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -496,7 +477,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   furo
     #   myst-nb
     #   myst-parser
@@ -507,26 +488,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -570,28 +551,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   fastapi
     #   ipython
     #   mypy
@@ -603,42 +582,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpcou9btyd
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -34,7 +33,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -78,7 +76,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2023.5.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -89,7 +86,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 docutils==0.19
     # via
     #   myst-parser
@@ -106,7 +102,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -116,7 +111,6 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,16 +120,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 geopandas==0.13.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -143,7 +134,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -154,7 +144,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   asv-runner
     #   build
     #   dask
@@ -183,7 +172,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -200,7 +188,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -222,7 +209,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -250,7 +237,6 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -260,16 +246,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -288,10 +271,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 numpy==1.24.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   dask
     #   modin
     #   pandas
@@ -301,7 +282,6 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   black
     #   build
     #   dask
@@ -315,13 +295,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.0.3.230814
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -335,7 +313,6 @@ pexpect==4.9.0
 pickleshare==0.7.5
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -349,14 +326,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pre-commit==3.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -373,11 +347,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   fastapi
 pygments==2.18.0
     # via
@@ -387,7 +359,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -395,36 +366,28 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   babel
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   asv
     #   dask
     #   distributed
@@ -439,11 +402,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 referencing==0.35.1
     # via
     #   jsonschema
@@ -470,10 +431,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.10.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -497,7 +456,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   furo
     #   myst-nb
     #   myst-parser
@@ -508,15 +466,11 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-design==0.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -579,26 +533,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   anyio
     #   astroid
     #   black
@@ -617,7 +563,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 urllib3==2.2.2
     # via
     #   distributed
@@ -625,7 +570,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -637,10 +581,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.13
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -35,14 +33,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -80,8 +77,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -90,16 +89,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -109,9 +105,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -121,6 +116,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -130,33 +126,35 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   asv-runner
     #   build
     #   dask
@@ -184,23 +182,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -250,6 +250,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -259,13 +260,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -284,18 +288,20 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 numpy==1.24.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   dask
     #   modin
     #   pandas
     #   pyarrow
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   black
     #   build
     #   dask
@@ -309,10 +315,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -325,7 +334,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -338,12 +348,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pre-commit==3.5.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -351,13 +367,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   pyspark
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -366,6 +387,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -373,31 +395,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   babel
     #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   asv
     #   dask
     #   distributed
@@ -407,15 +434,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 referencing==0.35.1
     # via
     #   jsonschema
@@ -437,13 +465,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -455,9 +486,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -468,6 +497,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   furo
     #   myst-nb
     #   myst-parser
@@ -478,11 +508,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-design==0.5.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -545,19 +579,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
     #   anyio
     #   astroid
     #   black
@@ -576,34 +617,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpqi5vo2ww
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -1,591 +1,200 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.13
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via
-    #   ipykernel
-    #   ipython
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   fiona
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backcall==0.2.0
-    # via ipython
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   fiona
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   click-plugins
-    #   cligj
-    #   dask
-    #   distributed
-    #   fiona
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 click-plugins==1.1.1
-    # via fiona
 cligj==0.7.2
-    # via fiona
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2023.5.0
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2023.5.0
 docutils==0.19
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 fiona==1.9.6
-    # via geopandas
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2023.3.27
 geopandas==0.13.2
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   fiona
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 importlib-resources==6.4.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
-    #   keyring
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.12.3
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==0.6.1
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==2.2.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.3.5
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==0.17.2
 myst-parser==0.18.1
-    # via myst-nb
 nbclient==0.7.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.24.4
-    # via
-    #   dask
-    #   modin
-    #   pandas
-    #   pyarrow
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.0.3.230814
 parso==0.8.4
-    # via jedi
 partd==1.4.1
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pickleshare==0.7.5
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.5.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyproj==3.5.0
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   babel
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.10.0
 readme-renderer==43.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.10.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   fiona
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==5.3.0
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==1.0.4
-    # via sphinx
 sphinxcontrib-devhelp==1.0.2
-    # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==1.0.3
-    # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   myst-parser
-    #   pydantic
-    #   pylint
-    #   rich
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
@@ -20,6 +17,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -37,14 +35,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -82,8 +79,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,16 +91,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -111,9 +107,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,6 +118,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,33 +128,35 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   asv-runner
     #   build
     #   dask
@@ -186,23 +184,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -252,6 +252,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -261,13 +262,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -286,18 +290,20 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 numpy==1.24.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   dask
     #   modin
     #   pandas
     #   pyarrow
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   black
     #   build
     #   dask
@@ -311,10 +317,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -327,7 +336,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -340,12 +350,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pre-commit==3.5.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -353,13 +369,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   pyspark
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -370,6 +391,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -377,31 +399,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   babel
     #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   asv
     #   dask
     #   distributed
@@ -411,15 +438,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 referencing==0.35.1
     # via
     #   jsonschema
@@ -441,13 +469,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -459,9 +490,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -472,6 +501,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,11 +512,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-design==0.5.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -549,19 +583,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   annotated-types
     #   anyio
     #   astroid
@@ -582,34 +623,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -17,7 +17,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -36,7 +35,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -80,7 +78,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2023.5.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -91,7 +88,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 docutils==0.19
     # via
     #   myst-parser
@@ -108,7 +104,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -118,7 +113,6 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -128,16 +122,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 geopandas==0.13.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -145,7 +136,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -156,7 +146,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   asv-runner
     #   build
     #   dask
@@ -185,7 +174,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -202,7 +190,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -224,7 +211,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -252,7 +239,6 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -262,16 +248,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -290,10 +273,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 numpy==1.24.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   dask
     #   modin
     #   pandas
@@ -303,7 +284,6 @@ numpy==1.24.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   black
     #   build
     #   dask
@@ -317,13 +297,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.0.3.230814
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -337,7 +315,6 @@ pexpect==4.9.0
 pickleshare==0.7.5
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -351,14 +328,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pre-commit==3.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -375,11 +349,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -391,7 +363,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -399,36 +370,28 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   babel
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   asv
     #   dask
     #   distributed
@@ -443,11 +406,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 referencing==0.35.1
     # via
     #   jsonschema
@@ -474,10 +435,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.10.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -501,7 +460,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   furo
     #   myst-nb
     #   myst-parser
@@ -512,15 +470,11 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-design==0.5.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -583,26 +537,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   annotated-types
     #   anyio
     #   astroid
@@ -623,7 +569,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 urllib3==2.2.2
     # via
     #   distributed
@@ -631,7 +576,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -643,10 +587,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpz2wgphtq
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -1,597 +1,202 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.13
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via
-    #   ipykernel
-    #   ipython
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   fiona
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backcall==0.2.0
-    # via ipython
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   fiona
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   click-plugins
-    #   cligj
-    #   dask
-    #   distributed
-    #   fiona
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 click-plugins==1.1.1
-    # via fiona
 cligj==0.7.2
-    # via fiona
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2023.5.0
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2023.5.0
 docutils==0.19
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 fiona==1.9.6
-    # via geopandas
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2023.3.27
 geopandas==0.13.2
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   fiona
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 importlib-resources==6.4.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
-    #   keyring
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.12.3
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==0.6.1
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==2.2.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.3.5
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==0.17.2
 myst-parser==0.18.1
-    # via myst-nb
 nbclient==0.7.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.24.4
-    # via
-    #   dask
-    #   modin
-    #   pandas
-    #   pyarrow
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.0.3.230814
 parso==0.8.4
-    # via jedi
 partd==1.4.1
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pickleshare==0.7.5
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.5.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyproj==3.5.0
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   babel
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.10.0
 readme-renderer==43.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.10.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   fiona
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==5.3.0
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==1.0.4
-    # via sphinx
 sphinxcontrib-devhelp==1.0.2
-    # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==1.0.3
-    # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   annotated-types
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   myst-parser
-    #   pydantic
-    #   pydantic-core
-    #   pylint
-    #   rich
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -77,7 +74,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 docutils==0.21.2
     # via
     #   myst-parser
@@ -95,7 +91,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -103,7 +98,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -113,16 +107,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -130,7 +121,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -141,7 +131,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   asv-runner
     #   build
     #   dask
@@ -164,7 +153,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -181,7 +169,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -203,7 +190,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -231,7 +218,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -241,16 +227,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -269,10 +252,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   dask
     #   geopandas
     #   modin
@@ -285,7 +266,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   black
     #   build
     #   dask
@@ -300,13 +280,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -318,7 +296,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -330,14 +307,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -354,11 +328,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   fastapi
 pygments==2.18.0
     # via
@@ -368,7 +340,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -378,35 +349,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   asv
     #   dask
     #   distributed
@@ -421,11 +384,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 referencing==0.35.1
     # via
     #   jsonschema
@@ -452,10 +413,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -478,7 +437,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   furo
     #   myst-nb
     #   myst-parser
@@ -489,15 +447,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -561,26 +515,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   anyio
     #   astroid
     #   black
@@ -597,7 +543,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 urllib3==2.2.2
     # via
     #   distributed
@@ -605,7 +550,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -617,10 +561,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,6 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -30,13 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -68,8 +65,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,16 +77,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -98,9 +94,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +103,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +112,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   asv-runner
     #   build
     #   dask
@@ -165,23 +163,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -231,6 +231,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -240,13 +241,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -265,8 +269,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   dask
     #   geopandas
     #   modin
@@ -274,12 +280,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   black
     #   build
     #   dask
@@ -294,10 +300,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -308,7 +317,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -319,12 +329,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -332,13 +348,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   pyspark
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -347,6 +368,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +378,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   asv
     #   dask
     #   distributed
@@ -388,15 +416,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +447,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +467,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +478,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,22 +489,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -526,19 +561,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
     #   anyio
     #   astroid
     #   black
@@ -555,34 +597,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmp682s900f
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -1,569 +1,194 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.18.1
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==3.0.1
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.13.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pylint
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -70,8 +67,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,16 +79,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -100,9 +96,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,6 +105,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,34 +114,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   asv-runner
     #   build
     #   dask
@@ -167,23 +165,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -233,6 +233,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -242,13 +243,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 mypy==1.10.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -267,8 +271,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 numpy==1.26.4
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   dask
     #   geopandas
     #   modin
@@ -276,12 +282,12 @@ numpy==1.26.4
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   black
     #   build
     #   dask
@@ -296,10 +302,13 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -310,7 +319,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -321,12 +331,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -334,13 +350,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   pyspark
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -351,6 +372,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -360,29 +382,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+pytest==8.3.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pytest-cov==5.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pytest-xdist==3.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   asv
     #   dask
     #   distributed
@@ -392,15 +420,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 referencing==0.35.1
     # via
     #   jsonschema
@@ -422,13 +451,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -439,9 +471,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -452,6 +482,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   furo
     #   myst-nb
     #   myst-parser
@@ -462,22 +493,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -530,19 +565,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typeguard==4.3.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   anyio
     #   astroid
     #   black
@@ -560,34 +602,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -1,574 +1,196 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.2.1
-    # via
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.2.1
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.18.1
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.22.3
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==3.0.1
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==1.26.4
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==1.5.3
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.13.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   pylint
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.2.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   distributed
 debugpy==1.8.3
     # via ipykernel
@@ -79,7 +76,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 docutils==0.21.2
     # via
     #   myst-parser
@@ -97,7 +93,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -105,7 +100,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -115,16 +109,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -132,7 +123,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -143,7 +133,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   asv-runner
     #   build
     #   dask
@@ -166,7 +155,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -183,7 +171,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -205,7 +192,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -233,7 +220,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -243,16 +229,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -271,10 +254,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 numpy==1.26.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   dask
     #   geopandas
     #   modin
@@ -287,7 +268,6 @@ numpy==1.26.4
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   black
     #   build
     #   dask
@@ -302,13 +282,11 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   dask
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -320,7 +298,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -332,14 +309,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -356,11 +330,9 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -372,7 +344,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -382,35 +353,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   asv
     #   dask
     #   distributed
@@ -425,11 +388,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 referencing==0.35.1
     # via
     #   jsonschema
@@ -456,10 +417,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -482,7 +441,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   furo
     #   myst-nb
     #   myst-parser
@@ -493,15 +451,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -565,26 +519,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   anyio
     #   astroid
     #   black
@@ -602,7 +548,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 urllib3==2.2.2
     # via
     #   distributed
@@ -610,7 +555,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -622,10 +566,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpg4lnbuec
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -13,7 +13,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -29,7 +28,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -66,7 +64,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -80,7 +77,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 docutils==0.21.2
     # via
     #   myst-parser
@@ -98,7 +94,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -106,7 +101,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,16 +110,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -133,7 +124,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -144,7 +134,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   asv-runner
     #   build
     #   dask
@@ -167,7 +156,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -184,7 +172,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -206,7 +193,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -234,7 +221,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -244,16 +230,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -272,10 +255,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask
     #   geopandas
     #   modin
@@ -288,7 +269,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   black
     #   build
     #   dask
@@ -303,14 +283,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -322,7 +300,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -334,14 +311,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -358,12 +332,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask-expr
     #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   fastapi
 pygments==2.18.0
     # via
@@ -373,7 +345,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -383,35 +354,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   asv
     #   dask
     #   distributed
@@ -426,11 +389,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 referencing==0.35.1
     # via
     #   jsonschema
@@ -457,10 +418,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -483,7 +442,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   furo
     #   myst-nb
     #   myst-parser
@@ -494,15 +452,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -566,26 +520,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   anyio
     #   astroid
     #   black
@@ -602,7 +548,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -612,7 +557,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -624,10 +568,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -3,10 +3,7 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -16,7 +13,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,14 +28,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,14 +64,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,18 +79,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -106,10 +97,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -117,7 +106,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,39 +115,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   asv-runner
     #   build
     #   dask
@@ -181,25 +167,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -249,7 +234,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -259,16 +244,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -287,10 +272,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask
     #   geopandas
     #   modin
@@ -298,13 +283,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   black
     #   build
     #   dask
@@ -319,13 +303,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -336,8 +321,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -348,15 +333,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -365,17 +352,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   dask-expr
+    #   pyspark
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   fastapi
 pygments==2.18.0
     # via
@@ -385,7 +373,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -395,39 +383,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   asv
     #   dask
     #   distributed
@@ -437,17 +421,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 referencing==0.35.1
     # via
     #   jsonschema
@@ -469,15 +452,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -489,9 +472,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -502,7 +483,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   furo
     #   myst-nb
     #   myst-parser
@@ -513,26 +494,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -585,28 +566,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   anyio
     #   astroid
     #   black
@@ -623,42 +602,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpfiwr0y3s
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -1,576 +1,196 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.18.1
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==3.0.1
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==1.10.11
-    # via
-    #   fastapi
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.13.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pylint
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -1,581 +1,198 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
 geopandas==1.0.1
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   asv-runner
-    #   build
-    #   dask
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.18.1
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
 mypy==1.10.0
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
 myst-parser==3.0.1
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
 numpy==2.0.1
-    # via
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
 pre-commit==3.8.0
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   dask-expr
-    #   pyspark
 pydantic==2.3.0
-    # via
-    #   fastapi
 pydantic-core==2.6.3
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
 pytest==8.3.2
-    # via
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.13.1
 shapely==2.0.5
-    # via
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-docsearch==0.0.7
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
 typeguard==4.3.0
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
 types-pytz==2024.1.0.20240417
-    # via
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240712
 types-setuptools==71.1.0.20240806
 typing-extensions==4.12.2
-    # via
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   pylint
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   astroid
 xdoctest==1.1.6
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,7 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -33,14 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+black==24.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -71,14 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,18 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,10 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -119,7 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -128,39 +117,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+furo==2024.7.18
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-h11==0.14.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+hypothesis==6.108.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   asv-runner
     #   build
     #   dask
@@ -183,25 +169,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -251,7 +236,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -261,16 +246,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -289,10 +274,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-numpy==2.0.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask
     #   geopandas
     #   modin
@@ -300,13 +285,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   black
     #   build
     #   dask
@@ -321,13 +305,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -338,8 +323,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+pip==24.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -350,15 +335,17 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+polars==1.4.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+pre-commit==3.8.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+    #   googleapis-common-protos
+    #   grpcio-status
     #   ray
 psutil==6.0.0
     # via
@@ -367,17 +354,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask-expr
+    #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -389,7 +377,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -399,39 +387,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-pytest==8.2.2
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-    #   fastapi
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   asv
     #   dask
     #   distributed
@@ -441,17 +425,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+ray==2.34.0
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 referencing==0.35.1
     # via
     #   jsonschema
@@ -473,15 +456,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -493,9 +476,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -506,7 +487,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   furo
     #   myst-nb
     #   myst-parser
@@ -517,26 +498,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+sphinx-design==0.6.1
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -589,28 +570,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+types-pyyaml==6.0.12.20240724
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+types-setuptools==71.1.0.20240726
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   anyio
     #   astroid
     #   black
@@ -628,42 +607,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+xdoctest==1.1.6
+    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -15,7 +15,6 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -31,7 +30,6 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
     # via furo
 black==24.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 build==1.2.1
     # via asv
 certifi==2024.7.4
@@ -68,7 +66,6 @@ coverage==7.6.0
     # via pytest-cov
 dask==2024.7.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask-expr
     #   distributed
 dask-expr==1.1.9
@@ -82,7 +79,6 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 docutils==0.21.2
     # via
     #   myst-parser
@@ -100,7 +96,6 @@ execnet==2.1.1
 executing==2.0.1
     # via stack-data
 fastapi==0.112.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,7 +103,6 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,16 +112,13 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2024.7.18
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 geopandas==1.0.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 googleapis-common-protos==1.63.2
     # via
     #   grpcio-status
     #   pyspark
 grpcio==1.65.4
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   grpcio-status
     #   pyspark
 grpcio-status==1.65.4
@@ -135,7 +126,6 @@ grpcio-status==1.65.4
 h11==0.14.0
     # via uvicorn
 hypothesis==6.108.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -146,7 +136,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   asv-runner
     #   build
     #   dask
@@ -169,7 +158,6 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
@@ -186,7 +174,6 @@ jinja2==3.1.4
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -208,7 +195,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -236,7 +223,6 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -246,16 +232,13 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 mypy==1.10.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -274,10 +257,8 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 numpy==2.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask
     #   geopandas
     #   modin
@@ -290,7 +271,6 @@ numpy==2.0.1
     #   shapely
 packaging==24.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   black
     #   build
     #   dask
@@ -305,14 +285,12 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
     #   pyspark
 pandas-stubs==2.2.2.240603
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -324,7 +302,6 @@ petl==1.7.15
 pexpect==4.9.0
     # via ipython
 pip==24.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -336,14 +313,11 @@ platformdirs==4.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.4.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pre-commit==3.8.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.27.3
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   googleapis-common-protos
     #   grpcio-status
     #   ray
@@ -360,12 +334,10 @@ py4j==0.10.9.7
     # via pyspark
 pyarrow==17.0.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   dask-expr
     #   pyspark
 pydantic==2.3.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -377,7 +349,6 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -387,35 +358,27 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pytest==8.3.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pytest-cov==5.0.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 pytest-xdist==3.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
 python-multipart==0.0.9
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pandas
 pyyaml==6.0.1
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   asv
     #   dask
     #   distributed
@@ -430,11 +393,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
 ray==2.34.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 referencing==0.35.1
     # via
     #   jsonschema
@@ -461,10 +422,8 @@ rpds-py==0.19.1
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 shapely==2.0.5
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -487,7 +446,6 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   furo
     #   myst-nb
     #   myst-parser
@@ -498,15 +456,11 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinx-design==0.6.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -570,26 +524,18 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typeguard==4.3.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typer==0.12.3
     # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   pandas-stubs
 types-pyyaml==6.0.12.20240724
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 types-requests==2.32.0.20240712
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 types-setuptools==71.1.0.20240726
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   anyio
     #   astroid
     #   black
@@ -607,7 +553,6 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
@@ -617,7 +562,6 @@ urllib3==2.2.2
     #   twine
     #   types-requests
 uvicorn==0.30.5
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
@@ -629,10 +573,8 @@ wcwidth==0.2.13
     # via prompt-toolkit
 wrapt==1.16.0
     # via
-    #   -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
     #   astroid
 xdoctest==1.1.6
-    # via -r /var/folders/wr/z1ppjzsd7w3f2x3r921cv4gw0000gn/T/tmpc300kzl4
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -1,633 +1,198 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
-    # via -r requirements.in
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
-    # via -r requirements.in
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
-    # via -r requirements.in
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
-    # via -r requirements.in
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
-    # via -r requirements.in
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
-    # via -r requirements.in
 geopandas==1.0.1
-    # via -r requirements.in
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   -r requirements.in
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
-    # via -r requirements.in
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   -r requirements.in
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   -r requirements.in
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
-    # via -r requirements.in
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
-    # via -r requirements.in
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
-    # via -r requirements.in
 mypy==1.10.0
-    # via -r requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
-    # via -r requirements.in
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
-    # via -r requirements.in
 numpy==2.0.1
-    # via
-    #   -r requirements.in
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   -r requirements.in
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   -r requirements.in
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
-    # via -r requirements.in
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
-    # via -r requirements.in
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
-    # via -r requirements.in
 pre-commit==3.8.0
-    # via -r requirements.in
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   -r requirements.in
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   pyspark
 pydantic==2.8.2
-    # via
-    #   -r requirements.in
-    #   fastapi
 pydantic-core==2.20.1
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
-    # via -r requirements.in
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
-    # via -r requirements.in
 pytest==8.3.2
-    # via
-    #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r requirements.in
 pytest-cov==5.0.0
-    # via -r requirements.in
 pytest-xdist==3.6.1
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
-    # via -r requirements.in
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   -r requirements.in
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   -r requirements.in
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
-    # via -r requirements.in
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
-    # via -r requirements.in
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
-    # via -r requirements.in
 shapely==2.0.5
-    # via
-    #   -r requirements.in
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   -r requirements.in
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
-    # via -r requirements.in
 sphinx-design==0.6.1
-    # via -r requirements.in
 sphinx-docsearch==0.0.7
-    # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
-    # via -r requirements.in
 typeguard==4.3.0
-    # via -r requirements.in
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
-    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via
-    #   -r requirements.in
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r requirements.in
 types-requests==2.32.0.20240712
-    # via -r requirements.in
 types-setuptools==71.1.0.20240806
-    # via -r requirements.in
 typing-extensions==4.12.2
-    # via
-    #   -r requirements.in
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
-    # via -r requirements.in
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
-    # via -r requirements.in
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   -r requirements.in
-    #   astroid
 xdoctest==1.1.6
-    # via -r requirements.in
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,13 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,17 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,34 +117,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r requirements.in
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r requirements.in
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -167,23 +164,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -233,6 +232,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
+    # via -r requirements.in
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -242,13 +242,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r requirements.in
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -267,8 +270,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -276,12 +281,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -296,11 +301,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -311,7 +319,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -322,12 +331,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -335,14 +350,19 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
+    #   pyspark
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -353,6 +373,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -362,29 +383,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r requirements.in
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -394,15 +421,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -424,13 +452,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -441,9 +472,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -454,6 +483,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -464,22 +494,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -532,19 +566,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240726
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -560,36 +601,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -204,7 +204,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,13 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,24 +81,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +102,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +111,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r requirements.in
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r requirements.in
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -161,23 +158,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -227,6 +226,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
+    # via -r requirements.in
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -236,13 +236,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r requirements.in
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -261,8 +264,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -270,12 +275,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -290,11 +295,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -305,7 +313,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -316,12 +325,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -329,14 +344,19 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
+    #   pyspark
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -347,6 +367,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +377,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r requirements.in
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -388,15 +415,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +446,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +466,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +477,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,22 +488,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -517,19 +551,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240726
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   fastapi
     #   ipython
     #   mypy
@@ -541,36 +582,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -1,614 +1,197 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
-    # via -r requirements.in
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
-    # via -r requirements.in
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
-    # via -r requirements.in
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
-    # via -r requirements.in
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
-    # via -r requirements.in
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
-    # via -r requirements.in
 geopandas==1.0.1
-    # via -r requirements.in
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   -r requirements.in
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
-    # via -r requirements.in
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   -r requirements.in
-    #   asv-runner
-    #   dask
-    #   jupyter-cache
-    #   keyring
-    #   myst-nb
-    #   twine
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.26.0
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   -r requirements.in
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
-    # via -r requirements.in
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
-    # via -r requirements.in
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
-    # via -r requirements.in
 mypy==1.10.0
-    # via -r requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
-    # via -r requirements.in
 myst-parser==4.0.0
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
-    # via -r requirements.in
 numpy==2.0.1
-    # via
-    #   -r requirements.in
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   -r requirements.in
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   -r requirements.in
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
-    # via -r requirements.in
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
-    # via -r requirements.in
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
-    # via -r requirements.in
 pre-commit==3.8.0
-    # via -r requirements.in
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   -r requirements.in
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   pyspark
 pydantic==2.8.2
-    # via
-    #   -r requirements.in
-    #   fastapi
 pydantic-core==2.20.1
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
-    # via -r requirements.in
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
-    # via -r requirements.in
 pytest==8.3.2
-    # via
-    #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r requirements.in
 pytest-cov==5.0.0
-    # via -r requirements.in
 pytest-xdist==3.6.1
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
-    # via -r requirements.in
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   -r requirements.in
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   -r requirements.in
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
-    # via -r requirements.in
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
-    # via -r requirements.in
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.14.0
-    # via -r requirements.in
 shapely==2.0.5
-    # via
-    #   -r requirements.in
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   -r requirements.in
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
-    # via -r requirements.in
 sphinx-design==0.6.1
-    # via -r requirements.in
 sphinx-docsearch==0.0.7
-    # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via asv
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
-    # via -r requirements.in
 typeguard==4.3.0
-    # via -r requirements.in
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
-    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via
-    #   -r requirements.in
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r requirements.in
 types-requests==2.32.0.20240712
-    # via -r requirements.in
 types-setuptools==71.1.0.20240806
-    # via -r requirements.in
 typing-extensions==4.12.2
-    # via
-    #   -r requirements.in
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   sqlalchemy
-    #   typeguard
-    #   typer
-    #   typing-inspect
 typing-inspect==0.9.0
-    # via -r requirements.in
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
-    # via -r requirements.in
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   -r requirements.in
-    #   astroid
 xdoctest==1.1.6
-    # via -r requirements.in
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -198,7 +198,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -1,657 +1,203 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.13
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via
-    #   ipykernel
-    #   ipython
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
-    # via -r requirements.in
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   fiona
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backcall==0.2.0
-    # via ipython
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
-    # via -r requirements.in
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   fiona
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   click-plugins
-    #   cligj
-    #   dask
-    #   distributed
-    #   fiona
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 click-plugins==1.1.1
-    # via fiona
 cligj==0.7.2
-    # via fiona
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2023.5.0
-    # via
-    #   -r requirements.in
-    #   distributed
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2023.5.0
-    # via -r requirements.in
 docutils==0.19
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
-    # via -r requirements.in
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 fiona==1.9.6
-    # via geopandas
 frictionless==4.40.8
-    # via -r requirements.in
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2023.3.27
-    # via -r requirements.in
 geopandas==0.13.2
-    # via -r requirements.in
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   -r requirements.in
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
-    # via -r requirements.in
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   -r requirements.in
-    #   asv-runner
-    #   build
-    #   dask
-    #   fiona
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 importlib-resources==6.4.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
-    #   keyring
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.12.3
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   -r requirements.in
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
-    # via -r requirements.in
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==0.6.1
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==2.2.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.3.5
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.23.1.post0
-    # via -r requirements.in
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
-    # via -r requirements.in
 mypy==1.10.0
-    # via -r requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==0.17.2
-    # via -r requirements.in
 myst-parser==0.18.1
-    # via myst-nb
 nbclient==0.7.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
-    # via -r requirements.in
 numpy==1.24.4
-    # via
-    #   -r requirements.in
-    #   dask
-    #   modin
-    #   pandas
-    #   pyarrow
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   -r requirements.in
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.0.3
-    # via
-    #   -r requirements.in
-    #   dask
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.0.3.230814
-    # via -r requirements.in
 parso==0.8.4
-    # via jedi
 partd==1.4.1
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pickleshare==0.7.5
-    # via ipython
 pip==24.2
-    # via -r requirements.in
 pkginfo==1.10.0
-    # via twine
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
-    # via -r requirements.in
 pre-commit==3.5.0
-    # via -r requirements.in
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   -r requirements.in
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   -r requirements.in
-    #   pyspark
 pydantic==2.8.2
-    # via
-    #   -r requirements.in
-    #   fastapi
 pydantic-core==2.20.1
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
-    # via -r requirements.in
 pympler==1.1
-    # via asv
 pyproj==3.5.0
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
-pyspark==3.5.1
-    # via -r requirements.in
+pyspark==3.5.2
 pytest==8.3.2
-    # via
-    #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r requirements.in
 pytest-cov==5.0.0
-    # via -r requirements.in
 pytest-xdist==3.6.1
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
-    # via -r requirements.in
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   -r requirements.in
-    #   babel
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   -r requirements.in
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.10.0
-    # via -r requirements.in
 readme-renderer==43.0
-    # via twine
 recommonmark==0.7.1
-    # via -r requirements.in
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.10.1
-    # via -r requirements.in
 shapely==2.0.5
-    # via
-    #   -r requirements.in
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   fiona
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==5.3.0
-    # via
-    #   -r requirements.in
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
-    # via -r requirements.in
 sphinx-design==0.5.0
-    # via -r requirements.in
 sphinx-docsearch==0.0.7
-    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
-    # via sphinx
 sphinxcontrib-devhelp==1.0.2
-    # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==1.0.3
-    # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
-    # via -r requirements.in
 typeguard==4.3.0
-    # via -r requirements.in
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
-    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via
-    #   -r requirements.in
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r requirements.in
 types-requests==2.32.0.20240712
-    # via -r requirements.in
 types-setuptools==71.1.0.20240806
-    # via -r requirements.in
 typing-extensions==4.12.2
-    # via
-    #   -r requirements.in
-    #   annotated-types
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   myst-parser
-    #   pydantic
-    #   pydantic-core
-    #   pylint
-    #   rich
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
-    # via -r requirements.in
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
-    # via -r requirements.in
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   -r requirements.in
-    #   astroid
 xdoctest==1.1.6
-    # via -r requirements.in
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -224,7 +224,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -5,10 +5,7 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
@@ -20,6 +17,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -37,14 +35,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -82,8 +79,10 @@ commonmark==0.9.1
 coverage==7.6.0
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r requirements.in
+    #   distributed
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,16 +91,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r requirements.in
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -111,9 +107,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,6 +118,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,33 +128,35 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r requirements.in
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r requirements.in
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r requirements.in
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -186,23 +184,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -252,6 +252,7 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.23.1.post0
+    # via -r requirements.in
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -261,13 +262,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r requirements.in
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -286,18 +290,20 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r requirements.in
 numpy==1.24.4
     # via
+    #   -r requirements.in
     #   dask
     #   modin
     #   pandas
     #   pyarrow
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -311,10 +317,13 @@ packaging==24.1
     #   sphinx
 pandas==2.0.3
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.0.3.230814
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -327,7 +336,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -340,12 +350,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.0
+    # via -r requirements.in
 pre-commit==3.5.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -353,13 +369,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   pyspark
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -370,6 +391,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -377,31 +399,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   babel
     #   pandas
 pyyaml==6.0.1
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -411,15 +438,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r requirements.in
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -441,13 +469,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -459,9 +490,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -472,6 +501,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,11 +512,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r requirements.in
 sphinx-design==0.5.0
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -549,19 +583,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240726
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   annotated-types
     #   anyio
     #   astroid
@@ -582,36 +623,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -5,10 +5,7 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
 argcomplete==3.4.0
@@ -18,6 +15,7 @@ astroid==2.15.8
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
 attrs==23.2.0
@@ -32,13 +30,12 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,13 +66,14 @@ commonmark==0.9.1
     # via recommonmark
 coverage==7.6.0
     # via pytest-cov
-dask==2024.7.0
+dask==2024.7.1
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.9
     # via dask
-debugpy==1.8.2
+debugpy==1.8.3
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,17 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.7.1
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,34 +117,36 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.7.18
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-h11==0.14.0
+    # via -r requirements.in
+googleapis-common-protos==1.63.2
     # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+    #   grpcio-status
+    #   pyspark
+grpcio==1.65.4
+    # via
+    #   -r requirements.in
+    #   grpcio-status
+    #   pyspark
+grpcio-status==1.65.4
+    # via pyspark
+h11==0.14.0
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.108.5
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -171,23 +168,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -237,6 +236,7 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
+    # via -r requirements.in
 more-itertools==10.3.0
     # via
     #   jaraco-classes
@@ -246,13 +246,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r requirements.in
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -271,8 +274,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -280,12 +285,12 @@ numpy==2.0.0
     #   pandas-stubs
     #   pyarrow
     #   pyogrio
+    #   pyspark
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -300,11 +305,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
+    #   pyspark
 pandas-stubs==2.2.2.240603
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -315,7 +323,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -326,12 +335,18 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.0
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -339,14 +354,19 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
+    #   pyspark
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -357,6 +377,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -366,29 +387,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
+    # via
+    #   -r requirements.in
+    #   pandas
 pyyaml==6.0.1
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -398,15 +425,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
 pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -428,13 +456,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -445,9 +476,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -458,6 +487,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -468,22 +498,26 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
@@ -536,19 +570,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240724
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240726
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -566,36 +607,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -1,639 +1,198 @@
 aiosignal==1.3.1
-    # via ray
 alabaster==0.7.16
-    # via sphinx
 annotated-types==0.7.0
-    # via pydantic
 anyio==4.4.0
-    # via starlette
 appnope==0.1.4
-    # via ipykernel
 argcomplete==3.5.0
-    # via nox
 astroid==2.15.8
-    # via pylint
 asttokens==2.4.1
-    # via stack-data
 asv==0.6.3
-    # via -r requirements.in
 asv-runner==0.2.1
-    # via asv
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   jsonschema
-    #   jupyter-cache
-    #   referencing
 babel==2.16.0
-    # via sphinx
 backports-tarfile==1.2.0
-    # via jaraco-context
 beautifulsoup4==4.12.3
-    # via furo
 black==24.8.0
-    # via -r requirements.in
 build==1.2.1
-    # via asv
 certifi==2024.7.4
-    # via
-    #   pyogrio
-    #   pyproj
-    #   requests
 cfgv==3.4.0
-    # via pre-commit
 chardet==5.2.0
-    # via frictionless
 charset-normalizer==3.3.2
-    # via requests
 click==8.1.7
-    # via
-    #   black
-    #   dask
-    #   distributed
-    #   jupyter-cache
-    #   ray
-    #   typer
-    #   uvicorn
 cloudpickle==3.0.0
-    # via
-    #   dask
-    #   distributed
 colorlog==6.8.2
-    # via nox
 comm==0.2.2
-    # via ipykernel
 commonmark==0.9.1
-    # via recommonmark
 coverage==7.6.1
-    # via pytest-cov
 dask==2024.8.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   distributed
 dask-expr==1.1.10
-    # via dask
 debugpy==1.8.5
-    # via ipykernel
 decorator==5.1.1
-    # via ipython
 dill==0.3.8
-    # via pylint
 distlib==0.3.8
-    # via virtualenv
 distributed==2024.8.0
-    # via -r requirements.in
 docutils==0.21.2
-    # via
-    #   myst-parser
-    #   readme-renderer
-    #   recommonmark
-    #   sphinx
 exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   hypothesis
-    #   ipython
-    #   pytest
 execnet==2.1.1
-    # via pytest-xdist
 executing==2.0.1
-    # via stack-data
 fastapi==0.112.0
-    # via -r requirements.in
 fastjsonschema==2.20.0
-    # via nbformat
 filelock==3.15.4
-    # via
-    #   ray
-    #   virtualenv
 frictionless==4.40.8
-    # via -r requirements.in
 frozenlist==1.4.1
-    # via
-    #   aiosignal
-    #   ray
 fsspec==2024.6.1
-    # via
-    #   dask
-    #   modin
 furo==2024.8.6
-    # via -r requirements.in
 geopandas==1.0.1
-    # via -r requirements.in
 googleapis-common-protos==1.63.2
-    # via
-    #   grpcio-status
-    #   pyspark
 grpcio==1.65.4
-    # via
-    #   -r requirements.in
-    #   grpcio-status
-    #   pyspark
 grpcio-status==1.65.4
-    # via pyspark
 h11==0.14.0
-    # via uvicorn
 hypothesis==6.111.0
-    # via -r requirements.in
 identify==2.6.0
-    # via pre-commit
 idna==3.7
-    # via
-    #   anyio
-    #   requests
 imagesize==1.4.1
-    # via sphinx
 importlib-metadata==8.2.0
-    # via
-    #   -r requirements.in
-    #   asv-runner
-    #   build
-    #   dask
-    #   jupyter-cache
-    #   jupyter-client
-    #   keyring
-    #   myst-nb
-    #   sphinx
-    #   twine
-    #   typeguard
 iniconfig==2.0.0
-    # via pytest
 ipykernel==6.29.5
-    # via myst-nb
 ipython==8.18.1
-    # via
-    #   ipykernel
-    #   myst-nb
 isodate==0.6.1
-    # via frictionless
 isort==5.13.2
-    # via
-    #   -r requirements.in
-    #   pylint
 jaraco-classes==3.4.0
-    # via keyring
 jaraco-context==5.3.0
-    # via keyring
 jaraco-functools==4.0.2
-    # via keyring
 jedi==0.19.1
-    # via ipython
 jinja2==3.1.4
-    # via
-    #   distributed
-    #   frictionless
-    #   myst-parser
-    #   sphinx
 joblib==1.4.2
-    # via -r requirements.in
 json5==0.9.25
-    # via asv
 jsonschema==4.23.0
-    # via
-    #   frictionless
-    #   nbformat
-    #   ray
 jsonschema-specifications==2023.12.1
-    # via jsonschema
 jupyter-cache==1.0.0
-    # via myst-nb
 jupyter-client==8.6.2
-    # via
-    #   ipykernel
-    #   nbclient
 jupyter-core==5.7.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-    #   nbclient
-    #   nbformat
 keyring==25.3.0
-    # via twine
 lazy-object-proxy==1.10.0
-    # via astroid
 locket==1.0.0
-    # via
-    #   distributed
-    #   partd
 markdown-it-py==3.0.0
-    # via
-    #   mdit-py-plugins
-    #   myst-parser
-    #   rich
 marko==2.1.2
-    # via frictionless
 markupsafe==2.1.5
-    # via jinja2
 matplotlib-inline==0.1.7
-    # via
-    #   ipykernel
-    #   ipython
 mccabe==0.7.0
-    # via pylint
 mdit-py-plugins==0.4.1
-    # via myst-parser
 mdurl==0.1.2
-    # via markdown-it-py
 modin==0.31.0
-    # via -r requirements.in
 more-itertools==10.4.0
-    # via
-    #   jaraco-classes
-    #   jaraco-functools
 msgpack==1.0.8
-    # via
-    #   distributed
-    #   ray
 multimethod==1.10
-    # via -r requirements.in
 mypy==1.10.0
-    # via -r requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-    #   typing-inspect
 myst-nb==1.1.1
-    # via -r requirements.in
 myst-parser==3.0.1
-    # via myst-nb
 nbclient==0.10.0
-    # via
-    #   jupyter-cache
-    #   myst-nb
 nbformat==5.10.4
-    # via
-    #   jupyter-cache
-    #   myst-nb
-    #   nbclient
 nest-asyncio==1.6.0
-    # via ipykernel
 nh3==0.2.18
-    # via readme-renderer
 nodeenv==1.9.1
-    # via pre-commit
 nox==2024.4.15
-    # via -r requirements.in
 numpy==2.0.1
-    # via
-    #   -r requirements.in
-    #   dask
-    #   geopandas
-    #   modin
-    #   pandas
-    #   pandas-stubs
-    #   pyarrow
-    #   pyogrio
-    #   pyspark
-    #   scipy
-    #   shapely
 packaging==24.1
-    # via
-    #   -r requirements.in
-    #   black
-    #   build
-    #   dask
-    #   distributed
-    #   geopandas
-    #   ipykernel
-    #   modin
-    #   nox
-    #   pyogrio
-    #   pytest
-    #   ray
-    #   sphinx
 pandas==2.2.2
-    # via
-    #   -r requirements.in
-    #   dask
-    #   dask-expr
-    #   geopandas
-    #   modin
-    #   pyspark
 pandas-stubs==2.2.2.240807
-    # via -r requirements.in
 parso==0.8.4
-    # via jedi
 partd==1.4.2
-    # via dask
 pathspec==0.12.1
-    # via black
 petl==1.7.15
-    # via frictionless
 pexpect==4.9.0
-    # via ipython
 pip==24.2
-    # via -r requirements.in
 pkginfo==1.10.0
-    # via twine
 platformdirs==4.2.2
-    # via
-    #   black
-    #   jupyter-core
-    #   pylint
-    #   virtualenv
 pluggy==1.5.0
-    # via pytest
 polars==1.4.1
-    # via -r requirements.in
 pre-commit==3.8.0
-    # via -r requirements.in
 prompt-toolkit==3.0.47
-    # via ipython
 protobuf==5.27.3
-    # via
-    #   -r requirements.in
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   ray
 psutil==6.0.0
-    # via
-    #   distributed
-    #   ipykernel
-    #   modin
 ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
-    # via stack-data
 py4j==0.10.9.7
-    # via pyspark
 pyarrow==17.0.0
-    # via
-    #   -r requirements.in
-    #   dask-expr
-    #   pyspark
 pydantic==2.8.2
-    # via
-    #   -r requirements.in
-    #   fastapi
 pydantic-core==2.20.1
-    # via pydantic
 pygments==2.18.0
-    # via
-    #   furo
-    #   ipython
-    #   readme-renderer
-    #   rich
-    #   sphinx
 pylint==2.17.3
-    # via -r requirements.in
 pympler==1.1
-    # via asv
 pyogrio==0.9.0
-    # via geopandas
 pyproj==3.6.1
-    # via geopandas
 pyproject-hooks==1.1.0
-    # via build
 pyspark==3.5.1
-    # via -r requirements.in
 pytest==8.3.2
-    # via
-    #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-xdist
 pytest-asyncio==0.23.8
-    # via -r requirements.in
 pytest-cov==5.0.0
-    # via -r requirements.in
 pytest-xdist==3.6.1
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via
-    #   frictionless
-    #   jupyter-client
-    #   pandas
 python-multipart==0.0.9
-    # via -r requirements.in
 python-slugify==8.0.4
-    # via frictionless
 pytz==2024.1
-    # via
-    #   -r requirements.in
-    #   pandas
 pyyaml==6.0.2
-    # via
-    #   -r requirements.in
-    #   asv
-    #   dask
-    #   distributed
-    #   frictionless
-    #   jupyter-cache
-    #   myst-nb
-    #   myst-parser
-    #   pre-commit
-    #   ray
 pyzmq==26.1.0
-    # via
-    #   ipykernel
-    #   jupyter-client
 ray==2.34.0
-    # via -r requirements.in
 readme-renderer==44.0
-    # via twine
 recommonmark==0.7.1
-    # via -r requirements.in
 referencing==0.35.1
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   frictionless
-    #   ray
-    #   requests-toolbelt
-    #   sphinx
-    #   twine
 requests-toolbelt==1.0.0
-    # via twine
 rfc3986==2.0.0
-    # via
-    #   frictionless
-    #   twine
 rich==13.7.1
-    # via
-    #   twine
-    #   typer
 rpds-py==0.20.0
-    # via
-    #   jsonschema
-    #   referencing
 scipy==1.13.1
-    # via -r requirements.in
 shapely==2.0.5
-    # via
-    #   -r requirements.in
-    #   geopandas
 shellingham==1.5.4
-    # via typer
 simpleeval==0.9.13
-    # via frictionless
 six==1.16.0
-    # via
-    #   asttokens
-    #   isodate
-    #   python-dateutil
 sniffio==1.3.1
-    # via anyio
 snowballstemmer==2.2.0
-    # via sphinx
 sortedcontainers==2.4.0
-    # via
-    #   distributed
-    #   hypothesis
 soupsieve==2.5
-    # via beautifulsoup4
 sphinx==7.3.7
-    # via
-    #   -r requirements.in
-    #   furo
-    #   myst-nb
-    #   myst-parser
-    #   recommonmark
-    #   sphinx-autodoc-typehints
-    #   sphinx-basic-ng
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
-    # via furo
 sphinx-copybutton==0.5.2
-    # via -r requirements.in
 sphinx-design==0.6.1
-    # via -r requirements.in
 sphinx-docsearch==0.0.7
-    # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
-    # via sphinx
 sphinxcontrib-devhelp==2.0.0
-    # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
 sphinxcontrib-qthelp==2.0.0
-    # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
 sqlalchemy==2.0.32
-    # via jupyter-cache
 stack-data==0.6.3
-    # via ipython
 starlette==0.37.2
-    # via fastapi
 stringcase==1.2.0
-    # via frictionless
 tabulate==0.9.0
-    # via
-    #   asv
-    #   frictionless
-    #   jupyter-cache
 tblib==3.0.0
-    # via distributed
 text-unidecode==1.3
-    # via python-slugify
 tomli==2.0.1
-    # via
-    #   asv
-    #   black
-    #   build
-    #   coverage
-    #   mypy
-    #   nox
-    #   pylint
-    #   pytest
-    #   sphinx
 tomlkit==0.13.0
-    # via pylint
 toolz==0.12.1
-    # via
-    #   dask
-    #   distributed
-    #   partd
 tornado==6.4.1
-    # via
-    #   distributed
-    #   ipykernel
-    #   jupyter-client
 traitlets==5.14.3
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
-    #   nbclient
-    #   nbformat
 twine==5.1.1
-    # via -r requirements.in
 typeguard==4.3.0
-    # via -r requirements.in
 typer==0.12.3
-    # via frictionless
 types-click==7.1.8
-    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via
-    #   -r requirements.in
-    #   pandas-stubs
 types-pyyaml==6.0.12.20240808
-    # via -r requirements.in
 types-requests==2.32.0.20240712
-    # via -r requirements.in
 types-setuptools==71.1.0.20240806
-    # via -r requirements.in
 typing-extensions==4.12.2
-    # via
-    #   -r requirements.in
-    #   anyio
-    #   astroid
-    #   black
-    #   fastapi
-    #   ipython
-    #   mypy
-    #   myst-nb
-    #   pydantic
-    #   pydantic-core
-    #   pylint
-    #   sqlalchemy
-    #   starlette
-    #   typeguard
-    #   typer
-    #   typing-inspect
-    #   uvicorn
 typing-inspect==0.9.0
-    # via -r requirements.in
 tzdata==2024.1
-    # via pandas
 urllib3==2.2.2
-    # via
-    #   distributed
-    #   requests
-    #   twine
-    #   types-requests
 uvicorn==0.30.5
-    # via -r requirements.in
 validators==0.33.0
-    # via frictionless
 virtualenv==20.26.3
-    # via
-    #   asv
-    #   nox
-    #   pre-commit
 wcwidth==0.2.13
-    # via prompt-toolkit
 wrapt==1.16.0
-    # via
-    #   -r requirements.in
-    #   astroid
 xdoctest==1.1.6
-    # via -r requirements.in
 zict==3.0.0
-    # via distributed
 zipp==3.20.0
-    # via importlib-metadata

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -208,7 +208,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - pandas-stubs
 
   # pyspark extra
-  - pyspark >= 3.2.0
+  - pyspark[connect] >= 3.2.0
 
   # polars extra
   - polars >= 0.20.0
@@ -92,6 +92,6 @@ dependencies:
       - typeguard
       - types-click
       - types-pyyaml
-      - types-pkg_resources
+      - types-setuptools
       - types-requests
       - types-pytz

--- a/noxfile.py
+++ b/noxfile.py
@@ -362,6 +362,7 @@ def ci_requirements(session: Session, pandas: str, pydantic: str) -> None:
             _ci_requirement_file_name(session, pandas, pydantic),
             "--no-header",
             "--upgrade",
+            "--no-annotate",
         )
 
 
@@ -379,6 +380,7 @@ def dev_requirements(session: Session) -> None:
         output_file,
         "--no-header",
         "--upgrade",
+        "--no-annotate",
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ ALWAYS_USE_PIP = {
     "furo",
     "types-click",
     "types-pyyaml",
-    "types-pkg_resources",
+    "types-setuptools",
 }
 
 CI_RUN = os.environ.get("CI") == "true"

--- a/pandera/accessors/pyspark_sql_accessor.py
+++ b/pandera/accessors/pyspark_sql_accessor.py
@@ -2,8 +2,8 @@
 """
 
 import warnings
-from packaging import version
 from typing import Optional
+from packaging import version
 
 import pyspark
 from pandera.api.base.error_handler import ErrorHandler

--- a/pandera/accessors/pyspark_sql_accessor.py
+++ b/pandera/accessors/pyspark_sql_accessor.py
@@ -2,8 +2,10 @@
 """
 
 import warnings
+from packaging import version
 from typing import Optional
 
+import pyspark
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.api.pyspark.container import DataFrameSchema
 
@@ -104,7 +106,7 @@ def _register_accessor(name, cls):
 
 def register_dataframe_accessor(name):
     """
-    Register a custom accessor with a DataFrame
+    Register a custom accessor with a classical Spark DataFrame
 
     :param name: name used when calling the accessor after its registered
     :returns: a class decorator callable.
@@ -113,6 +115,19 @@ def register_dataframe_accessor(name):
     from pyspark.sql import DataFrame
 
     return _register_accessor(name, DataFrame)
+
+
+def register_connect_dataframe_accessor(name):
+    """
+    Register a custom accessor with a Spark Connect DataFrame
+
+    :param name: name used when calling the accessor after its registered
+    :returns: a class decorator callable.
+    """
+    # pylint: disable=import-outside-toplevel
+    from pyspark.sql.connect.dataframe import DataFrame as psc_DataFrame
+
+    return _register_accessor(name, psc_DataFrame)
 
 
 class PanderaDataFrameAccessor(PanderaAccessor):
@@ -127,3 +142,6 @@ class PanderaDataFrameAccessor(PanderaAccessor):
 
 
 register_dataframe_accessor("pandera")(PanderaDataFrameAccessor)
+# Handle optional Spark Connect imports for pyspark>=3.4 (if available)
+if version.parse(pyspark.__version__) >= version.parse("3.4"):
+    register_connect_dataframe_accessor("pandera")(PanderaDataFrameAccessor)

--- a/pandera/api/pyspark/types.py
+++ b/pandera/api/pyspark/types.py
@@ -1,24 +1,25 @@
 """Utility functions for pyspark validation."""
 
 from functools import lru_cache
+from typing import List, NamedTuple, Tuple, Type, Union
 from numpy import bool_ as np_bool
 from packaging import version
-from typing import List, NamedTuple, Tuple, Type, Union
 
-import pyspark
 import pyspark.sql.types as pst
 from pyspark.sql import DataFrame
 
+import pyspark
 from pandera.api.checks import Check
 from pandera.dtypes import DataType
 
+# pylint: disable=reimported
 # Handles optional Spark Connect imports for pyspark>=3.4 (if available)
-import pyspark
-
 if version.parse(pyspark.__version__) >= version.parse("3.4"):
     from pyspark.sql.connect.dataframe import DataFrame as psc_DataFrame
 else:
-    from pyspark.sql import DataFrame as psc_DataFrame
+    from pyspark.sql import (
+        DataFrame as psc_DataFrame,
+    )
 
 DataFrameTypes = Union[DataFrame, psc_DataFrame]
 

--- a/pandera/backends/pyspark/base.py
+++ b/pandera/backends/pyspark/base.py
@@ -22,6 +22,7 @@ from pandera.backends.pyspark.error_formatters import (
     scalar_failure_case,
 )
 from pandera.errors import FailureCaseMetadata, SchemaError, SchemaWarning
+from pandera.api.pyspark.types import DataFrameTypes
 
 
 class ColumnInfo(NamedTuple):
@@ -34,7 +35,7 @@ class ColumnInfo(NamedTuple):
     lazy_exclude_column_names: List
 
 
-FieldCheckObj = Union[col, DataFrame]
+FieldCheckObj = Union[col, DataFrameTypes]
 
 T = TypeVar(
     "T",
@@ -50,7 +51,7 @@ class PysparkSchemaBackend(BaseSchemaBackend):
 
     def subsample(
         self,
-        check_obj: DataFrame,
+        check_obj: DataFrameTypes,
         head: Optional[int] = None,
         tail: Optional[int] = None,
         sample: Optional[float] = None,

--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -553,18 +553,6 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
 
         return check_obj
 
-    def _check_uniqueness(
-        self,
-        obj: DataFrame,
-        schema,
-    ) -> DataFrame:
-        """Ensure uniqueness in dataframe columns.
-
-        :param obj: dataframe to check.
-        :param schema: schema object.
-        :returns: dataframe checked.
-        """
-
     ##########
     # Checks #
     ##########

--- a/pandera/backends/pyspark/register.py
+++ b/pandera/backends/pyspark/register.py
@@ -1,8 +1,15 @@
 """Register pyspark backends."""
 
 from functools import lru_cache
+from packaging import version
 
-import pyspark.sql as pst
+import pyspark
+import pyspark.sql as ps
+
+# Handles optional Spark Connect imports for pyspark>=3.4 (if available)
+CURRENT_PYSPARK_VERSION = version.parse(pyspark.__version__)
+if CURRENT_PYSPARK_VERSION >= version.parse("3.4"):
+    from pyspark.sql.connect import dataframe as psc
 
 
 @lru_cache
@@ -28,7 +35,14 @@ def register_pyspark_backends():
     from pandera.backends.pyspark.components import ColumnBackend
     from pandera.backends.pyspark.container import DataFrameSchemaBackend
 
-    Check.register_backend(pst.DataFrame, PySparkCheckBackend)
-    ColumnSchema.register_backend(pst.DataFrame, ColumnSchemaBackend)
-    Column.register_backend(pst.DataFrame, ColumnBackend)
-    DataFrameSchema.register_backend(pst.DataFrame, DataFrameSchemaBackend)
+    # Register classical DataFrame
+    Check.register_backend(ps.DataFrame, PySparkCheckBackend)
+    ColumnSchema.register_backend(ps.DataFrame, ColumnSchemaBackend)
+    Column.register_backend(ps.DataFrame, ColumnBackend)
+    DataFrameSchema.register_backend(ps.DataFrame, DataFrameSchemaBackend)
+    # Register Spark Connect DataFrame, if available
+    if CURRENT_PYSPARK_VERSION >= version.parse("3.4"):
+        Check.register_backend(psc.DataFrame, PySparkCheckBackend)
+        ColumnSchema.register_backend(psc.DataFrame, ColumnSchemaBackend)
+        Column.register_backend(psc.DataFrame, ColumnBackend)
+        DataFrameSchema.register_backend(psc.DataFrame, DataFrameSchemaBackend)

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ pyarrow
 pydantic
 multimethod <= 1.10.0
 pandas-stubs
-pyspark >= 3.2.0
+pyspark[connect] >= 3.2.0
 polars >= 0.20.0
 modin
 protobuf
@@ -56,6 +56,6 @@ ray
 typeguard
 types-click
 types-pyyaml
-types-pkg_resources
+types-setuptools
 types-requests
 types-pytz

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ _extras_require = {
     "strategies": ["hypothesis >= 6.92.7"],
     "hypotheses": ["scipy"],
     "io": ["pyyaml >= 5.1", "black", "frictionless <= 4.40.8"],
-    "pyspark": ["pyspark >= 3.2.0"],
+    "pyspark": ["pyspark[connect] >= 3.2.0"],
     "modin": ["modin", "ray", "dask[dataframe]"],
     "modin-ray": ["modin", "ray"],
     "modin-dask": ["modin", "dask[dataframe]"],

--- a/tests/pyspark/conftest.py
+++ b/tests/pyspark/conftest.py
@@ -2,6 +2,7 @@
 
 # pylint:disable=redefined-outer-name
 import datetime
+import os
 
 import pyspark.sql.types as T
 import pytest
@@ -15,7 +16,21 @@ def spark() -> SparkSession:
     """
     creates spark session
     """
-    return SparkSession.builder.getOrCreate()
+    spark: SparkSession = SparkSession.builder.getOrCreate()
+    yield spark
+    spark.stop()
+
+
+@pytest.fixture(scope="session")
+def spark_connect() -> SparkSession:
+    """
+    creates spark connection session
+    """
+    # Set location of localhost Spark Connect server
+    os.environ["SPARK_LOCAL_REMOTE"] = "sc://localhost"
+    spark: SparkSession = SparkSession.builder.getOrCreate()
+    yield spark
+    spark.stop()
 
 
 @pytest.fixture(scope="session")

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -32,6 +32,12 @@ from pandera.errors import PysparkSchemaError
 from pandera.pyspark import Column, DataFrameModel, DataFrameSchema, Field
 from pandera.validation_depth import ValidationScope
 
+# from .conftest import spark, spark_connect
+
+pytestmark = pytest.mark.parametrize(
+    "spark_session", ["spark", "spark_connect"]
+)
+
 
 @pytest.fixture(scope="function")
 def extra_registered_checks():
@@ -60,10 +66,11 @@ class TestDecorator:
     """This class is used to test the decorator to check datatype mismatches and unacceptable datatype"""
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_datatype_check_decorator(self, spark):
+    def test_datatype_check_decorator(self, spark_session, request):
         """
         Test to validate the decorator to check datatype mismatches and unacceptable datatype
         """
+        spark = request.getfixturevalue(spark_session)
         schema = DataFrameSchema(
             {
                 "product": Column(StringType()),
@@ -386,8 +393,11 @@ class TestEqualToCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.equal_to, pa.Check.eq])
-    def test_equal_to_check(self, spark, check_fn, datatype, data) -> None:
+    def test_equal_to_check(
+        self, spark_session, check_fn, datatype, data, request
+    ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -400,9 +410,10 @@ class TestEqualToCheck(BaseClass):
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.equal_to, pa.Check.eq])
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -514,8 +525,11 @@ class TestNotEqualToCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.not_equal_to, pa.Check.ne])
-    def test_not_equal_to_check(self, spark, check_fn, datatype, data) -> None:
+    def test_not_equal_to_check(
+        self, spark_session, check_fn, datatype, data, request
+    ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -528,9 +542,10 @@ class TestNotEqualToCheck(BaseClass):
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.not_equal_to, pa.Check.ne])
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -636,8 +651,11 @@ class TestGreaterThanCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.greater_than, pa.Check.gt])
-    def test_greater_than_check(self, spark, check_fn, datatype, data) -> None:
+    def test_greater_than_check(
+        self, spark_session, check_fn, datatype, data, request
+    ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -650,9 +668,10 @@ class TestGreaterThanCheck(BaseClass):
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.greater_than, pa.Check.gt])
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -761,9 +780,10 @@ class TestGreaterThanEqualToCheck(BaseClass):
         "check_fn", [pa.Check.greater_than_or_equal_to, pa.Check.ge]
     )
     def test_greater_than_or_equal_to_check(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -778,9 +798,10 @@ class TestGreaterThanEqualToCheck(BaseClass):
         "check_fn", [pa.Check.greater_than_or_equal_to, pa.Check.ge]
     )
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -898,8 +919,11 @@ class TestLessThanCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.less_than, pa.Check.lt])
-    def test_less_than_check(self, spark, check_fn, datatype, data) -> None:
+    def test_less_than_check(
+        self, spark_session, check_fn, datatype, data, request
+    ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -912,9 +936,10 @@ class TestLessThanCheck(BaseClass):
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.less_than, pa.Check.lt])
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -928,9 +953,10 @@ class TestLessThanCheck(BaseClass):
     @validate_scope(scope=ValidationScope.DATA)
     @pytest.mark.parametrize("check_fn", [pa.Check.less_than, pa.Check.lt])
     def test_failed_none_expression(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(ValueError):
             self.check_function(
                 spark,
@@ -1051,9 +1077,10 @@ class TestLessThanOrEqualToCheck(BaseClass):
         "check_fn", [pa.Check.less_than_or_equal_to, pa.Check.le]
     )
     def test_less_than_or_equal_to_check(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if all the values are equal to defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             check_fn,
@@ -1068,9 +1095,10 @@ class TestLessThanOrEqualToCheck(BaseClass):
         "check_fn", [pa.Check.less_than_or_equal_to, pa.Check.le]
     )
     def test_failed_unaccepted_datatypes(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -1086,9 +1114,10 @@ class TestLessThanOrEqualToCheck(BaseClass):
         "check_fn", [pa.Check.less_than_or_equal_to, pa.Check.le]
     )
     def test_failed_none_expression(
-        self, spark, check_fn, datatype, data
+        self, spark_session, check_fn, datatype, data, request
     ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(ValueError):
             self.check_function(
                 spark,
@@ -1209,8 +1238,9 @@ class TestIsInCheck(BaseClass):
         }
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_isin_check(self, spark, datatype, data) -> None:
+    def test_isin_check(self, spark_session, datatype, data, request) -> None:
         """Test the Check to see if all the values are is in the defined value"""
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             pa.Check.isin,
@@ -1221,8 +1251,11 @@ class TestIsInCheck(BaseClass):
         )
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_failed_unaccepted_datatypes(self, spark, datatype, data) -> None:
+    def test_failed_unaccepted_datatypes(
+        self, spark_session, datatype, data, request
+    ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -1335,9 +1368,9 @@ class TestNotInCheck(BaseClass):
         }
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_notin_check(self, spark, datatype, data) -> None:
+    def test_notin_check(self, spark_session, datatype, data, request) -> None:
         """Test the Check to see if all the values are equal to defined value"""
-
+        spark = request.getfixturevalue(spark_session)
         self.check_function(
             spark,
             pa.Check.notin,
@@ -1348,8 +1381,11 @@ class TestNotInCheck(BaseClass):
         )
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_failed_unaccepted_datatypes(self, spark, datatype, data) -> None:
+    def test_failed_unaccepted_datatypes(
+        self, spark_session, datatype, data, request
+    ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -1365,8 +1401,9 @@ class TestStringType(BaseClass):
     """This class is used to test the string types checks"""
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_str_startswith_check(self, spark) -> None:
+    def test_str_startswith_check(self, spark_session, request) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         check_func = pa.Check.str_startswith
         check_value = "B"
 
@@ -1377,8 +1414,9 @@ class TestStringType(BaseClass):
         )
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_str_endswith_check(self, spark) -> None:
+    def test_str_endswith_check(self, spark_session, request) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         check_func = pa.Check.str_endswith
         check_value = "d"
 
@@ -1389,8 +1427,9 @@ class TestStringType(BaseClass):
         )
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_str_contains_check(self, spark) -> None:
+    def test_str_contains_check(self, spark_session, request) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         check_func = pa.Check.str_contains
         check_value = "Ba"
 
@@ -1507,9 +1546,10 @@ class TestInRangeCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     def test_inrange_exclude_min_max_check(
-        self, spark, datatype, data
+        self, spark_session, datatype, data, request
     ) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         min_val, max_val, add_value = self.create_min_max(data)
         self.check_function(
             spark,
@@ -1522,9 +1562,10 @@ class TestInRangeCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     def test_inrange_exclude_min_only_check(
-        self, spark, datatype, data
+        self, spark_session, datatype, data, request
     ) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         min_val, max_val, add_value = self.create_min_max(data)
         self.check_function(
             spark,
@@ -1537,9 +1578,10 @@ class TestInRangeCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     def test_inrange_exclude_max_only_check(
-        self, spark, datatype, data
+        self, spark_session, datatype, data, request
     ) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         min_val, max_val, add_value = self.create_min_max(data)
         self.check_function(
             spark,
@@ -1552,9 +1594,10 @@ class TestInRangeCheck(BaseClass):
 
     @validate_scope(scope=ValidationScope.DATA)
     def test_inrange_include_min_max_check(
-        self, spark, datatype, data
+        self, spark_session, datatype, data, request
     ) -> None:
         """Test the Check to see if any value is not in the specified value"""
+        spark = request.getfixturevalue(spark_session)
         (
             min_val,
             max_val,
@@ -1570,8 +1613,11 @@ class TestInRangeCheck(BaseClass):
         )
 
     @validate_scope(scope=ValidationScope.DATA)
-    def test_failed_unaccepted_datatypes(self, spark, datatype, data) -> None:
+    def test_failed_unaccepted_datatypes(
+        self, spark_session, datatype, data, request
+    ) -> None:
         """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
         with pytest.raises(TypeError):
             self.check_function(
                 spark,
@@ -1599,7 +1645,6 @@ class TestCustomCheck(BaseClass):
         """
         This function does performs the actual validation
         """
-
         spark_schema = StructType(
             [
                 StructField("product", StringType(), False),
@@ -1621,9 +1666,10 @@ class TestCustomCheck(BaseClass):
                 raise PysparkSchemaError
 
     def test_extension(
-        self, spark, extra_registered_checks
+        self, spark_session, extra_registered_checks, request
     ):  # pylint: disable=unused-argument
         """Test custom extension with DataFrameSchema way of defining schema"""
+        spark = request.getfixturevalue(spark_session)
         schema = DataFrameSchema(
             {
                 "product": Column(StringType()),
@@ -1644,9 +1690,10 @@ class TestCustomCheck(BaseClass):
         )
 
     def test_extension_pydantic(
-        self, spark, extra_registered_checks
+        self, spark_session, extra_registered_checks, request
     ):  # pylint: disable=unused-argument
         """Test custom extension with DataFrameModel way of defining schema"""
+        spark = request.getfixturevalue(spark_session)
 
         class Schema(DataFrameModel):
             """Test Schema"""

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -32,8 +32,6 @@ from pandera.errors import PysparkSchemaError
 from pandera.pyspark import Column, DataFrameModel, DataFrameSchema, Field
 from pandera.validation_depth import ValidationScope
 
-# from .conftest import spark, spark_connect
-
 pytestmark = pytest.mark.parametrize(
     "spark_session", ["spark", "spark_connect"]
 )

--- a/tests/pyspark/test_pyspark_config.py
+++ b/tests/pyspark/test_pyspark_config.py
@@ -15,14 +15,21 @@ from pandera.pyspark import (
 )
 from tests.pyspark.conftest import spark_df
 
+pytestmark = pytest.mark.parametrize(
+    "spark_session", ["spark", "spark_connect"]
+)
+
 
 class TestPanderaConfig:
     """Class to test all the different configs types"""
 
     sample_data = [("Bread", 9), ("Cutter", 15)]
 
-    def test_disable_validation(self, spark, sample_spark_schema):
+    def test_disable_validation(
+        self, spark_session, sample_spark_schema, request
+    ):
         """This function validates that a none object is loaded if validation is disabled"""
+        spark = request.getfixturevalue(spark_session)
         pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
@@ -50,9 +57,9 @@ class TestPanderaConfig:
             assert TestSchema.validate(input_df) == input_df
 
     # pylint:disable=too-many-locals
-    def test_schema_only(self, spark, sample_spark_schema):
+    def test_schema_only(self, spark_session, sample_spark_schema, request):
         """This function validates that only schema related checks are run not data level"""
-
+        spark = request.getfixturevalue(spark_session)
         pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
@@ -138,9 +145,9 @@ class TestPanderaConfig:
         )
 
     # pylint:disable=too-many-locals
-    def test_data_only(self, spark, sample_spark_schema):
+    def test_data_only(self, spark_session, sample_spark_schema, request):
         """This function validates that only data related checks are run not schema level"""
-
+        spark = request.getfixturevalue(spark_session)
         pandera_schema = DataFrameSchema(
             {
                 "product": Column(T.StringType(), Check.str_startswith("B")),
@@ -231,8 +238,11 @@ class TestPanderaConfig:
         )
 
     # pylint:disable=too-many-locals
-    def test_schema_and_data(self, spark, sample_spark_schema):
+    def test_schema_and_data(
+        self, spark_session, sample_spark_schema, request
+    ):
         """This function validates that both data and schema level checks are validated"""
+        spark = request.getfixturevalue(spark_session)
         # self.remove_python_module_cache()
         pandera_schema = DataFrameSchema(
             {
@@ -363,6 +373,7 @@ class TestPanderaConfig:
         self,
         cache_dataframe,
         keep_cached_dataframe,
+        spark_session,  # pylint:disable=unused-argument
     ):
         """This function validates setters and getters for cache/keep_cache options."""
         # Set expected properties in Config object

--- a/tests/pyspark/test_pyspark_decorators.py
+++ b/tests/pyspark/test_pyspark_decorators.py
@@ -14,15 +14,22 @@ from pandera.config import config_context
 from pandera.pyspark import Check, Column, DataFrameSchema
 from tests.pyspark.conftest import spark_df
 
+pytestmark = pytest.mark.parametrize(
+    "spark_session", ["spark", "spark_connect"]
+)
+
 
 class TestPanderaDecorators:
     """Class to test all the different configs types"""
 
     sample_data = [("Bread", 9), ("Cutter", 15)]
 
-    def test_cache_dataframe_requirements(self, spark, sample_spark_schema):
+    def test_cache_dataframe_requirements(
+        self, spark_session, sample_spark_schema, request
+    ):
         """Validates if decorator can only be applied in a proper function."""
         # Set expected properties in Config object
+        spark = request.getfixturevalue(spark_session)
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
 
         class FakeDataFrameSchemaBackend:
@@ -74,17 +81,19 @@ class TestPanderaDecorators:
     # pylint:disable=too-many-locals
     def test_cache_dataframe_settings(
         self,
-        spark,
+        spark_session,
         sample_spark_schema,
         cache_enabled,
         keep_cache_enabled,
         expected_caching_message,
         expected_unpersisting_message,
         caplog,
+        request,
     ):
         """This function validates that caching/unpersisting works as expected."""
         # Set expected properties in Config object
         # Prepare test data
+        spark = request.getfixturevalue(spark_session)
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
         pandera_schema = DataFrameSchema(
             {

--- a/tests/pyspark/test_pyspark_dtypes.py
+++ b/tests/pyspark/test_pyspark_dtypes.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import pytest
 import pyspark
 import pyspark.sql.types as T
 from pyspark.sql import DataFrame
@@ -11,6 +12,10 @@ from pandera.config import PanderaConfig
 from pandera.pyspark import Column, DataFrameSchema
 from pandera.validation_depth import ValidationScope
 from tests.pyspark.conftest import spark_df
+
+pytestmark = pytest.mark.parametrize(
+    "spark_session", ["spark", "spark_connect"]
+)
 
 
 class BaseClass:
@@ -134,33 +139,36 @@ class TestAllNumericTypes(BaseClass):
         return spark_schema
 
     def test_pyspark_all_float_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test float dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.FloatType())
         df = spark_df(spark, sample_data, spark_schema)
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_double_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test double dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.DoubleType())
         df = spark_df(spark, sample_data, spark_schema)
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_decimal_default_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test decimal dtype column with default values
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.DecimalType())
         df = spark_df(spark, sample_data, spark_schema)
@@ -168,11 +176,12 @@ class TestAllNumericTypes(BaseClass):
 
     @validate_scope(scope=ValidationScope.SCHEMA)
     def test_pyspark_decimal_parameterized_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test decimal dtype column with parameterized inputs
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.DecimalType(20, 5))
         df = spark_df(spark, sample_data, spark_schema)
@@ -195,44 +204,48 @@ class TestAllNumericTypes(BaseClass):
         }
 
     def test_pyspark_all_int_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test int dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.IntegerType())
         df = spark_df(spark, sample_data, spark_schema)
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_longint_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test long dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.LongType())
         df = spark_df(spark, sample_data, spark_schema)
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_shortint_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test short int dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.ShortType())
         df = spark_df(spark, sample_data, spark_schema)
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_bytetint_types(
-        self, spark, sample_data, pandera_equivalent
+        self, spark_session, sample_data, pandera_equivalent, request
     ):
         """
         Test byte int dtype column
         """
+        spark = request.getfixturevalue(spark_session)
         column_name = "price"
         spark_schema = self.create_schema(column_name, T.ByteType())
         df = spark_df(spark, sample_data, spark_schema)
@@ -273,7 +286,10 @@ class TestAllDatetimeTestClass(BaseClass):
     }
 
     def test_pyspark_all_date_types(
-        self, pandera_equivalent, sample_date_object
+        self,
+        pandera_equivalent,
+        sample_date_object,
+        spark_session,  # pylint:disable=unused-argument
     ):
         """
         Test date dtype column
@@ -283,7 +299,10 @@ class TestAllDatetimeTestClass(BaseClass):
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_datetime_types(
-        self, pandera_equivalent, sample_date_object
+        self,
+        pandera_equivalent,
+        sample_date_object,
+        spark_session,  # pylint:disable=unused-argument
     ):
         """
         Test datetime dtype column
@@ -314,7 +333,10 @@ class TestBinaryStringTypes(BaseClass):
     }
 
     def test_pyspark_all_binary_types(
-        self, pandera_equivalent, sample_string_binary_object
+        self,
+        pandera_equivalent,
+        sample_string_binary_object,
+        spark_session,  # pylint:disable=unused-argument
     ):
         """
         Test binary dytpe column
@@ -324,7 +346,10 @@ class TestBinaryStringTypes(BaseClass):
         self.validate_data(df, pandera_equivalent, column_name)
 
     def test_pyspark_all_string_types(
-        self, pandera_equivalent, sample_string_binary_object
+        self,
+        pandera_equivalent,
+        sample_string_binary_object,
+        spark_session,  # pylint:disable=unused-argument
     ):
         """
         Test string dtype column
@@ -361,7 +386,12 @@ class TestComplexType(BaseClass):
     }
 
     @validate_scope(scope=ValidationScope.SCHEMA)
-    def test_pyspark_array_type(self, sample_complex_data, pandera_equivalent):
+    def test_pyspark_array_type(
+        self,
+        sample_complex_data,
+        pandera_equivalent,
+        spark_session,  # pylint:disable=unused-argument
+    ):
         """
         Test array dtype column
         """
@@ -383,7 +413,12 @@ class TestComplexType(BaseClass):
         }
 
     @validate_scope(scope=ValidationScope.SCHEMA)
-    def test_pyspark_map_type(self, sample_complex_data, pandera_equivalent):
+    def test_pyspark_map_type(
+        self,
+        sample_complex_data,
+        pandera_equivalent,
+        spark_session,  # pylint:disable=unused-argument
+    ):
         """
         Test map dtype column
         """

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -493,7 +493,7 @@ def test_invalid_field(
 
 
 # For the second parameterized `spark_session` run, `@pax.register_check_method` will
-# raise a ValueError due to duplicate registration
+# raise a ValueError due to a duplicated registration tentative
 @pytest.mark.xfail(raises=ValueError)
 def test_registered_dataframemodel_checks(spark_session, request) -> None:
     """Check that custom registered checks work"""

--- a/tests/pyspark/test_schemas_on_pyspark_pandas.py
+++ b/tests/pyspark/test_schemas_on_pyspark_pandas.py
@@ -6,10 +6,10 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pyspark
 import pyspark.pandas as ps
 import pytest
 from packaging import version
-from pyspark import SparkContext
 
 import pandera as pa
 from pandera import dtypes, extensions, system
@@ -63,7 +63,7 @@ PYSPARK_PANDAS_UNSUPPORTED = {
     pandas_engine.Date,
 }
 
-SPARK_VERSION = version.parse(SparkContext.getOrCreate().version)
+SPARK_VERSION = version.parse(pyspark.__version__)
 
 if SPARK_VERSION < version.parse("3.3.0"):
     PYSPARK_PANDAS_UNSUPPORTED.add(numpy_engine.Timedelta64)


### PR DESCRIPTION
#### Description
Fixes #1673 by adding support for the new Spark Connect dataframes, that are available since Spark 3.4.

#### Considerations
- A new type `DataFrameTypes` was created under `pandera/api/pyspark/types.py` to standardize the type annotations for both types of DFs, accross all the files that need this new type annotation in the pyspark backend. I didn't change all type annotations yet, I'll change those later, when the solution and test design is approved.
- In the `pandera/backends/pyspark/checks.py` file, the current pinned and outdated `multimethod==1.10` package does not understand the new annotated type (I tried some approaches like `Union[]`, `TypeVar()` etc), while the more recent versions `1.11+` were able to parse them correctly and dispatch the execution to the proper `@overload`ed function.
    Unfortunately `multimethod==1.10` is the last version that supports Python 3.8, whose end of life is planned to happen on this oct/2024. Upgrading `multimethod` to solve this incompability and removing support for Python 3.8 in Pandera (by consequence) is not supposed to happen right now, so I opted for replacing the overloaded functions by pure functions. When Python 3.8 support is dropped and `multimethod` is updated, we can return the original design if needed.
- Unit tests were added in a manner that both `SparkSession` types (original non-connect and the new connect) always run, by parameterizing both types at the top of the test modules and all test functions inherit it. This design allows that future new tests inherit such structure.
- With the addition of `[connect]` extra for `pyspark`, new requirements were generated.
- `types-pkg_resources` was replaced by `types-setuptools`, as the [yank message in PyPI suggests to do](https://pypi.org/project/types-pkg-resources/).

#### TODO
- [ ] Change type annotations under `pyspark/` namespace.
- [ ] Increase coverage rates, if necessary.