### PR TITLE
Swap `types-pkg_resources` with `types-setuptools`

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,10 +53,10 @@ jobs:
           python -m pip install nox pre_commit \
             mypy==0.982 \
             types-click \
+            types-pytz \
             types-pyyaml \
-            types-pkg_resources \
             types-requests \
-            types-pytz
+            types-setuptools
       - name: Pip info
         run: python -m pip list
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -153,11 +153,11 @@ jobs:
         uses: codecov/codecov-action@v4
 
       # - name: Check Docstrings
-      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pandas-version == '2.2.0' }}
+      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pandas-version == '2.2.2' }}
       #   run: nox ${{ env.NOX_FLAGS }} --session doctests
 
       # - name: Check Docs
-      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pydantic-version == '2.2.0' }}
+      #   if: ${{ matrix.os != 'windows-latest' && matrix.python-version == '3.11' && matrix.pydantic-version == '2.2.2' }}
       #   run: nox ${{ env.NOX_FLAGS }} --session docs
 
   extras-tests:
@@ -207,7 +207,7 @@ jobs:
           pip-cache: ~/AppData/Local/pip/Cache
         exclude:
         - python-version: "3.8"
-          pandas-version: "2.2.0"
+          pandas-version: "2.2.2"
         - python-version: "3.11"
           pandas-version: "1.5.3"
           # mypy tests hang on windows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,10 +50,10 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-click
-          - types-pkg_resources
           - types-pytz
           - types-pyyaml
           - types-requests
+          - types-setuptools
         args: ["pandera", "tests", "scripts"]
         exclude: (^docs/|^tests/mypy/modules/)
         pass_filenames: false

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic1.10.11.txt
@@ -3,40 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -65,11 +62,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,16 +77,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -98,9 +94,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +103,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +112,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -161,23 +150,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -199,7 +190,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -227,7 +218,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -236,14 +228,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -261,8 +256,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   dask
     #   geopandas
     #   modin
@@ -272,10 +269,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   black
     #   build
     #   dask
@@ -290,10 +286,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -304,7 +302,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -315,12 +314,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -328,13 +331,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -343,6 +349,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -352,29 +359,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   asv
     #   dask
     #   distributed
@@ -384,15 +397,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 referencing==0.35.1
     # via
     #   jsonschema
@@ -414,13 +428,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -431,9 +448,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -444,6 +459,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   furo
     #   myst-nb
     #   myst-parser
@@ -454,24 +470,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -522,19 +542,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
     #   anyio
     #   astroid
     #   black
@@ -549,34 +576,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp6ejs7w6z
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas1.5.3-pydantic2.3.0.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,11 +64,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,16 +79,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -100,9 +96,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,6 +105,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,34 +114,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -163,23 +152,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -201,7 +192,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -229,7 +220,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -238,14 +230,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -263,8 +258,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   dask
     #   geopandas
     #   modin
@@ -274,10 +271,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   black
     #   build
     #   dask
@@ -292,10 +288,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -306,7 +304,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -317,12 +316,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -330,13 +333,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -347,6 +353,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +363,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   asv
     #   dask
     #   distributed
@@ -388,15 +401,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +432,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +452,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +463,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,24 +474,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -526,19 +546,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
     #   anyio
     #   astroid
     #   black
@@ -554,34 +581,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptvr6b9t2
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic1.10.11.txt
@@ -3,42 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,16 +62,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,18 +79,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -106,10 +97,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -117,7 +106,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,39 +115,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -177,25 +154,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -217,7 +193,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -245,8 +221,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -255,17 +231,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -283,10 +259,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   dask
     #   geopandas
     #   modin
@@ -296,11 +272,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   black
     #   build
     #   dask
@@ -315,13 +289,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -332,8 +306,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -344,15 +318,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   ray
 psutil==6.0.0
     # via
@@ -361,17 +335,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   fastapi
 pygments==2.18.0
     # via
@@ -381,7 +355,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -391,39 +365,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   asv
     #   dask
     #   distributed
@@ -433,17 +403,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 referencing==0.35.1
     # via
     #   jsonschema
@@ -465,15 +434,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -485,9 +454,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -498,7 +465,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   furo
     #   myst-nb
     #   myst-parser
@@ -509,28 +476,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -581,28 +548,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   anyio
     #   astroid
     #   black
@@ -617,42 +582,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpz1de_6_i
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeteiyyih
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.10-pandas2.2.2-pydantic2.3.0.txt
@@ -5,42 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,16 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,18 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,10 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -119,7 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -128,39 +117,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -179,25 +156,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -219,7 +195,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -247,8 +223,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -257,17 +233,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -285,10 +261,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   dask
     #   geopandas
     #   modin
@@ -298,11 +274,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   black
     #   build
     #   dask
@@ -317,13 +291,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -334,8 +308,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -346,15 +320,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   ray
 psutil==6.0.0
     # via
@@ -363,17 +337,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -385,7 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -395,39 +369,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   asv
     #   dask
     #   distributed
@@ -437,17 +407,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 referencing==0.35.1
     # via
     #   jsonschema
@@ -469,15 +438,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -489,9 +458,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -502,7 +469,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   furo
     #   myst-nb
     #   myst-parser
@@ -513,28 +480,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -585,28 +552,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   anyio
     #   astroid
     #   black
@@ -622,42 +587,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpr3k_cks4
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpzu9tkl04
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic1.10.11.txt
@@ -3,40 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -65,11 +62,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,23 +77,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -102,6 +97,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -110,34 +106,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -155,23 +144,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -193,7 +184,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -221,7 +212,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -230,14 +222,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -255,8 +250,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   dask
     #   geopandas
     #   modin
@@ -266,10 +263,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   black
     #   build
     #   dask
@@ -284,10 +280,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -298,7 +296,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -309,12 +308,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -322,13 +325,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -337,6 +343,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -346,29 +353,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   asv
     #   dask
     #   distributed
@@ -378,15 +391,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 referencing==0.35.1
     # via
     #   jsonschema
@@ -408,13 +422,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -425,9 +442,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -438,6 +453,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   furo
     #   myst-nb
     #   myst-parser
@@ -448,24 +464,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -507,19 +527,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
     #   fastapi
     #   ipython
     #   mypy
@@ -530,34 +557,30 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpcgdgfpte
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas1.5.3-pydantic2.3.0.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,11 +64,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,23 +79,19 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -104,6 +99,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -112,34 +108,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -157,23 +146,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -195,7 +186,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -223,7 +214,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -232,14 +224,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -257,8 +252,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   dask
     #   geopandas
     #   modin
@@ -268,10 +265,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   black
     #   build
     #   dask
@@ -286,10 +282,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -300,7 +298,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -311,12 +310,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -324,13 +327,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -341,6 +347,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -350,29 +357,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   asv
     #   dask
     #   distributed
@@ -382,15 +395,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 referencing==0.35.1
     # via
     #   jsonschema
@@ -412,13 +426,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -429,9 +446,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -442,6 +457,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   furo
     #   myst-nb
     #   myst-parser
@@ -452,24 +468,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -511,19 +531,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
     #   fastapi
     #   ipython
     #   mypy
@@ -535,34 +562,30 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpa1pv_jna
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic1.10.11.txt
@@ -3,42 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,16 +62,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,26 +79,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -111,7 +100,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -120,39 +109,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -171,25 +148,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -211,7 +187,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -239,8 +215,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -249,17 +225,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -277,10 +253,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   dask
     #   geopandas
     #   modin
@@ -290,11 +266,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   black
     #   build
     #   dask
@@ -309,13 +283,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -326,8 +300,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -338,15 +312,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   ray
 psutil==6.0.0
     # via
@@ -355,17 +329,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   fastapi
 pygments==2.18.0
     # via
@@ -375,7 +349,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -385,39 +359,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   asv
     #   dask
     #   distributed
@@ -427,17 +397,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 referencing==0.35.1
     # via
     #   jsonschema
@@ -459,15 +428,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -479,9 +448,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -492,7 +459,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   furo
     #   myst-nb
     #   myst-parser
@@ -503,28 +470,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -566,28 +533,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   fastapi
     #   ipython
     #   mypy
@@ -598,42 +563,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp9qfe95c9
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpu85ag4st
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.11-pandas2.2.2-pydantic2.3.0.txt
@@ -5,42 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,16 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,26 +81,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -113,7 +102,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,39 +111,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -173,25 +150,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -213,7 +189,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -241,8 +217,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -251,17 +227,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-myst-parser==3.0.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -279,10 +255,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   dask
     #   geopandas
     #   modin
@@ -292,11 +268,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   black
     #   build
     #   dask
@@ -311,13 +285,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -328,8 +302,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -340,15 +314,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   ray
 psutil==6.0.0
     # via
@@ -357,17 +331,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -379,7 +353,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -389,39 +363,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   asv
     #   dask
     #   distributed
@@ -431,17 +401,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 referencing==0.35.1
     # via
     #   jsonschema
@@ -463,15 +432,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -483,9 +452,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -496,7 +463,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   furo
     #   myst-nb
     #   myst-parser
@@ -507,28 +474,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -570,28 +537,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   fastapi
     #   ipython
     #   mypy
@@ -603,42 +568,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp43zj_dvq
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpwdokpijq
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic1.10.11.txt
@@ -3,31 +3,29 @@ aiosignal==1.3.1
 alabaster==0.7.13
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -35,14 +33,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -77,11 +74,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -90,16 +89,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -109,9 +105,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -121,6 +116,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -130,33 +126,26 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   asv-runner
     #   build
     #   dask
@@ -184,23 +173,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -222,7 +213,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -250,7 +241,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -259,13 +251,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -284,18 +279,19 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 numpy==1.24.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   dask
     #   modin
     #   pandas
     #   pyarrow
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   black
     #   build
     #   dask
@@ -309,10 +305,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   dask
     #   geopandas
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -325,7 +323,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -338,12 +337,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pre-commit==3.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -351,13 +354,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -366,6 +372,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -373,31 +380,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   babel
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   asv
     #   dask
     #   distributed
@@ -407,15 +419,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 referencing==0.35.1
     # via
     #   jsonschema
@@ -437,13 +450,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -455,9 +471,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -468,6 +482,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   furo
     #   myst-nb
     #   myst-parser
@@ -478,11 +493,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 sphinx-design==0.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -495,7 +514,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -545,19 +564,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
     #   anyio
     #   astroid
     #   black
@@ -576,34 +602,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmp21wht3lv
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.8-pandas1.5.3-pydantic2.3.0.txt
@@ -5,31 +5,29 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -37,14 +35,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -79,11 +76,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,16 +91,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -111,9 +107,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,6 +118,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,33 +128,26 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   asv-runner
     #   build
     #   dask
@@ -186,23 +175,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -224,7 +215,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -252,7 +243,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -261,13 +253,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -286,18 +281,19 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 numpy==1.24.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   dask
     #   modin
     #   pandas
     #   pyarrow
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   black
     #   build
     #   dask
@@ -311,10 +307,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   dask
     #   geopandas
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -327,7 +325,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -340,12 +339,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pre-commit==3.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -353,13 +356,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -370,6 +376,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -377,31 +384,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   babel
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   asv
     #   dask
     #   distributed
@@ -411,15 +423,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 referencing==0.35.1
     # via
     #   jsonschema
@@ -441,13 +454,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -459,9 +475,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -472,6 +486,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,11 +497,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 sphinx-design==0.5.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 sphinx-docsearch==0.0.7
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -499,7 +518,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -549,19 +568,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
     #   annotated-types
     #   anyio
     #   astroid
@@ -582,34 +608,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpki59_lmj
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic1.10.11.txt
@@ -3,40 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -65,11 +62,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -78,16 +77,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -98,9 +94,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +103,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +112,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   asv-runner
     #   build
     #   dask
@@ -165,23 +154,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -203,7 +194,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -231,7 +222,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -240,13 +232,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -265,8 +260,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   dask
     #   geopandas
     #   modin
@@ -276,10 +273,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   black
     #   build
     #   dask
@@ -294,10 +290,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -308,7 +306,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -319,12 +318,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -332,13 +335,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 pydantic==1.10.11
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   fastapi
 pygments==2.18.0
     # via
     #   furo
@@ -347,6 +353,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +363,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   asv
     #   dask
     #   distributed
@@ -388,15 +401,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +432,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +452,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +463,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,24 +474,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -526,19 +546,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
     #   anyio
     #   astroid
     #   black
@@ -555,34 +582,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpeifj3nvu
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas1.5.3-pydantic2.3.0.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,11 +64,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2024.2.1
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -80,16 +79,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2024.2.1
-dnspython==2.6.1
-    # via email-validator
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -100,9 +96,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -110,6 +105,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -118,34 +114,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   asv-runner
     #   build
     #   dask
@@ -167,23 +156,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -205,7 +196,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -233,7 +224,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.22.3
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -242,13 +234,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 mypy==1.10.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -267,8 +262,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 numpy==1.26.4
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   dask
     #   geopandas
     #   modin
@@ -278,10 +275,9 @@ numpy==1.26.4
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   black
     #   build
     #   dask
@@ -296,10 +292,12 @@ packaging==24.1
     #   sphinx
 pandas==1.5.3
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   dask
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -310,7 +308,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -321,12 +320,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -334,13 +337,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 pydantic==2.3.0
-    # via fastapi
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   fastapi
 pydantic-core==2.6.3
     # via pydantic
 pygments==2.18.0
@@ -351,6 +357,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -360,29 +367,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+pytest==8.3.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 pytest-cov==5.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 pytest-xdist==3.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   asv
     #   dask
     #   distributed
@@ -392,15 +405,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 referencing==0.35.1
     # via
     #   jsonschema
@@ -422,13 +436,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -439,9 +456,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -452,6 +467,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   furo
     #   myst-nb
     #   myst-parser
@@ -462,24 +478,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -530,19 +550,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 typeguard==4.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 types-requests==2.32.0.20240712
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 typing-extensions==4.12.2
     # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
     #   anyio
     #   astroid
     #   black
@@ -560,34 +587,30 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-ujson==5.10.0
-    # via fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
+    #   astroid
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmpqccnkfd8
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic1.10.11.txt
@@ -3,42 +3,37 @@ aiosignal==1.3.1
 alabaster==0.7.16
     # via sphinx
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,16 +62,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -84,18 +79,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -106,10 +97,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -117,7 +106,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -126,39 +115,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   asv-runner
     #   build
     #   dask
@@ -181,25 +158,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -221,7 +197,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -249,8 +225,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -259,16 +235,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -287,10 +263,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   dask
     #   geopandas
     #   modin
@@ -300,11 +276,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   black
     #   build
     #   dask
@@ -319,13 +293,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -336,8 +310,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -348,15 +322,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   ray
 psutil==6.0.0
     # via
@@ -365,17 +339,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   dask-expr
 pydantic==1.10.11
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   fastapi
 pygments==2.18.0
     # via
@@ -385,7 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -395,39 +369,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   asv
     #   dask
     #   distributed
@@ -437,17 +407,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 referencing==0.35.1
     # via
     #   jsonschema
@@ -469,15 +438,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -489,9 +458,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -502,7 +469,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   furo
     #   myst-nb
     #   myst-parser
@@ -513,28 +480,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -585,28 +552,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   anyio
     #   astroid
     #   black
@@ -623,42 +588,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmp0n6jx2py
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmprghjfjjf
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
+++ b/ci/requirements-py3.9-pandas2.2.2-pydantic2.3.0.txt
@@ -5,42 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+black==24.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -69,16 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -86,18 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -108,10 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -119,7 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -128,39 +117,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+furo==2024.8.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 geopandas==1.0.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+grpcio==1.65.4
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+hypothesis==6.110.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   asv-runner
     #   build
     #   dask
@@ -183,25 +160,24 @@ isodate==0.6.1
     # via frictionless
 isort==5.13.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -223,7 +199,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -251,8 +227,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-more-itertools==10.3.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -261,16 +237,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 mypy==1.10.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -289,10 +265,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-numpy==2.0.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+numpy==2.0.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   dask
     #   geopandas
     #   modin
@@ -302,11 +278,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   black
     #   build
     #   dask
@@ -321,13 +295,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+pandas-stubs==2.2.2.240807
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -338,8 +312,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+pip==24.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -350,15 +324,15 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-pre-commit==3.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+polars==1.4.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+pre-commit==3.8.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   ray
 psutil==6.0.0
     # via
@@ -367,17 +341,17 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   dask-expr
 pydantic==2.3.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   fastapi
 pydantic-core==2.6.3
     # via pydantic
@@ -389,7 +363,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -399,39 +373,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-pytest==8.2.2
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+pytest==8.3.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+pytest-asyncio==0.23.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 pytest-cov==5.0.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 pytest-xdist==3.6.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-    #   fastapi
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   asv
     #   dask
     #   distributed
@@ -441,17 +411,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+ray==2.34.0
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 referencing==0.35.1
     # via
     #   jsonschema
@@ -473,15 +442,15 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 shapely==2.0.5
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   geopandas
 shellingham==1.5.4
     # via typer
@@ -493,9 +462,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -506,7 +473,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   furo
     #   myst-nb
     #   myst-parser
@@ -517,28 +484,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-sphinx-design==0.6.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+sphinx-design==0.6.1
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 sphinx-docsearch==0.0.7
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-sphinxcontrib-applehelp==1.0.8
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -589,28 +556,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 typeguard==4.3.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-types-pkg-resources==0.1.3
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 types-pytz==2024.1.0.20240417
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   pandas-stubs
-types-pyyaml==6.0.12.20240311
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+types-pyyaml==6.0.12.20240808
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 types-requests==2.32.0.20240712
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+types-setuptools==71.1.0.20240806
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 typing-extensions==4.12.2
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   anyio
     #   astroid
     #   black
@@ -628,42 +593,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
     # via
-    #   -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+    #   -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
     #   astroid
-xdoctest==1.1.5
-    # via -r /var/folders/5r/4t87zv7x32s7xv9fmnmbd8z80000gn/T/tmpt1t78zeh
+xdoctest==1.1.6
+    # via -r /var/folders/wd/sx8dvgys011_mrcsd1_vrz1m0000gn/T/tmptmrbt8dt
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.10.txt
+++ b/dev/requirements-3.10.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,15 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,17 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,34 +117,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -167,23 +155,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -205,7 +195,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -233,7 +223,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -242,14 +233,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r requirements.in
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -267,8 +261,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -278,10 +274,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -296,11 +291,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -311,7 +308,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -322,12 +320,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -335,14 +337,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -353,6 +359,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -362,29 +369,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r requirements.in
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -394,15 +407,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -424,13 +438,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -441,9 +458,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -454,6 +469,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -464,24 +480,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -532,19 +552,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -560,36 +587,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.11.txt
+++ b/dev/requirements-3.11.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,15 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,24 +81,20 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -108,6 +102,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -116,34 +111,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   dask
     #   jupyter-cache
@@ -161,23 +149,25 @@ ipython==8.26.0
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -199,7 +189,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -227,7 +217,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -236,14 +227,17 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
-myst-parser==3.0.1
+    # via -r requirements.in
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -261,8 +255,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -272,10 +268,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -290,11 +285,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -305,7 +302,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -316,12 +314,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -329,14 +331,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -347,6 +353,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -356,29 +363,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r requirements.in
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -388,15 +401,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -418,13 +432,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.14.0
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -435,9 +452,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -448,6 +463,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -458,24 +474,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -517,19 +537,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   fastapi
     #   ipython
     #   mypy
@@ -541,36 +568,32 @@ typing-extensions==4.12.2
     #   typer
     #   typing-inspect
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.8.txt
+++ b/dev/requirements-3.8.txt
@@ -5,31 +5,29 @@ alabaster==0.7.13
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via
     #   ipykernel
     #   ipython
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   fiona
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -37,14 +35,13 @@ backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
     #   fiona
-    #   httpcore
-    #   httpx
     #   pyproj
     #   requests
 cfgv==3.4.0
@@ -79,11 +76,13 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 dask==2023.5.0
-    # via distributed
-debugpy==1.8.2
+    # via
+    #   -r requirements.in
+    #   distributed
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -92,16 +91,13 @@ dill==0.3.8
 distlib==0.3.8
     # via virtualenv
 distributed==2023.5.0
-dnspython==2.6.1
-    # via email-validator
+    # via -r requirements.in
 docutils==0.19
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -111,9 +107,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -123,6 +118,7 @@ filelock==3.15.4
 fiona==1.9.6
     # via geopandas
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -132,33 +128,26 @@ fsspec==2024.6.1
     #   dask
     #   modin
 furo==2023.3.27
+    # via -r requirements.in
 geopandas==0.13.2
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -186,23 +175,25 @@ ipython==8.12.3
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -224,7 +215,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -252,7 +243,8 @@ mdit-py-plugins==0.3.5
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.23.1.post0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -261,13 +253,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==0.17.2
+    # via -r requirements.in
 myst-parser==0.18.1
     # via myst-nb
 nbclient==0.7.4
@@ -286,18 +281,19 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
+    # via -r requirements.in
 numpy==1.24.4
     # via
+    #   -r requirements.in
     #   dask
     #   modin
     #   pandas
     #   pyarrow
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -311,10 +307,12 @@ packaging==24.1
     #   sphinx
 pandas==2.0.3
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
 pandas-stubs==2.0.3.230814
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.1
@@ -327,7 +325,8 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
@@ -340,12 +339,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
+polars==1.4.1
+    # via -r requirements.in
 pre-commit==3.5.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -353,13 +356,16 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
+pyarrow==17.0.0
+    # via -r requirements.in
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -370,6 +376,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyproj==3.5.0
@@ -377,31 +384,36 @@ pyproj==3.5.0
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
     # via
+    #   -r requirements.in
     #   babel
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -411,15 +423,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
 ray==2.10.0
+    # via -r requirements.in
 readme-renderer==43.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -441,13 +454,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.10.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -459,9 +475,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -472,6 +486,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==5.3.0
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -482,11 +497,15 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
+    # via -r requirements.in
 sphinx-design==0.5.0
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -499,7 +518,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -549,19 +568,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   annotated-types
     #   anyio
     #   astroid
@@ -582,36 +608,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/dev/requirements-3.9.txt
+++ b/dev/requirements-3.9.txt
@@ -5,40 +5,37 @@ alabaster==0.7.16
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 appnope==0.1.4
     # via ipykernel
-argcomplete==3.4.0
+argcomplete==3.5.0
     # via nox
 astroid==2.15.8
     # via pylint
 asttokens==2.4.1
     # via stack-data
 asv==0.6.3
+    # via -r requirements.in
 asv-runner==0.2.1
     # via asv
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   hypothesis
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via furo
-black==24.4.2
+black==24.8.0
+    # via -r requirements.in
 build==1.2.1
     # via asv
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   pyogrio
     #   pyproj
     #   requests
@@ -67,15 +64,16 @@ comm==0.2.2
     # via ipykernel
 commonmark==0.9.1
     # via recommonmark
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
-dask==2024.7.0
+dask==2024.8.0
     # via
+    #   -r requirements.in
     #   dask-expr
     #   distributed
-dask-expr==1.1.7
+dask-expr==1.1.10
     # via dask
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -83,17 +81,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-distributed==2024.7.0
-dnspython==2.6.1
-    # via email-validator
+distributed==2024.8.0
+    # via -r requirements.in
 docutils==0.21.2
     # via
     #   myst-parser
     #   readme-renderer
     #   recommonmark
     #   sphinx
-email-validator==2.2.0
-    # via fastapi
 exceptiongroup==1.2.2
     # via
     #   anyio
@@ -104,9 +99,8 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.111.0
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
+    # via -r requirements.in
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.4
@@ -114,6 +108,7 @@ filelock==3.15.4
     #   ray
     #   virtualenv
 frictionless==4.40.8
+    # via -r requirements.in
 frozenlist==1.4.1
     # via
     #   aiosignal
@@ -122,34 +117,27 @@ fsspec==2024.6.1
     # via
     #   dask
     #   modin
-furo==2024.5.6
+furo==2024.8.6
+    # via -r requirements.in
 geopandas==1.0.1
-greenlet==3.0.3
-    # via sqlalchemy
-grpcio==1.64.1
+    # via -r requirements.in
+grpcio==1.65.4
+    # via -r requirements.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-hypothesis==6.108.0
+hypothesis==6.110.1
+    # via -r requirements.in
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
+    #   -r requirements.in
     #   asv-runner
     #   build
     #   dask
@@ -171,23 +159,25 @@ ipython==8.18.1
 isodate==0.6.1
     # via frictionless
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements.in
+    #   pylint
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via
     #   distributed
-    #   fastapi
     #   frictionless
     #   myst-parser
     #   sphinx
 joblib==1.4.2
+    # via -r requirements.in
 json5==0.9.25
     # via asv
 jsonschema==4.23.0
@@ -209,7 +199,7 @@ jupyter-core==5.7.2
     #   jupyter-client
     #   nbclient
     #   nbformat
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 lazy-object-proxy==1.10.0
     # via astroid
@@ -237,7 +227,8 @@ mdit-py-plugins==0.4.1
 mdurl==0.1.2
     # via markdown-it-py
 modin==0.31.0
-more-itertools==10.3.0
+    # via -r requirements.in
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -246,13 +237,16 @@ msgpack==1.0.8
     #   distributed
     #   ray
 multimethod==1.10
+    # via -r requirements.in
 mypy==1.10.0
+    # via -r requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
     #   typing-inspect
 myst-nb==1.1.1
+    # via -r requirements.in
 myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
@@ -271,8 +265,10 @@ nh3==0.2.18
 nodeenv==1.9.1
     # via pre-commit
 nox==2024.4.15
-numpy==2.0.0
+    # via -r requirements.in
+numpy==2.0.1
     # via
+    #   -r requirements.in
     #   dask
     #   geopandas
     #   modin
@@ -282,10 +278,9 @@ numpy==2.0.0
     #   pyogrio
     #   scipy
     #   shapely
-orjson==3.10.6
-    # via fastapi
 packaging==24.1
     # via
+    #   -r requirements.in
     #   black
     #   build
     #   dask
@@ -300,11 +295,13 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
+    #   -r requirements.in
     #   dask
     #   dask-expr
     #   geopandas
     #   modin
-pandas-stubs==2.2.2.240603
+pandas-stubs==2.2.2.240807
+    # via -r requirements.in
 parso==0.8.4
     # via jedi
 partd==1.4.2
@@ -315,7 +312,8 @@ petl==1.7.15
     # via frictionless
 pexpect==4.9.0
     # via ipython
-pip==24.1.2
+pip==24.2
+    # via -r requirements.in
 pkginfo==1.10.0
     # via twine
 platformdirs==4.2.2
@@ -326,12 +324,16 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.1.0
-pre-commit==3.7.1
+polars==1.4.1
+    # via -r requirements.in
+pre-commit==3.8.0
+    # via -r requirements.in
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
-    # via ray
+protobuf==5.27.3
+    # via
+    #   -r requirements.in
+    #   ray
 psutil==6.0.0
     # via
     #   distributed
@@ -339,14 +341,18 @@ psutil==6.0.0
     #   modin
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 py4j==0.10.9.7
     # via pyspark
-pyarrow==16.1.0
-    # via dask-expr
+pyarrow==17.0.0
+    # via
+    #   -r requirements.in
+    #   dask-expr
 pydantic==2.8.2
-    # via fastapi
+    # via
+    #   -r requirements.in
+    #   fastapi
 pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
@@ -357,6 +363,7 @@ pygments==2.18.0
     #   rich
     #   sphinx
 pylint==2.17.3
+    # via -r requirements.in
 pympler==1.1
     # via asv
 pyogrio==0.9.0
@@ -366,29 +373,35 @@ pyproj==3.6.1
 pyproject-hooks==1.1.0
     # via build
 pyspark==3.5.1
-pytest==8.2.2
+    # via -r requirements.in
+pytest==8.3.2
     # via
+    #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
+    # via -r requirements.in
 pytest-cov==5.0.0
+    # via -r requirements.in
 pytest-xdist==3.6.1
+    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   frictionless
     #   jupyter-client
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
 python-multipart==0.0.9
-    # via fastapi
+    # via -r requirements.in
 python-slugify==8.0.4
     # via frictionless
 pytz==2024.1
-    # via pandas
-pyyaml==6.0.1
     # via
+    #   -r requirements.in
+    #   pandas
+pyyaml==6.0.2
+    # via
+    #   -r requirements.in
     #   asv
     #   dask
     #   distributed
@@ -398,15 +411,16 @@ pyyaml==6.0.1
     #   myst-parser
     #   pre-commit
     #   ray
-    #   uvicorn
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
-ray==2.32.0
+ray==2.34.0
+    # via -r requirements.in
 readme-renderer==44.0
     # via twine
 recommonmark==0.7.1
+    # via -r requirements.in
 referencing==0.35.1
     # via
     #   jsonschema
@@ -428,13 +442,16 @@ rich==13.7.1
     # via
     #   twine
     #   typer
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 scipy==1.13.1
+    # via -r requirements.in
 shapely==2.0.5
-    # via geopandas
+    # via
+    #   -r requirements.in
+    #   geopandas
 shellingham==1.5.4
     # via typer
 simpleeval==0.9.13
@@ -445,9 +462,7 @@ six==1.16.0
     #   isodate
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -458,6 +473,7 @@ soupsieve==2.5
     # via beautifulsoup4
 sphinx==7.3.7
     # via
+    #   -r requirements.in
     #   furo
     #   myst-nb
     #   myst-parser
@@ -468,24 +484,28 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-docsearch
 sphinx-autodoc-typehints==1.14.1
+    # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
-sphinx-design==0.6.0
+    # via -r requirements.in
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-docsearch==0.0.7
-sphinxcontrib-applehelp==1.0.8
+    # via -r requirements.in
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -536,19 +556,26 @@ traitlets==5.14.3
     #   nbclient
     #   nbformat
 twine==5.1.1
+    # via -r requirements.in
 typeguard==4.3.0
+    # via -r requirements.in
 typer==0.12.3
-    # via
-    #   fastapi-cli
-    #   frictionless
+    # via frictionless
 types-click==7.1.8
-types-pkg-resources==0.1.3
+    # via -r requirements.in
 types-pytz==2024.1.0.20240417
-    # via pandas-stubs
-types-pyyaml==6.0.12.20240311
+    # via
+    #   -r requirements.in
+    #   pandas-stubs
+types-pyyaml==6.0.12.20240808
+    # via -r requirements.in
 types-requests==2.32.0.20240712
+    # via -r requirements.in
+types-setuptools==71.1.0.20240806
+    # via -r requirements.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements.in
     #   anyio
     #   astroid
     #   black
@@ -566,36 +593,32 @@ typing-extensions==4.12.2
     #   typing-inspect
     #   uvicorn
 typing-inspect==0.9.0
+    # via -r requirements.in
 tzdata==2024.1
     # via pandas
-ujson==5.10.0
-    # via fastapi
 urllib3==2.2.2
     # via
     #   distributed
     #   requests
     #   twine
     #   types-requests
-uvicorn==0.30.1
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
-validators==0.32.0
+uvicorn==0.30.5
+    # via -r requirements.in
+validators==0.33.0
     # via frictionless
 virtualenv==20.26.3
     # via
     #   asv
     #   nox
     #   pre-commit
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 wrapt==1.16.0
-    # via astroid
-xdoctest==1.1.5
+    # via
+    #   -r requirements.in
+    #   astroid
+xdoctest==1.1.6
+    # via -r requirements.in
 zict==3.0.0
     # via distributed
 zipp==3.19.2

--- a/environment.yml
+++ b/environment.yml
@@ -91,7 +91,7 @@ dependencies:
       - ray
       - typeguard
       - types-click
-      - types-pyyaml
-      - types-pkg_resources
-      - types-requests
       - types-pytz
+      - types-pyyaml
+      - types-requests
+      - types-setuptools

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,11 +37,11 @@ PACKAGE = "pandera"
 SOURCE_PATHS = PACKAGE, "tests", "noxfile.py"
 REQUIREMENT_PATH = "requirements.in"
 ALWAYS_USE_PIP = {
-    "ray",
     "furo",
+    "ray",
     "types-click",
     "types-pyyaml",
-    "types-pkg_resources",
+    "types-setuptools",
 }
 
 CI_RUN = os.environ.get("CI") == "true"

--- a/requirements.in
+++ b/requirements.in
@@ -55,7 +55,7 @@ grpcio
 ray
 typeguard
 types-click
-types-pyyaml
-types-pkg_resources
-types-requests
 types-pytz
+types-pyyaml
+types-requests
+types-setuptools

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -132,7 +132,7 @@ PANDAS_INDEX_ERRORS = [
 PANDAS_SERIES_ERRORS = [
     {
         "msg": (
-            'Argument 1 to "fn" has incompatible type "Series[float]"; '
+            'Argument "s" to "fn" has incompatible type "Series[float]"; '
             'expected "Series[str]"'
         ),
         "errcode": "arg-type",

--- a/tests/mypy/test_static_type_checking.py
+++ b/tests/mypy/test_static_type_checking.py
@@ -129,14 +129,31 @@ PANDAS_INDEX_ERRORS = [
     {"msg": "Incompatible types in assignment", "errcode": "assignment"},
 ] * 3
 
-PANDAS_SERIES_ERRORS = [
+PANDAS_SERIES_ERRORS_NO_PLUGIN = [
+    {
+        "msg": (
+            'Argument 1 to "fn" has incompatible type "Series[float]"; '
+            'expected "Series[str]"'
+        ),
+        "errcode": "arg-type",
+    }
+]
+
+PANDAS_SERIES_ERRORS_PLUGIN = [
     {
         "msg": (
             'Argument "s" to "fn" has incompatible type "Series[float]"; '
             'expected "Series[str]"'
         ),
         "errcode": "arg-type",
-    }
+    },
+    {
+        "msg": (
+            'Argument 1 to "fn" has incompatible type "Series[float]"; '
+            'expected "Series[str]"'
+        ),
+        "errcode": "arg-type",
+    },
 ]
 
 
@@ -159,8 +176,8 @@ PANDAS_SERIES_ERRORS = [
         ["python_slice.py", "plugin_mypy.ini", PYTHON_SLICE_ERRORS],
         ["pandas_index.py", "no_plugin.ini", []],
         ["pandas_index.py", "plugin_mypy.ini", []],
-        ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS],
-        ["pandas_series.py", "plugin_mypy.ini", PANDAS_SERIES_ERRORS],
+        ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS_NO_PLUGIN],
+        ["pandas_series.py", "plugin_mypy.ini", PANDAS_SERIES_ERRORS_PLUGIN],
     ],
 )
 def test_pandas_stubs_false_positives(


### PR DESCRIPTION
All `types-pkg-resources` releases were yanked; see https://pypi.org/project/types-pkg-resources/

Also fixes a bug in the CI, where pandas 2.2.2 + Python 3.8 combo was allowed.