### PR TITLE
add back external_config and typing modules to root __init__

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -11,7 +11,7 @@ import pandera.backends
 import pandera.backends.base.builtin_checks
 import pandera.backends.base.builtin_hypotheses
 import pandera.backends.pandas
-from pandera import errors
+from pandera import errors, external_config, typing
 from pandera.accessors import pandas_accessor
 from pandera.api import extensions
 from pandera.api.checks import Check


### PR DESCRIPTION
Fixes https://github.com/unionai-oss/pandera/issues/1795