### PR TITLE
Bugfix/1760 Bad type hint for argument unique for DataFrameSchema

### DIFF
--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -175,7 +175,7 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         self.strict: Union[bool, str] = strict
         self._coerce = coerce
         self.ordered = ordered
-        self._unique = unique
+        self._unique = [unique] if isinstance(unique, str) else unique
         self.report_duplicates = report_duplicates
         self.unique_column_names = unique_column_names
         self.add_missing_columns = add_missing_columns

--- a/pandera/api/pyspark/container.py
+++ b/pandera/api/pyspark/container.py
@@ -146,7 +146,7 @@ class DataFrameSchema(BaseSchema):  # pylint: disable=too-many-public-methods
         self.strict: Union[bool, str] = strict
         self._coerce = coerce
         self.ordered = ordered
-        self._unique = unique
+        self._unique = [unique] if isinstance(unique, str) else unique
         self.report_duplicates = report_duplicates
         self.unique_column_names = unique_column_names
 


### PR DESCRIPTION
Problem description:
- init sets `_unique` attribute
- class `DataFrameSchema` defines `unique` property, getter returns `_unique` attribute, setter modifies string value into list of strings and saves to `_unique` attribute
- other package functions use `unique` property

Because of above, `unique` property setter is never invoked. Thus string value is never turned into list of strings as I believe was intended.

I added code turning string into list of string to `__init__` function. I've also found same issue in dataframe and pyspark modules. 