### PR TITLE
accept expr in default value

### DIFF
--- a/pandera/backends/polars/components.py
+++ b/pandera/backends/polars/components.py
@@ -387,7 +387,10 @@ class ColumnBackend(PolarsSchemaBackend):
         if hasattr(schema, "default") and schema.default is None:
             return check_obj
 
-        default_value = pl.lit(schema.default, dtype=schema.dtype.type)
+        if isinstance(schema.default, pl.Expr):
+            default_value = schema.default
+        else:
+            default_value = pl.lit(schema.default, dtype=schema.dtype.type)
         expr = pl.col(schema.selector)
         if is_float_dtype(check_obj, schema.selector):
             expr = expr.fill_nan(default_value)

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -256,4 +256,24 @@ def test_set_default(data, dtype, default):
     assert validated_data.select(pl.col("column").eq(default).any()).item()
 
 
+def test_expr_as_default():
+    schema = pa.DataFrameSchema(
+        columns={
+            "a": pa.Column(int),
+            "b": pa.Column(float, default=1),
+            "c": pa.Column(str, default=pl.lit("foo")),
+            "d": pa.Column(int, nullable=True, default=pl.col("a")),
+        },
+        add_missing_columns=True,
+        coerce=True,
+    )
+    df = pl.LazyFrame({"a": [1, 2, 3]})
+    assert schema.validate(df).collect().to_dict(as_series=False) == {
+        "a": [1, 2, 3],
+        "b": [1.0, 1.0, 1.0],
+        "c": ["foo", "foo", "foo"],
+        "d": [1, 2, 3],
+    }
+
+
 def test_column_schema_on_lazyframe_coerce(): ...


### PR DESCRIPTION
Fixes: #1658

The way of doing it is to pass polars expression in the default value. Passing string refer to other column in the datafame.

I am not really sure of where to put the test...

Example:
```python
# Your code here
import polars as pl
import pandera.polars as pa

schema = pa.DataFrameSchema(
    columns={
        "a": pa.Column(int),
        "b": pa.Column(float, default=1),
        "c": pa.Column(str, default=pl.lit("foo")), # <- pl.lit !
        "d": pa.Column(float, nullable=True),
    },
    add_missing_columns=True,
    coerce=True,
)
df = pl.DataFrame({"a": [1, 2, 3]})
schema.validate(df)
# shape: (3, 4)
# ┌─────┬─────┬─────┬──────┐
# │ a   ┆ b   ┆ c   ┆ d    │
# │ --- ┆ --- ┆ --- ┆ ---  │
# │ i64 ┆ f64 ┆ str ┆ f64  │
# ╞═════╪═════╪═════╪══════╡
# │ 1   ┆ 1.0 ┆ foo ┆ null │
# │ 2   ┆ 1.0 ┆ foo ┆ null │
# │ 3   ┆ 1.0 ┆ foo ┆ null │
# └─────┴─────┴─────┴──────┘
```