### PR TITLE
Reduce import overhead to improve runtime

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -13,7 +13,6 @@ import pandera.backends.base.builtin_checks
 import pandera.backends.base.builtin_hypotheses
 import pandera.backends.pandas
 from pandera import errors, external_config
-from pandera.accessors import pandas_accessor
 from pandera.api import extensions
 from pandera.api.checks import Check
 from pandera.api.dataframe.model_components import (

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=wrong-import-position
 """A flexible and expressive pandas validation library."""
 
+import os
 import platform
 
 from pandera._patch_numpy2 import _patch_numpy2
@@ -80,9 +81,6 @@ from pandera.version import __version__
 if platform.system() != "Windows":
     # pylint: disable=ungrouped-imports
     from pandera.dtypes import Complex256, Float128
-
-
-external_config._set_pyspark_environment_variables()
 
 
 __all__ = [

--- a/pandera/api/extensions.py
+++ b/pandera/api/extensions.py
@@ -27,6 +27,7 @@ def register_builtin_check(
     fn=None,
     strategy: Optional[Callable] = None,
     _check_cls: Type = Check,
+    aliases: Optional[List[str]] = None,
     **outer_kwargs,
 ):
     """Register a check method to the Check namespace.
@@ -41,6 +42,7 @@ def register_builtin_check(
             register_builtin_check,
             strategy=strategy,
             _check_cls=_check_cls,
+            aliases=aliases,
             **outer_kwargs,
         )
 

--- a/pandera/backends/pandas/builtin_checks.py
+++ b/pandera/backends/pandas/builtin_checks.py
@@ -1,5 +1,6 @@
 """Pandas implementation of built-in checks"""
 
+import sys
 import operator
 import re
 from typing import Any, Iterable, Optional, TypeVar, Union, cast
@@ -10,18 +11,21 @@ import pandera.strategies as st
 from pandera.api.extensions import register_builtin_check
 
 
-from pandera.typing.modin import MODIN_INSTALLED
-from pandera.typing.pyspark import PYSPARK_INSTALLED
+MODIN_IMPORTED = "modin" in sys.modules
+PYSPARK_IMPORTED = "pyspark" in sys.modules
 
-if MODIN_INSTALLED and not PYSPARK_INSTALLED:  # pragma: no cover
+
+# TODO: create a separate module for each framework: dask, modin, pyspark
+# so checks are registered for the correct framework.
+if MODIN_IMPORTED and not PYSPARK_IMPORTED:  # pragma: no cover
     import modin.pandas as mpd
 
     PandasData = Union[pd.Series, pd.DataFrame, mpd.Series, mpd.DataFrame]
-elif not MODIN_INSTALLED and PYSPARK_INSTALLED:  # pragma: no cover
+elif not MODIN_IMPORTED and PYSPARK_IMPORTED:  # pragma: no cover
     import pyspark.pandas as ppd
 
     PandasData = Union[pd.Series, pd.DataFrame, ppd.Series, ppd.DataFrame]  # type: ignore[misc]
-elif MODIN_INSTALLED and PYSPARK_INSTALLED:  # pragma: no cover
+elif MODIN_IMPORTED and PYSPARK_IMPORTED:  # pragma: no cover
     import modin.pandas as mpd
     import pyspark.pandas as ppd
 
@@ -40,6 +44,8 @@ else:  # pragma: no cover
 T = TypeVar("T")
 
 
+# TODO: remove aliases, it's not needed anymore since aliases are defined in the
+# Check class.
 @register_builtin_check(
     aliases=["eq"],
     strategy=st.eq_strategy,

--- a/pandera/backends/pandas/hypotheses.py
+++ b/pandera/backends/pandas/hypotheses.py
@@ -12,14 +12,6 @@ from pandera.api.pandas.types import is_field, is_table
 from pandera.backends.pandas.checks import PandasCheckBackend
 
 
-try:
-    from scipy import stats  # pylint: disable=unused-import
-except ImportError:  # pragma: no cover
-    HAS_SCIPY = False
-else:
-    HAS_SCIPY = True
-
-
 DEFAULT_ALPHA = 0.01
 
 

--- a/tests/core/test_extension_modules.py
+++ b/tests/core/test_extension_modules.py
@@ -4,13 +4,20 @@ import pandas as pd
 import pytest
 
 from pandera.api.hypotheses import Hypothesis
-from pandera.backends.pandas.hypotheses import HAS_SCIPY
+
+
+try:
+    from scipy import stats  # pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    SCIPY_INSTALLED = False
+else:
+    SCIPY_INSTALLED = True
 
 
 def test_hypotheses_module_import() -> None:
     """Test that Hypothesis built-in methods raise import error."""
     data = pd.Series([1, 2, 3])
-    if not HAS_SCIPY:
+    if not SCIPY_INSTALLED:
         for fn, check_args in [
             (
                 lambda: Hypothesis.two_sample_ttest("sample1", "sample2"),

--- a/tests/hypotheses/test_hypotheses.py
+++ b/tests/hypotheses/test_hypotheses.py
@@ -12,15 +12,19 @@ from pandera import (
     String,
     errors,
 )
-from pandera.backends.pandas.hypotheses import HAS_SCIPY
 
-if HAS_SCIPY:
-    from scipy import stats  # pylint: disable=import-error
+
+try:
+    from scipy import stats  # pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    SCIPY_INSTALLED = False
+else:
+    SCIPY_INSTALLED = True
 
 
 # skip all tests in module if "hypotheses" depends aren't installed
 pytestmark = pytest.mark.skipif(
-    not HAS_SCIPY, reason='needs "hypotheses" module dependencies'
+    not SCIPY_INSTALLED, reason='needs "hypotheses" module dependencies'
 )
 
 

--- a/tests/pyspark/test_schemas_on_pyspark_pandas.py
+++ b/tests/pyspark/test_schemas_on_pyspark_pandas.py
@@ -12,6 +12,7 @@ import pytest
 from packaging import version
 
 import pandera as pa
+from pandera.typing import pyspark as pyspark_typing
 from pandera import dtypes, extensions, system
 from pandera.engines import numpy_engine, pandas_engine, geopandas_engine
 from pandera.typing import DataFrame, Index, Series
@@ -554,11 +555,9 @@ def test_schema_model():
 
     # pylint: disable=too-few-public-methods
     class Schema(pa.DataFrameModel):
-        int_field: pa.typing.pyspark.Series[int] = pa.Field(gt=0)
-        float_field: pa.typing.pyspark.Series[float] = pa.Field(lt=0)
-        str_field: pa.typing.pyspark.Series[str] = pa.Field(
-            isin=["a", "b", "c"]
-        )
+        int_field: pyspark_typing.Series[int] = pa.Field(gt=0)
+        float_field: pyspark_typing.Series[float] = pa.Field(lt=0)
+        str_field: pyspark_typing.Series[str] = pa.Field(isin=["a", "b", "c"])
 
     valid_df = ps.DataFrame(
         {
@@ -621,10 +620,10 @@ def test_check_decorators():
 
     # pylint: disable=too-few-public-methods
     class InSchema(pa.DataFrameModel):
-        a: pa.typing.pyspark.Series[int]
+        a: pyspark_typing.Series[int]
 
     class OutSchema(InSchema):
-        b: pa.typing.pyspark.Series[int]
+        b: pyspark_typing.Series[int]
 
     @pa.check_input(in_schema)
     @pa.check_output(out_schema)
@@ -648,16 +647,16 @@ def test_check_decorators():
 
     @pa.check_types
     def function_check_types(
-        df: pa.typing.pyspark.DataFrame[InSchema],
-    ) -> pa.typing.pyspark.DataFrame[OutSchema]:
+        df: pyspark_typing.DataFrame[InSchema],
+    ) -> pyspark_typing.DataFrame[OutSchema]:
         df["b"] = df["a"] + 1
-        return typing.cast(pa.typing.pyspark.DataFrame[OutSchema], df)
+        return typing.cast(pyspark_typing.DataFrame[OutSchema], df)
 
     @pa.check_types
     def function_check_types_invalid(
-        df: pa.typing.pyspark.DataFrame[InSchema],
-    ) -> pa.typing.pyspark.DataFrame[OutSchema]:
-        return typing.cast(pa.typing.pyspark.DataFrame[OutSchema], df)
+        df: pyspark_typing.DataFrame[InSchema],
+    ) -> pyspark_typing.DataFrame[OutSchema]:
+        return typing.cast(pyspark_typing.DataFrame[OutSchema], df)
 
     valid_df = ps.DataFrame({"a": [1, 2, 3]})
     invalid_df = ps.DataFrame({"b": [1, 2, 3]})


### PR DESCRIPTION
This PR optmizes the import runtime by lazily importing alternative dataframe libraries that are supported by the pandas backend, e.g. dask, modin, and pyspark.