### PR TITLE
fix: preserve Check options in schema statistics roundtrip

### DIFF
--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -127,13 +127,24 @@ columns:
     dtype: int64
     nullable: false
     checks:
-      greater_than: 0
-      less_than: 10
+      greater_than:
+        value: 0
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10
+        options:
+          raise_warning: false
+          ignore_na: true
       in_range:
         min_value: 0
         max_value: 10
         include_min: true
         include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -144,13 +155,24 @@ columns:
     dtype: float64
     nullable: false
     checks:
-      greater_than: -10
-      less_than: 20
+      greater_than:
+        value: -10
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 20
+        options:
+          raise_warning: false
+          ignore_na: true
       in_range:
         min_value: -10
         max_value: 20
         include_min: true
         include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -162,13 +184,20 @@ columns:
     nullable: false
     checks:
       isin:
-      - foo
-      - bar
-      - x
-      - xy
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
       str_length:
         min_value: 1
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -179,8 +208,16 @@ columns:
     dtype: datetime64[ns]
     nullable: false
     checks:
-      greater_than: '2010-01-01 00:00:00'
-      less_than: '2020-01-01 00:00:00'
+      greater_than:
+        value: '2010-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: '2020-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -191,8 +228,16 @@ columns:
     dtype: timedelta64[ns]
     nullable: false
     checks:
-      greater_than: 1000
-      less_than: 10000
+      greater_than:
+        value: 1000
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10000
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -206,6 +251,9 @@ columns:
       str_length:
         min_value: 1
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: false
@@ -217,10 +265,14 @@ columns:
     nullable: false
     checks:
       isin:
-      - foo
-      - bar
-      - x
-      - xy
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -290,13 +342,20 @@ columns:
     nullable: false
     checks:
       isin:
-      - foo
-      - bar
-      - x
-      - xy
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
       str_length:
         min_value: 1
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
 index: null
 checks: null
 coerce: false
@@ -388,13 +447,24 @@ columns:
     dtype: int64
     nullable: false
     checks:
-      greater_than: 0
-      less_than: 10
+      greater_than:
+        value: 0
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10
+        options:
+          raise_warning: false
+          ignore_na: true
       in_range:
         min_value: 0
         max_value: 10
         include_min: true
         include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -405,13 +475,24 @@ columns:
     dtype: float64
     nullable: false
     checks:
-      greater_than: -10
-      less_than: 20
+      greater_than:
+        value: -10
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 20
+        options:
+          raise_warning: false
+          ignore_na: true
       in_range:
         min_value: -10
         max_value: 20
         include_min: true
         include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -423,13 +504,20 @@ columns:
     nullable: false
     checks:
       isin:
-      - foo
-      - bar
-      - x
-      - xy
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
       str_length:
         min_value: 1
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -440,8 +528,16 @@ columns:
     dtype: datetime64[ns]
     nullable: false
     checks:
-      greater_than: '2010-01-01 00:00:00'
-      less_than: '2020-01-01 00:00:00'
+      greater_than:
+        value: '2010-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: '2020-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -452,8 +548,16 @@ columns:
     dtype: timedelta64[ns]
     nullable: false
     checks:
-      greater_than: 1000
-      less_than: 10000
+      greater_than:
+        value: 1000
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10000
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -467,6 +571,9 @@ columns:
       str_length:
         min_value: 1
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: false
@@ -478,10 +585,14 @@ columns:
     nullable: false
     checks:
       isin:
-      - foo
-      - bar
-      - x
-      - xy
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -1138,6 +1249,9 @@ columns:
         max_value: 99
         include_min: true
         include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: true
     coerce: true
     required: true
@@ -1148,7 +1262,11 @@ columns:
     dtype: {INT_DTYPE}
     nullable: true
     checks:
-      less_than_or_equal_to: 30
+      less_than_or_equal_to:
+        value: 30
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1162,6 +1280,9 @@ columns:
       str_length:
         min_value: 3
         max_value: 80
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1172,7 +1293,11 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_matches: ^\\d{{3}}[A-Z]$
+      str_matches:
+        value: ^\\d{{3}}[A-Z]$
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1186,6 +1311,9 @@ columns:
       str_length:
         min_value: 3
         max_value: null
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1199,6 +1327,9 @@ columns:
       str_length:
         min_value: null
         max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1210,9 +1341,13 @@ columns:
     nullable: false
     checks:
       isin:
-      - 1.0
-      - 2.0
-      - 3.0
+        value:
+        - 1.0
+        - 2.0
+        - 3.0
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1233,7 +1368,11 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      greater_than_or_equal_to: '20201231'
+      greater_than_or_equal_to:
+        value: '20201231'
+        options:
+          raise_warning: false
+          ignore_na: true
     unique: false
     coerce: true
     required: true


### PR DESCRIPTION
# fix: preserve Check options in schema statistics roundtrip (#694)

## What does this PR do?
Fixes #694 by ensuring check options (like `raise_warning` and `ignore_na`) are preserved when schemas are serialized and deserialized.

## Changes
- Update `parse_checks` to include check options in statistics
- Update `parse_check_statistics` to reconstruct checks with their original options
- Update test suite to verify options persistence

## Testing

Updated existing test cases in test_schema_statistics.py to verify options persistence
All tests passing locally
All pre-commit are passing
No new warnings introduced

## Related Issues
Closes #694


Let me know if you need any additional information or would like me to make any adjustments.