### PR TITLE
fix: remove Category inheritance from ArrowDictionary

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1661,7 +1661,7 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
         equivalents=[pyarrow.dictionary, pyarrow.DictionaryType]
     )
     @immutable(init=True)
-    class ArrowDictionary(ArrowDataType, dtypes.Category):
+    class ArrowDictionary(ArrowDataType):
         """Semantic representation of a :class:`pyarrow.dictionary`."""
 
         type: Optional[pd.ArrowDtype] = dataclasses.field(

--- a/pandera/engines/pyarrow_engine.py
+++ b/pandera/engines/pyarrow_engine.py
@@ -268,7 +268,7 @@ class ArrowTimestamp(ArrowDataType, dtypes.Timestamp):
     equivalents=[pyarrow.dictionary, pyarrow.DictionaryType]
 )
 @immutable(init=True)
-class ArrowDictionary(ArrowDataType, dtypes.Category):
+class ArrowDictionary(ArrowDataType):
     """Semantic representation of a :class:`pyarrow.dictionary`."""
 
     type: Optional[pd.ArrowDtype] = dataclasses.field(default=None, init=False)


### PR DESCRIPTION
This PR removes Category inheritance from ArrowDictionary because it does not need the category attribute check here: https://github.com/unionai-oss/pandera/blob/main/pandera/dtypes.py#L483

Old behavior:

```python
import pyarrow
from pandera.engines.pandas_engine import ArrowDictionary

int64_dictionary = ArrowDictionary(value_type=pyarrow.int64())
string_dictionary = ArrowDictionary(value_type=pyarrow.string())

int64_dictionary.check(string_dictionary)  # True
```

New behavior:

```python
int64_dictionary.check(string_dictionary)  # False
```