### PR TITLE
Fixing bug related to using coerce on a non-existent non-required column

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -446,11 +446,19 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             else "coerce"
         )
 
+        lf_columns = get_lazyframe_column_names(obj)
+
         try:
             if schema.dtype is not None:
                 obj = getattr(schema.dtype, coerce_fn)(obj)
             else:
                 for col_schema in schema.columns.values():
+                    if (
+                        not col_schema.required
+                        and col_schema.name not in lf_columns
+                    ):
+                        continue
+
                     if schema.coerce or col_schema.coerce:
                         obj = getattr(col_schema.dtype, coerce_fn)(
                             PolarsData(obj, col_schema.selector)

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -171,18 +171,10 @@ class DataType(dtypes.DataType):
         raises a :class:`~pandera.errors.ParserError` if the coercion fails
         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
         """
-        from pandera.api.polars.utils import (
-            get_lazyframe_schema,
-            get_lazyframe_column_names,
-        )
+        from pandera.api.polars.utils import get_lazyframe_schema
 
         if isinstance(data_container, pl.LazyFrame):
             data_container = PolarsData(data_container)
-
-        if data_container.key not in get_lazyframe_column_names(
-            data_container.lazyframe
-        ):
-            return data_container.lazyframe
 
         try:
             lf = self.coerce(data_container)

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -171,10 +171,18 @@ class DataType(dtypes.DataType):
         raises a :class:`~pandera.errors.ParserError` if the coercion fails
         :raises: :class:`~pandera.errors.ParserError`: if coercion fails
         """
-        from pandera.api.polars.utils import get_lazyframe_schema
+        from pandera.api.polars.utils import (
+            get_lazyframe_schema,
+            get_lazyframe_column_names,
+        )
 
         if isinstance(data_container, pl.LazyFrame):
             data_container = PolarsData(data_container)
+
+        if data_container.key not in get_lazyframe_column_names(
+            data_container.lazyframe
+        ):
+            return data_container.lazyframe
 
         try:
             lf = self.coerce(data_container)

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -177,6 +177,14 @@ def test_coerce_df_dtype_error(ldf_basic, ldf_schema_basic):
         modified_ldf.pipe(ldf_schema_basic.validate)
 
 
+def test_coerce_df_missing_column(ldf_basic, ldf_schema_basic):
+    """Test coerce dtype when column does not exist and not required."""
+    ldf_schema_basic.columns["string_col"].required = False
+    ldf_schema_basic.columns["string_col"].coerce = True
+    modified_ldf = ldf_basic.drop("string_col")
+    modified_ldf.collect().pipe(ldf_schema_basic.validate)
+
+
 def test_strict_filter(ldf_basic, ldf_schema_basic):
     """Test strictness and filtering schema logic."""
     # by default, strict is False, so by default it should pass

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -182,7 +182,8 @@ def test_coerce_df_missing_column(ldf_basic, ldf_schema_basic):
     ldf_schema_basic.columns["string_col"].required = False
     ldf_schema_basic.columns["string_col"].coerce = True
     modified_ldf = ldf_basic.drop("string_col")
-    modified_ldf.collect().pipe(ldf_schema_basic.validate)
+    # should not raise an error
+    modified_ldf.pipe(ldf_schema_basic.validate)
 
 
 def test_strict_filter(ldf_basic, ldf_schema_basic):


### PR DESCRIPTION
Fixes #1660 

Turns out that if coercion is attempted on a column that is not required and not present in the df, the coercion fails.
This PR fixes this bug.