### PR TITLE
bugfix/1835: Keep nulls in polars when dropping invalid rows and nullable=True

### DIFF
--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -252,7 +252,9 @@ class PolarsSchemaBackend(BaseSchemaBackend):
         valid_rows = check_outputs.select(
             valid_rows=pl.fold(
                 acc=pl.lit(True),
-                function=lambda acc, x: acc & x,
+                # if nullable=True for a column, the check_outputs values will be null for that row
+                # if the row value is null
+                function=lambda acc, x: acc & (x | x.is_null()),
                 exprs=pl.col(pl.Boolean),
             )
         )["valid_rows"]

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -252,9 +252,7 @@ class PolarsSchemaBackend(BaseSchemaBackend):
         valid_rows = check_outputs.select(
             valid_rows=pl.fold(
                 acc=pl.lit(True),
-                # if nullable=True for a column, the check_outputs values will be null for that row
-                # if the row value is null
-                function=lambda acc, x: acc & (x | x.is_null()),
+                function=lambda acc, x: acc & x,
                 exprs=pl.col(pl.Boolean),
             )
         )["valid_rows"]

--- a/pandera/backends/polars/checks.py
+++ b/pandera/backends/polars/checks.py
@@ -94,6 +94,10 @@ class PolarsCheckBackend(BaseCheckBackend):
     ) -> CheckResult:
         """Postprocesses the result of applying the check function."""
         results = pl.LazyFrame(check_output.collect())
+        if self.check.ignore_na:
+            results = results.with_columns(
+                pl.col(CHECK_OUTPUT_KEY) | pl.col(CHECK_OUTPUT_KEY).is_null()
+            )
         passed = results.select([pl.col(CHECK_OUTPUT_KEY).all()])
         failure_cases = pl.concat(
             [check_obj.lazyframe, results], how="horizontal"

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -32,10 +32,22 @@ def _column_check_fn_scalar_out(data: pa.PolarsData) -> pl.LazyFrame:
 
 
 @pytest.mark.parametrize(
-    "check_fn, invalid_data, expected_output",
+    "check_fn, invalid_data, expected_output, ignore_na",
     [
-        [_column_check_fn_df_out, [-1, 2, 3, -2], [False, True, True, False]],
-        [_column_check_fn_scalar_out, [-1, 2, 3, -2], [False]],
+        [
+            _column_check_fn_df_out,
+            [-1, 2, 3, -2],
+            [False, True, True, False],
+            False,
+        ],
+        [_column_check_fn_scalar_out, [-1, 2, 3, -2], [False], False],
+        [
+            _column_check_fn_df_out,
+            [-1, 2, 3, None],
+            [False, True, True, True],
+            True,
+        ],
+        [_column_check_fn_scalar_out, [-1, 2, 3, None], [False], True],
     ],
 )
 def test_polars_column_check(
@@ -43,8 +55,9 @@ def test_polars_column_check(
     check_fn,
     invalid_data,
     expected_output,
+    ignore_na,
 ):
-    check = pa.Check(check_fn)
+    check = pa.Check(check_fn, ignore_na=ignore_na)
     check_result = check(column_lf, column="col")
     assert check_result.check_passed.collect().item()
 


### PR DESCRIPTION
When nullable=True in polars, it seems the `check_outputs` values from the error handler are left as `null` rather than `True` where values are null. This would be one possible way to remedy that to match with pandas behavior as per #1835 however I am not sure if this is the best place to handle that behavior, or even if it makes sense to match pandas behavior here or not.

There also seemed to be a bug in the original test for polars dropping null values which I attempted to fix up here.