### PR TITLE
Bugfix/1677 Fix Pandera DataFrame - Pydantic compatibility

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -31,11 +31,6 @@ from pandera.typing.common import (
 from pandera.typing.formats import Formats
 from pandera.config import config_context
 
-try:
-    from typing import get_args
-except ImportError:
-    from typing_extensions import get_args
-
 
 try:
     from typing import _GenericAlias  # type: ignore[attr-defined]
@@ -200,20 +195,23 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 "int64": core_schema.int_schema(),
                 "float64": core_schema.float_schema(),
                 "bool": core_schema.bool_schema(),
-                "datetime64[ns]": core_schema.datetime_schema()
+                "datetime64[ns]": core_schema.datetime_schema(),
             }
             return core_schema.no_info_plain_validator_function(
-                    functools.partial(
+                functools.partial(
                     cls.pydantic_validate,
                     schema_model=schema_model,
                 ),
                 json_schema_input_schema=core_schema.list_schema(
-                core_schema.typed_dict_schema(
-                    {
-                        i:core_schema.typed_dict_field(type_map[str(j.dtype)]) for i,j in schema.columns.items()
-                    },
-                )
-            )
+                    core_schema.typed_dict_schema(
+                        {
+                            i: core_schema.typed_dict_field(
+                                type_map[str(j.dtype)]
+                            )
+                            for i, j in schema.columns.items()
+                        },
+                    )
+                ),
             )
 
     else:

--- a/tests/core/test_pydantic.py
+++ b/tests/core/test_pydantic.py
@@ -65,7 +65,7 @@ def test_typed_dataframe():
 
 
 def test_invalid_typed_dataframe():
-    """Test that an invalid typed DataFrame is recognized by pydantic."""
+    """Test that an invalid typed DataFrame is recognized by pandera."""
     with pytest.raises(ValidationError):
         TypedDfPydantic(df=1)
 
@@ -74,11 +74,10 @@ def test_invalid_typed_dataframe():
 
         str_col = pa.Field(unique=True)  # omit annotation
 
-    class PydanticModel(BaseModel):
-        pa_schema: DataFrame[InvalidSchema]
+    with pytest.raises(pa.errors.SchemaInitError):
 
-    with pytest.raises(ValueError):
-        PydanticModel(pa_schema=InvalidSchema)
+        class PydanticModel(BaseModel):
+            pa_schema: DataFrame[InvalidSchema]
 
 
 def test_dataframemodel():

--- a/tests/core/test_pydantic.py
+++ b/tests/core/test_pydantic.py
@@ -79,6 +79,10 @@ def test_invalid_typed_dataframe():
         class PydanticModel(BaseModel):
             pa_schema: DataFrame[InvalidSchema]
 
+    # This check prevents Linters from raising an error about not using the PydanticModel class
+    with pytest.raises(UnboundLocalError):
+        PydanticModel(pa_schema=InvalidSchema)
+
 
 def test_dataframemodel():
     """Test that DataFrameModel is compatible with pydantic."""


### PR DESCRIPTION
Update to [pydantic-core](https://github.com/pydantic/pydantic-core/commit/98bc1e2a380344a5157824f9e5659e7a040b1ea4) requires additional parameter `json_schema_input_schema` in `core_schema.no_info_plain_validator_function` function.

I did some checking and it seems that it doesn't matter what is put under the variable as long as it belongs to `core_schema` valid `schema` types. Generated schema also doesn't contain field checks. However, pydantic model validation includes pandera submodel with all checks. 

I'm not sure if this is correct. I made changes based on #1677 and #1704 

I had to modify one test, because current code change discovers schema issue earlier than before.