### PR TITLE
Bugfix/763 improve type annotations for DataFrameModel.validate

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,7 +56,7 @@ jobs:
             types-pytz \
             types-pyyaml \
             types-requests \
-            types-setuptools
+            types-setuptools \
             polars
       - name: Pip info
         run: python -m pip list

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,6 +57,7 @@ jobs:
             types-pyyaml \
             types-requests \
             types-setuptools
+            polars
       - name: Pip info
         run: python -m pip list
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
           - types-pyyaml
           - types-requests
           - types-setuptools
+          - polars
         args: ["pandera", "tests", "scripts"]
         exclude: (^docs/|^tests/mypy/modules/)
         pass_filenames: false

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,25 +12,17 @@ exclude=(?x)(
     | ^pandera/backends/pyspark
     | ^tests/pyspark
   )
-[mypy-polars.*]
-follow_imports = skip
-[mypy-mypy.*]
-follow_imports = skip
-[mypy-tests.mypy.modules.*]
-follow_imports = skip
 [mypy-pandera.api.pyspark.*]
 follow_imports = skip
-[mypy-pandera.backends.pyspark.*]
-follow_imports = skip
-[mypy-pandera.engines.pyspark_engine]
-follow_imports = skip
-[mypy-tests.mypy]
-follow_imports = skip
-[mypy-tests.geopandas]
-follow_imports = skip
+
 [mypy-docs.*]
 follow_imports = skip
 
-# potentially not required / not ideal, pre-commit mypy sometimes scans the pre-commit venv
-[mypy-urllib3.*]
-follow_imports = skip
+[mypy-pandera.engines.polars_engine]
+ignore_errors = True
+
+[mypy-pandera.backends.polars.builtin_checks]
+ignore_errors = True
+
+[mypy-tests.polars.*]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-follow_imports = skip
+follow_imports = normal
 allow_redefinition = True
 warn_return_any = False
 warn_unused_configs = True
@@ -12,3 +12,25 @@ exclude=(?x)(
     | ^pandera/backends/pyspark
     | ^tests/pyspark
   )
+[mypy-polars.*]
+follow_imports = skip
+[mypy-mypy.*]
+follow_imports = skip
+[mypy-tests.mypy.modules.*]
+follow_imports = skip
+[mypy-pandera.api.pyspark.*]
+follow_imports = skip
+[mypy-pandera.backends.pyspark.*]
+follow_imports = skip
+[mypy-pandera.engines.pyspark_engine]
+follow_imports = skip
+[mypy-tests.mypy]
+follow_imports = skip
+[mypy-tests.geopandas]
+follow_imports = skip
+[mypy-docs.*]
+follow_imports = skip
+
+# potentially not required / not ideal, pre-commit mypy sometimes scans the pre-commit venv
+[mypy-urllib3.*]
+follow_imports = skip

--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -18,13 +18,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload,
 )
-
-# TODO hard dependence on pandas and polars, use string forwardref instead?
-import pandas as pd  # TODO tmp
-import polars as pl
-from pandera.typing.polars import LazyFrame
 
 from pandera.api.base.model import BaseModel
 from pandera.api.base.schema import BaseSchema
@@ -277,50 +271,24 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
         """
         return cls.to_schema().to_yaml(stream)
 
-    # Overloads specify effectively check_obj: TDataFrame -> TDataFrame[TDataFrameModel]
-    # but to do this directly would required higher kinded typevars (https://github.com/python/typing/issues/548)
-
-    @overload
-    @classmethod
-    def validate(
-        cls: Type[TDataFrameModel],
-        check_obj: pl.LazyFrame,
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> LazyFrame[TDataFrameModel]: ...
-
-    @overload
-    @classmethod
-    def validate(
-        cls: Type[TDataFrameModel],
-        check_obj: pd.DataFrame,
-        head: Optional[int] = None,
-        tail: Optional[int] = None,
-        sample: Optional[int] = None,
-        random_state: Optional[int] = None,
-        lazy: bool = False,
-        inplace: bool = False,
-    ) -> DataFrame[TDataFrameModel]: ...
-
     @classmethod
     @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
     def validate(
         cls: Type[TDataFrameModel],
-        check_obj: pd.DataFrame | pl.LazyFrame,
+        check_obj: TDataFrame,
         head: Optional[int] = None,
         tail: Optional[int] = None,
         sample: Optional[int] = None,
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-    ) -> DataFrame[TDataFrameModel] | LazyFrame[TDataFrameModel]:
+    ) -> DataFrameBase[TDataFrameModel]:
         """%(validate_doc)s"""
-        return cls.to_schema().validate(
-            check_obj, head, tail, sample, random_state, lazy, inplace
+        return cast(
+            DataFrameBase[TDataFrameModel],
+            cls.to_schema().validate(
+                check_obj, head, tail, sample, random_state, lazy, inplace
+            ),
         )
 
     # TODO: add docstring_substitution using generic class

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -2,10 +2,11 @@
 
 import copy
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import pandas as pd
 
+from pandera.api.base.schema import BaseSchema
 from pandera.api.checks import Check
 from pandera.api.dataframe.model import DataFrameModel as _DataFrameModel
 from pandera.api.dataframe.model import get_dtype_kwargs
@@ -22,6 +23,7 @@ from pandera.typing import (
     AnnotationInfo,
     DataFrame,
 )
+from pandera.utils import docstring_substitution
 
 # if python version is < 3.11, import Self from typing_extensions
 if sys.version_info < (3, 11):
@@ -170,6 +172,26 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                 )
 
         return columns, _build_schema_index(indices, **multiindex_kwargs)
+
+    @classmethod
+    @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
+    def validate(
+        cls: Type[Self],
+        check_obj: pd.DataFrame,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> DataFrame[Self]:
+        """%(validate_doc)s"""
+        return cast(
+            DataFrame[Self],
+            cls.to_schema().validate(
+                check_obj, head, tail, sample, random_state, lazy, inplace
+            ),
+        )
 
     @classmethod
     def to_json_schema(cls):

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -23,7 +23,7 @@ class Column(ComponentSchema[PolarsCheckObjects]):
 
     def __init__(
         self,
-        dtype: PolarsDtypeInputTypes = None,
+        dtype: Optional[PolarsDtypeInputTypes] = None,
         checks: Optional[CheckList] = None,
         nullable: bool = False,
         unique: bool = False,

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -1,11 +1,13 @@
 """Class-based api for polars models."""
 
 import inspect
-from typing import Dict, List, Tuple, Type
+from typing import Dict, List, Tuple, Type, cast, Optional
+from typing_extensions import Self
 
 import pandas as pd
 import polars as pl
 
+from pandera.api.base.schema import BaseSchema
 from pandera.api.checks import Check
 from pandera.api.dataframe.model import DataFrameModel as _DataFrameModel
 from pandera.api.dataframe.model import get_dtype_kwargs
@@ -16,7 +18,8 @@ from pandera.api.polars.model_config import BaseConfig
 from pandera.engines import polars_engine as pe
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
-from pandera.typing.polars import Series
+from pandera.typing.polars import Series, LazyFrame
+from pandera.utils import docstring_substitution
 
 
 class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
@@ -108,6 +111,26 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
                 )
 
         return columns
+
+    @classmethod
+    @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
+    def validate(
+        cls: Type[Self],
+        check_obj: pl.LazyFrame,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> LazyFrame[Self]:
+        """%(validate_doc)s"""
+        return cast(
+            LazyFrame[Self],
+            cls.to_schema().validate(
+                check_obj, head, tail, sample, random_state, lazy, inplace
+            ),
+        )
 
     @classmethod
     def to_json_schema(cls):

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -1,7 +1,7 @@
 """Class-based api for polars models."""
 
 import inspect
-from typing import Dict, List, Tuple, Type, cast, Optional
+from typing import Dict, List, Tuple, Type, cast, Optional, overload
 from typing_extensions import Self
 
 import pandas as pd
@@ -18,7 +18,7 @@ from pandera.api.polars.model_config import BaseConfig
 from pandera.engines import polars_engine as pe
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
-from pandera.typing.polars import Series, LazyFrame
+from pandera.typing.polars import Series, LazyFrame, DataFrame
 from pandera.utils import docstring_substitution
 
 
@@ -113,7 +113,20 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
         return columns
 
     @classmethod
-    @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
+    @overload
+    def validate(
+        cls: Type[Self],
+        check_obj: pl.DataFrame,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> DataFrame[Self]: ...
+
+    @classmethod
+    @overload
     def validate(
         cls: Type[Self],
         check_obj: pl.LazyFrame,
@@ -123,14 +136,28 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-    ) -> LazyFrame[Self]:
+    ) -> LazyFrame[Self]: ...
+
+    @classmethod
+    @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
+    def validate(
+        cls: Type[Self],
+        check_obj: pl.LazyFrame | pl.DataFrame,
+        head: Optional[int] = None,
+        tail: Optional[int] = None,
+        sample: Optional[int] = None,
+        random_state: Optional[int] = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> LazyFrame[Self] | DataFrame[Self]:
         """%(validate_doc)s"""
-        return cast(
-            LazyFrame[Self],
-            cls.to_schema().validate(
-                check_obj, head, tail, sample, random_state, lazy, inplace
-            ),
+        result = cls.to_schema().validate(
+            check_obj, head, tail, sample, random_state, lazy, inplace
         )
+        if isinstance(check_obj, pl.LazyFrame):
+            return cast(LazyFrame[Self], result)
+        else:
+            return cast(DataFrame[Self], result)
 
     @classmethod
     def to_json_schema(cls):

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -1,7 +1,7 @@
 """Class-based api for polars models."""
 
 import inspect
-from typing import Dict, List, Tuple, Type, cast, Optional, overload
+from typing import Dict, List, Tuple, Type, cast, Optional, overload, Union
 from typing_extensions import Self
 
 import pandas as pd
@@ -149,7 +149,7 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
         random_state: Optional[int] = None,
         lazy: bool = False,
         inplace: bool = False,
-    ) -> LazyFrame[Self] | DataFrame[Self]:
+    ) -> Union[LazyFrame[Self], DataFrame[Self]]:
         """%(validate_doc)s"""
         result = cls.to_schema().validate(
             check_obj, head, tail, sample, random_state, lazy, inplace

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -142,7 +142,7 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
     @docstring_substitution(validate_doc=BaseSchema.validate.__doc__)
     def validate(
         cls: Type[Self],
-        check_obj: pl.LazyFrame | pl.DataFrame,
+        check_obj: Union[pl.LazyFrame, pl.DataFrame],
         head: Optional[int] = None,
         tail: Optional[int] = None,
         sample: Optional[int] = None,

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -301,7 +301,7 @@ class DataFrameModel(BaseModel):
         random_state: Optional[int] = None,
         lazy: bool = True,
         inplace: bool = False,
-    ) -> Optional[DataFrame[TDataFrameModel]]:
+    ) -> DataFrame[TDataFrameModel]:
         """%(validate_doc)s"""
         return cast(
             DataFrame[TDataFrameModel],

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -41,6 +41,7 @@ from pandera.api.pyspark.model_config import BaseConfig
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
 from pandera.typing.common import DataFrameBase
+from pandera.typing.pyspark import DataFrame
 
 try:
     from typing_extensions import get_type_hints
@@ -300,10 +301,10 @@ class DataFrameModel(BaseModel):
         random_state: Optional[int] = None,
         lazy: bool = True,
         inplace: bool = False,
-    ) -> Optional[DataFrameBase[TDataFrameModel]]:
+    ) -> Optional[DataFrame[TDataFrameModel]]:
         """%(validate_doc)s"""
         return cast(
-            DataFrameBase[TDataFrameModel],
+            DataFrame[TDataFrameModel],
             cls.to_schema().validate(
                 check_obj, head, tail, sample, random_state, lazy, inplace
             ),

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -47,7 +47,10 @@ class PolarsSchemaBackend(BaseSchemaBackend):
             obj_subsample.append(check_obj.tail(tail))
         if sample is not None:
             obj_subsample.append(
-                check_obj.sample(sample, random_state=random_state)
+                # mypy is detecting a bug https://github.com/unionai-oss/pandera/issues/1912
+                check_obj.sample(  # type:ignore [attr-defined]
+                    sample, random_state=random_state
+                )
             )
         return (
             check_obj


### PR DESCRIPTION
This aims to close #763, but is currently a partial WIP step towards that.

I did come across that #1450 already exists, but it doesn't deal with different dataframe libraries, so it seemed easier to start from scratch, and focus specifically on the validate method to get some initial feedback too.

In the current state there's a few issues to resolve:
- typing imports depending on optional deps, which won't necessarily be available
- just testing with pandas and polars, would need to deal with all the other dataframe libraries supported (and pyspark seems to actually overload the validate method as well)
- the pandera mypy throws and error (or at least it does for the pre-commit hooks):
`pandera\api\dataframe\model.py:298: error: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader  [misc]`
which I gather is because without a stub library (and perhaps due to some mypy configuration) the revealed type of both pd.DataFrame and pl.LazyFrame is Any, and so the overloads are in conflict with one another.

Another possible approach would be to overload `validate` in all the dataframe library implementations, purely to update type annotations (avoiding the need to deal with optional imports) but this might not be worth the mess it creats.

I'd welcome any feedback, it's been quite a while since I last submitted a PR to pandera, didn't think it would be such a long gap.
