### PR TITLE
Update test to reflect scalar output since Ibis 10

### DIFF
--- a/tests/ibis/test_ibis_check.py
+++ b/tests/ibis/test_ibis_check.py
@@ -105,7 +105,7 @@ def _df_check_fn_scalar_out(data: pa.IbisData) -> ir.BooleanScalar:
                 "col_1": [-1, 2, 3, 4],
                 "col_2": [2, 1, 2, 5],
             },
-            [False],
+            False,
         ],
     ],
 )


### PR DESCRIPTION
The test is technically breaking because of https://github.com/ibis-project/ibis/pull/10233

However, I think this feels "more correct" regardless. Trying to debug how this worked with Ibis 9.5.0:

```python
(Pdb) output
False
(Pdb) expected_output
[False]
(Pdb) output == expected_output
array([ True])
(Pdb) type(output)
<class 'numpy.bool_'>
```

Really, this would have made more sense:

```python
(Pdb) output
False
(Pdb) expected_output
False
(Pdb) output == expected_output
True
(Pdb) type(output)
<class 'numpy.bool_'>
(Pdb) type(expected_output)
<class 'bool'>
```