### PR TITLE
Allow pydantic model validation via `Annotated` metadata

### DIFF
--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -582,8 +582,12 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
         def __get_pydantic_core_schema__(
             cls, _source_type: Any, _handler: GetCoreSchemaHandler
         ) -> core_schema.CoreSchema:
-            return core_schema.no_info_plain_validator_function(
-                cls.pydantic_validate,
+            if issubclass(_source_type, cls):
+                return core_schema.no_info_plain_validator_function(
+                    cls.pydantic_validate,
+                )
+            return core_schema.no_info_after_validator_function(
+                cls.validate, _handler(_source_type)
             )
 
         @classmethod

--- a/tests/core/test_pydantic.py
+++ b/tests/core/test_pydantic.py
@@ -1,13 +1,14 @@
 """Unit tests for pydantic compatibility."""
 
 # pylint:disable=too-few-public-methods,missing-class-docstring
-from typing import Optional
+from typing import Annotated, ClassVar, Optional
 
 import pandas as pd
 import pytest
 
 import pandera as pa
 from pandera.engines import pydantic_version
+from pandera.errors import SchemaError
 from pandera.typing import DataFrame, Series
 
 try:
@@ -54,6 +55,25 @@ class SeriesSchemaPydantic(BaseModel):
     pa_index: Optional[pa.Index]
 
 
+class AnnotatedDfPydantic(BaseModel):
+    """Test pydantic model with annotated dataframe model."""
+
+    # Required because pandas.DataFrame is not a valid pydantic type. Using
+    # arbitrary_types_allowed=True essentially adds an isinstance check for
+    # the annotated type.
+    if PYDANTIC_V2:
+        from pydantic import ConfigDict
+
+        model_config: ClassVar[ConfigDict] = ConfigDict(
+            arbitrary_types_allowed=True
+        )
+        df: Annotated[pd.DataFrame, SimpleSchema]
+    else:
+
+        class Config:
+            arbitrary_types_allowed = True
+
+
 def test_typed_dataframe():
     """Test that typed DataFrame is compatible with pydantic."""
     valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
@@ -62,6 +82,16 @@ def test_typed_dataframe():
     invalid_df = pd.DataFrame({"str_col": ["hello", "hello"]})
     with pytest.raises(ValidationError):
         TypedDfPydantic(df=invalid_df)
+
+
+def test_annotated_dataframe_model():
+    """Test that annotated DataFrame is compatible with pydantic."""
+    valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
+    assert isinstance(AnnotatedDfPydantic(df=valid_df), AnnotatedDfPydantic)
+
+    invalid_df = pd.DataFrame({"str_col": ["hello", "hello"]})
+    with pytest.raises(SchemaError):
+        AnnotatedDfPydantic(df=invalid_df)  # right type, wrong schema
 
 
 @pytest.mark.skipif(
@@ -86,6 +116,16 @@ def test_invalid_typed_dataframe():
     # This check prevents Linters from raising an error about not using the PydanticModel class
     with pytest.raises(UnboundLocalError):
         PydanticModel(pa_schema=InvalidSchema)
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 cannot catch the invalid dataframe model error",
+)
+def test_invalid_annotated_dataframe():
+    """Test that an invalid annotated DataFrame is recognized by pandera."""
+    with pytest.raises(ValidationError):
+        AnnotatedDfPydantic(df=1)
 
 
 def test_dataframemodel():

--- a/tests/core/test_pydantic.py
+++ b/tests/core/test_pydantic.py
@@ -1,7 +1,7 @@
 """Unit tests for pydantic compatibility."""
 
 # pylint:disable=too-few-public-methods,missing-class-docstring
-from typing import Annotated, ClassVar, Optional
+from typing import Annotated, Optional
 
 import pandas as pd
 import pytest
@@ -55,23 +55,27 @@ class SeriesSchemaPydantic(BaseModel):
     pa_index: Optional[pa.Index]
 
 
-class AnnotatedDfPydantic(BaseModel):
-    """Test pydantic model with annotated dataframe model."""
+if PYDANTIC_V2:
+    from pydantic import ConfigDict
 
-    # Required because pandas.DataFrame is not a valid pydantic type. Using
-    # arbitrary_types_allowed=True essentially adds an isinstance check for
-    # the annotated type.
-    if PYDANTIC_V2:
-        from pydantic import ConfigDict
+    class AnnotatedDfPydantic(BaseModel):  # type: ignore[no-redef]
+        """Test pydantic model with annotated dataframe model."""
 
-        model_config: ClassVar[ConfigDict] = ConfigDict(
-            arbitrary_types_allowed=True
-        )
+        # arbitrary_types_allowed=True required for pandas.DataFrame
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
         df: Annotated[pd.DataFrame, SimpleSchema]
-    else:
 
+else:
+
+    class AnnotatedDfPydantic(BaseModel):  # type: ignore[no-redef]
+        """Test pydantic model with annotated dataframe model."""
+
+        # arbitrary_types_allowed=True required for pandas.DataFrame
         class Config:
             arbitrary_types_allowed = True
+
+        df: Annotated[pd.DataFrame, SimpleSchema]
 
 
 def test_typed_dataframe():


### PR DESCRIPTION
Hi - this is an attempt to add preliminary schema validation via `Annotated` metadata (#1333). This PR, in it's current form, alters the `__get_pydantic_core_schema__` method of `DataFrameModel` to allow for metadata validation in a pydantic context. For example:

```python
from typing import Annotated

import pandas as pd
import pandera as pa
from pandera.typing import Series
from pydantic import BaseModel
from pydantic import ConfigDict
from pydantic import validate_call


class SimpleSchema(pa.DataFrameModel):
    str_col: Series[str] = pa.Field(unique=True)

df = pd.DataFrame({"str_col": ["hello", "world"]})


# NOTE: arbitrary_types_allowed required becuase pd.DataFrame
# is not a recognized pydantic type
config = ConfigDict(arbitrary_types_allowed=True)


# Case 1. Using pydanitc.BaseModel

class AnnotatedDataframe(BaseModel):
    model_config = config
    df: Annotated[pd.DataFrame, SimpleSchema]

model = AnnotatedDataframe(df=df)  # No type error!


# Case 2. Using pydanitc.validate_call

@validate_call(config=config, validate_return=True)
def process(
    df: Annotated[pd.DataFrame, SimpleSchema]
) -> Annotated[pd.DataFrame, SimpleSchema]:
    return df.dropna()  # No type error!

filtered_df = process(df)
```

The benefit of this approach is that `AnnotatedDataframe(df=df)` and `df.dropna()` pass type checkers without resorting to a (mypy-only) plugin.

Note that this PR, currently, does *not* address changes to `check_types`. If there is interest in this PR being merged, I would be happy to contribute additional changes to `check_types`. My idea was to use the information already available in `pandera.typing.AnnotationInfo` and create a support for `Annotated[DataFrame, Schema]` in additional to the current `DataFrame[Schema]`. Either way, just let me know - Thanks!