### PR TITLE
Fix: 1933 - @pa.dataframe_check pass the check_args to the class method

### DIFF
--- a/pandera/api/base/model_components.py
+++ b/pandera/api/base/model_components.py
@@ -136,8 +136,8 @@ class BaseCheckInfo:  # pylint:disable=too-few-public-methods
                 self.check_fn, "__name__", self.check_fn.__class__.__name__
             )
 
-        def _adapter(arg: Any) -> Union[bool, Iterable[bool]]:
-            return self.check_fn(model_cls, arg)
+        def _adapter(arg: Any, **kwargs) -> Union[bool, Iterable[bool]]:
+            return self.check_fn(model_cls, arg, **kwargs)
 
         return Check(_adapter, name=name, **self.check_kwargs)
 


### PR DESCRIPTION
Fixes #1933 

Everything was wired up already to support passing the check_args it was just missing the last little bit. Provided a test that shows validation reuse while providing different params. Might be a bit overkill and can simplify if needed but was trying to show one possible use case.