### PR TITLE
Bugfix/fix pandera compatibility with fastapi

### DIFF
--- a/docs/source/fastapi.md
+++ b/docs/source/fastapi.md
@@ -48,7 +48,7 @@ Next we'll create a FastAPI app and define a `/transactions/` POST endpoint:
 
 ```{literalinclude} ../../tests/fastapi/app.py
 :language: python
-:lines: 3,6,15-16,23-28
+:lines: 2-6,14-21,28-34
 ```
 
 ## Reading File Uploads
@@ -77,7 +77,7 @@ and the modified data in json format.
 
 ```{literalinclude} ../../tests/fastapi/app.py
 :language: python
-:lines: 7,30-38
+:lines: 37-44
 ```
 
 Pandera's {py:class}`~pandera.typing.fastapi.UploadFile` type is a subclass of FastAPI's

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -218,6 +218,11 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 return core_schema.no_info_plain_validator_function(
                     function,
                     json_schema_input_schema=json_schema_input_schema,
+                    serialization=core_schema.plain_serializer_function_ser_schema(
+                        function=lambda df: df,
+                        info_arg=False,
+                        return_schema=json_schema_input_schema,
+                    ),
                 )
             except TypeError:
                 return core_schema.no_info_plain_validator_function(function)


### PR DESCRIPTION
Update to [pydantic-core](https://github.com/pydantic/pydantic-core/commit/98bc1e2a380344a5157824f9e5659e7a040b1ea4) requires additional parameter `serialization` in `core_schema.no_info_plain_validator_function` function to be compatible with fastapi. 

I also updated [pandera fastapi docs page](https://pandera.readthedocs.io/en/stable/fastapi.html#fastapi-integration). Now page presents correct code lines so examples can be replicated.