### PR TITLE
Fix exit-0 issue in pandera.__init__

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,17 +1,32 @@
 # pylint: disable=wrong-import-position
 """A flexible and expressive dataframe validation library."""
 
-import sys
+
+from logging import getLogger
 
 from pandera._version import __version__
 
+
+log = getLogger(__name__)
+
+
 try:
+    #  Only add pandas to the pandera namespace
+    #  if pandas and numpy are installed
     import pandas as pd
-except ImportError:
-    sys.exit(0)
+    import numpy as np
 
+    from pandera.pandas import *
+    from pandera.pandas import __all__
+    __all__.append("__version__")
 
-from pandera.pandas import *
-from pandera.pandas import __all__
+except ImportError as err:
+    if 'pandas' or 'numpy' in str(err):
+        log.warn(
+            'Pandas and Numpy are required for this version of pandera.',
+            err,
+        )
+    else:
+        raise  # Re-raise any other `ImportError` exceptions
 
-__all__.append("__version__")
+    __all__ = ["__version__", ]

--- a/pandera/pandas.py
+++ b/pandera/pandas.py
@@ -35,7 +35,15 @@ warnings.warn(
     "`import pandera.pandas as pa`.",
     FutureWarning,
 )
-
+warnings.warn(
+    "The default dependency on Pandas is deprecated,"
+    " and will be removed soon."
+    " If your project depends on pandas, ensure that you include it"
+    " as an explicit dependency."
+    " Pandera now provides an optional extra pandera[pandas]"
+    " which is recomended when using pandera for pandas.",
+    FutureWarning,
+)
 
 from pandera._patch_numpy2 import _patch_numpy2
 


### PR DESCRIPTION
These changes remove the `sys.exit(0)` call, from the pandas import exception handler.

This protects the import of pandera.pandas symbols, and their addition to the pandera namespace, in a try block, so they will only be included in the namespace when pandas, and numpy are able to be imported.

Log a warning if the import for pandas or numpy fails.