### PR TITLE
Import for _version to get generated version

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -75,7 +75,11 @@ from pandera.engines.pandas_engine import (
     pandas_version,
 )
 from pandera.schema_inference.pandas import infer_schema
-from pandera.version import __version__
+
+try:
+    from pandera._version import __version__
+except ImportError:
+    from pandera.version import __version__
 
 if platform.system() != "Windows":
     # pylint: disable=ungrouped-imports


### PR DESCRIPTION
Fixes https://github.com/unionai-oss/pandera/issues/1939

The version file is already generated during build time:

https://github.com/unionai-oss/pandera/blob/82825c2003ae22c8a73074b4c68a7d9bec33a38a/pyproject.toml#L5-L6

To test this PR run (to trigger the build system and build `_version.py`):

```bash
pip install -e . --config-settings editable_mode=compat
```

And then:

```python
from pandera import __version__
print(__version__)
```