### PR TITLE
Fix inconsistent column filtering in Polars backend with `add_missing_columns`

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -359,8 +359,10 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
 
         # Get columns present in df but not in schema
         cols_not_in_schema = [
-            col for col in check_obj.collect_schema().names()
-            if col not in schema.columns]
+            col
+            for col in check_obj.collect_schema().names()
+            if col not in schema.columns
+        ]
 
         # Set column order
         check_obj = check_obj.select([*schema.columns, *cols_not_in_schema])

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -357,8 +357,13 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             **{k: v.default for k, v in missing_cols_schema.items()}
         ).cast({k: v.dtype.type for k, v in missing_cols_schema.items()})
 
+        # Get columns present in df but not in schema
+        cols_not_in_schema = [
+            col for col in check_obj.collect_schema().names()
+            if col not in schema.columns]
+
         # Set column order
-        check_obj = check_obj.select([*schema.columns])
+        check_obj = check_obj.select([*schema.columns, *cols_not_in_schema])
         return check_obj
 
     def strict_filter_columns(

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -275,5 +275,20 @@ def test_expr_as_default():
         "d": [1, 2, 3],
     }
 
+def test_missing_with_extra_columns():
+    schema = pa.DataFrameSchema(
+        columns={
+            "a": pa.Column(int),
+            "b": pa.Column(float, default=1),
+        },
+        add_missing_columns=True,
+        coerce=True,
+    )
+    df = pl.LazyFrame({"a": [1, 2, 3], "c": [4, 5, 6]})
+    assert schema.validate(df).collect().to_dict(as_series=False) == {
+        "a": [1, 2, 3],
+        "b": [1.0, 1.0, 1.0],
+        "c": [4, 5, 6],
+    }
 
 def test_column_schema_on_lazyframe_coerce(): ...

--- a/tests/polars/test_polars_components.py
+++ b/tests/polars/test_polars_components.py
@@ -275,6 +275,7 @@ def test_expr_as_default():
         "d": [1, 2, 3],
     }
 
+
 def test_missing_with_extra_columns():
     schema = pa.DataFrameSchema(
         columns={
@@ -290,5 +291,6 @@ def test_missing_with_extra_columns():
         "b": [1.0, 1.0, 1.0],
         "c": [4, 5, 6],
     }
+
 
 def test_column_schema_on_lazyframe_coerce(): ...


### PR DESCRIPTION
Fixes https://github.com/unionai-oss/pandera/issues/1960