### PR TITLE
Bugfix/1938 Improve Pandera DataFrame - Pydantic compatibility

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -276,6 +276,8 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 "number": core_schema.float_schema(),
                 "boolean": core_schema.bool_schema(),
                 "datetime": core_schema.datetime_schema(),
+                "duration": core_schema.timedelta_schema(),
+                "any": core_schema.any_schema(),
             }
             function = functools.partial(
                 cls.pydantic_validate,


### PR DESCRIPTION
[__get_pydantic_core_schema__](https://github.com/unionai-oss/pandera/blob/ebbcaf20e1208d1b14ce44b03fe7b3301cd8e888/pandera/typing/pandas.py#L186) function uses [type_map](https://github.com/unionai-oss/pandera/blob/ebbcaf20e1208d1b14ce44b03fe7b3301cd8e888/pandera/typing/pandas.py#L194C13-L194C21) dictionary to convert column types names generated with [pandas table schema](https://pandas.pydata.org/docs/user_guide/io.html#table-schema) to [pydantic serialization types](https://github.com/pydantic/pydantic-core/blob/9a25aa69f88183d06c484775c8cb2c4329368251/python/pydantic_core/core_schema.py#L200) 
Previous declaration lacked two types from pandas table schema 'any' and 'duration', which I added. 

Fixes #1938 