### PR TITLE
add import and future warning for top-level pandera module

### DIFF
--- a/asv_bench/benchmarks/dataframe_schema.py
+++ b/asv_bench/benchmarks/dataframe_schema.py
@@ -1,7 +1,7 @@
 # Airspeed Velocity Benchmarks for pandera
 import pandas as pd
 
-from pandera import (
+from pandera.pandas import (
     Column,
     DataFrameSchema,
     Bool,

--- a/asv_bench/benchmarks/series_schema.py
+++ b/asv_bench/benchmarks/series_schema.py
@@ -1,7 +1,7 @@
 # Airspeed Velocity Benchmarks for pandera
 import pandas as pd
 
-from pandera import (
+from pandera.pandas import (
     Column,
     DataFrameSchema,
     SeriesSchema,

--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -37,7 +37,7 @@ See the {ref}`Mypy Integration <mypy-integration>` for more details.
 ```{code-cell} python
 import pandas as pd
 import pandera.pandas as pa
-from pandera.typing import Index, DataFrame, Series
+from pandera.typing.pandas import Index, DataFrame, Series
 
 
 class InputSchema(pa.DataFrameModel):
@@ -114,7 +114,7 @@ This makes sure that each field attribute is bound to a unique `Field` instance.
 
 ```{code-cell} python
 from functools import partial
-from pandera import DataFrameModel, Field
+from pandera.pandas import DataFrameModel, Field
 
 NormalizedField = partial(Field, ge=0, le=1)
 

--- a/docs/source/dataframe_schemas.md
+++ b/docs/source/dataframe_schemas.md
@@ -19,19 +19,17 @@ The {class}`~pandera.api.pandas.container.DataFrameSchema` object consists of `C
 ```{code-cell} python
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema, Check, Index
-
-schema = DataFrameSchema(
+schema = pa.DataFrameSchema(
     {
-        "column1": Column(int),
-        "column2": Column(float, Check(lambda s: s < -1.2)),
+        "column1": pa.Column(int),
+        "column2": pa.Column(float, pa.Check(lambda s: s < -1.2)),
         # you can provide a list of validators
-        "column3": Column(str, [
-            Check(lambda s: s.str.startswith("value")),
-            Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
+        "column3": pa.Column(str, [
+            pa.Check(lambda s: s.str.startswith("value")),
+            pa.Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
         ]),
     },
-    index=Index(int),
+    index=pa.Index(int),
     strict=True,
     coerce=True,
 )
@@ -90,12 +88,10 @@ import numpy as np
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, Column, DataFrameSchema
-
 df = pd.DataFrame({"column1": [5, 1, np.nan]})
 
-non_null_schema = DataFrameSchema({
-    "column1": Column(float, Check(lambda x: x > 0))
+non_null_schema = pa.DataFrameSchema({
+    "column1": pa.Column(float, pa.Check(lambda x: x > 0))
 })
 
 try:
@@ -107,8 +103,8 @@ except pa.errors.SchemaError as exc:
 Setting `nullable=True` allows for null values in the corresponding column.
 
 ```{code-cell} python
-null_schema = DataFrameSchema({
-    "column1": Column(float, Check(lambda x: x > 0), nullable=True)
+null_schema = pa.DataFrameSchema({
+    "column1": pa.Column(float, pa.Check(lambda x: x > 0), nullable=True)
 })
 
 null_schema.validate(df)
@@ -130,10 +126,8 @@ checks.
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema
-
 df = pd.DataFrame({"column1": [1, 2, 3]})
-schema = DataFrameSchema({"column1": Column(str, coerce=True)})
+schema = pa.DataFrameSchema({"column1": pa.Column(str, coerce=True)})
 
 validated_df = schema.validate(df)
 assert isinstance(validated_df.column1.iloc[0], str)
@@ -147,8 +141,8 @@ and null values are allowed in the column.
 
 ```{code-cell} python
 df = pd.DataFrame({"column1": [1., 2., 3, np.nan]})
-schema = DataFrameSchema({
-    "column1": Column(int, coerce=True, nullable=True)
+schema = pa.DataFrameSchema({
+    "column1": pa.Column(int, coerce=True, nullable=True)
 })
 
 try:
@@ -161,11 +155,11 @@ The best way to handle this case is to simply specify the column as a
 `Float` or `Object`.
 
 ```{code-cell} python
-schema_object = DataFrameSchema({
-    "column1": Column(object, coerce=True, nullable=True)
+schema_object = pa.DataFrameSchema({
+    "column1": pa.Column(object, coerce=True, nullable=True)
 })
-schema_float = DataFrameSchema({
-    "column1": Column(float, coerce=True, nullable=True)
+schema_float = pa.DataFrameSchema({
+    "column1": pa.Column(float, coerce=True, nullable=True)
 })
 
 print(schema_object.validate(df).dtypes)
@@ -191,12 +185,11 @@ in the column constructor:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema
 
 df = pd.DataFrame({"column2": ["hello", "pandera"]})
-schema = DataFrameSchema({
-    "column1": Column(int, required=False),
-    "column2": Column(str)
+schema = pa.DataFrameSchema({
+    "column1": pa.Column(int, required=False),
+    "column2": pa.Column(str)
 })
 
 schema.validate(df)
@@ -205,9 +198,9 @@ schema.validate(df)
 Since `required=True` by default, missing columns would raise an error:
 
 ```{code-cell} python
-schema = DataFrameSchema({
-    "column1": Column(int),
-    "column2": Column(str),
+schema = pa.DataFrameSchema({
+    "column1": pa.Column(int),
+    "column2": pa.Column(str),
 })
 
 try:
@@ -333,10 +326,9 @@ schema, specify `strict=True`:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema
 
-schema = DataFrameSchema(
-    {"column1": Column(int)},
+schema = pa.DataFrameSchema(
+    {"column1": pa.Column(int)},
     strict=True)
 
 df = pd.DataFrame({"column2": [1, 2, 3]})
@@ -355,10 +347,9 @@ you can specify `strict='filter'`.
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema
 
 df = pd.DataFrame({"column1": ["drop", "me"],"column2": ["keep", "me"]})
-schema = DataFrameSchema({"column2": Column(str)}, strict='filter')
+schema = pa.DataFrameSchema({"column2": pa.Column(str)}, strict='filter')
 
 schema.validate(df)
 ```
@@ -482,13 +473,12 @@ You can also specify an {class}`~pandera.api.pandas.components.Index` in the {cl
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema, Index, Check
 
-schema = DataFrameSchema(
-    columns={"a": Column(int)},
-    index=Index(
+schema = pa.DataFrameSchema(
+    columns={"a": pa.Column(int)},
+    index=pa.Index(
         str,
-        Check(lambda x: x.str.startswith("index_"))))
+        pa.Check(lambda x: x.str.startswith("index_"))))
 
 df = pd.DataFrame(
     data={"a": [1, 2, 3]},
@@ -526,11 +516,10 @@ tuples for each level in the index hierarchy:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema, Index
 
-schema = DataFrameSchema({
-    ("foo", "bar"): Column(int),
-    ("foo", "baz"): Column(str)
+schema = pa.DataFrameSchema({
+    ("foo", "bar"): pa.Column(int),
+    ("foo", "baz"): pa.Column(str)
 })
 
 df = pd.DataFrame({
@@ -675,14 +664,13 @@ the pipeline output.
 ```{code-cell} python
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema, Check, Index
 
-schema = DataFrameSchema(
+schema = pa.DataFrameSchema(
     {
-        "column1": Column(int),
-        "column2": Column(float)
+        "column1": pa.Column(int),
+        "column2": pa.Column(float)
     },
-    index=Index(int, name = "column3"),
+    index=pa.Index(int, name = "column3"),
     strict=True,
     coerce=True,
 )

--- a/docs/source/decorators.md
+++ b/docs/source/decorators.md
@@ -25,23 +25,22 @@ function.
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import DataFrameSchema, Column, Check, check_input
-
 
 df = pd.DataFrame({
     "column1": [1, 4, 0, 10, 9],
     "column2": [-1.3, -1.4, -2.9, -10.1, -20.4],
 })
 
-in_schema = DataFrameSchema({
-    "column1": Column(int,
-                        Check(lambda x: 0 <= x <= 10, element_wise=True)),
-    "column2": Column(float, Check(lambda x: x < -1.2)),
+in_schema = pa.DataFrameSchema({
+    "column1": pa.Column(
+        int, pa.Check(lambda x: 0 <= x <= 10, element_wise=True)
+    ),
+    "column2": pa.Column(float, pa.Check(lambda x: x < -1.2)),
 })
 
 # by default, check_input assumes that the first argument is
 # dataframe/series.
-@check_input(in_schema)
+@pa.check_input(in_schema)
 def preprocessor(dataframe):
     dataframe["column3"] = dataframe["column1"] + dataframe["column2"]
     return dataframe
@@ -53,7 +52,7 @@ print(preprocessed_df)
 You can also provide the argument name as a string
 
 ```{code-cell} python
-@check_input(in_schema, "dataframe")
+@pa.check_input(in_schema, "dataframe")
 def preprocessor(dataframe):
     ...
 ```
@@ -61,7 +60,7 @@ def preprocessor(dataframe):
 Or an integer representing the index in the positional arguments.
 
 ```{code-cell} python
-@check_input(in_schema, 1)
+@pa.check_input(in_schema, 1)
 def preprocessor(foo, dataframe):
     ...
 ```
@@ -75,42 +74,40 @@ DataFrame/Series of the decorated function.
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import DataFrameSchema, Column, Check, check_output
-
 
 preprocessed_df = pd.DataFrame({
     "column1": [1, 4, 0, 10, 9],
 })
 
 # assert that all elements in "column1" are zero
-out_schema = DataFrameSchema({
-    "column1": Column(int, Check(lambda x: x == 0))
+out_schema = pa.DataFrameSchema({
+    "column1": pa.Column(int, pa.Check(lambda x: x == 0))
 })
 
 
 # by default assumes that the pandas DataFrame/Schema is the only output
-@check_output(out_schema)
+@pa.check_output(out_schema)
 def zero_column_1(df):
     df["column1"] = 0
     return df
 
 
 # you can also specify in the index of the argument if the output is list-like
-@check_output(out_schema, 1)
+@pa.check_output(out_schema, 1)
 def zero_column_1_arg(df):
     df["column1"] = 0
     return "foobar", df
 
 
 # or the key containing the data structure to verify if the output is dict-like
-@check_output(out_schema, "out_df")
+@pa.check_output(out_schema, "out_df")
 def zero_column_1_dict(df):
     df["column1"] = 0
     return {"out_df": df, "out_str": "foobar"}
 
 
 # for more complex outputs, you can specify a function
-@check_output(out_schema, lambda x: x[1]["out_df"])
+@pa.check_output(out_schema, lambda x: x[1]["out_df"])
 def zero_column_1_custom(df):
     df["column1"] = 0
     return ("foobar", {"out_df": df})
@@ -131,20 +128,18 @@ decorator where you can specify input and output schemas more concisely:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import DataFrameSchema, Column, Check, check_input
-
 
 df = pd.DataFrame({
     "column1": [1, 4, 0, 10, 9],
     "column2": [-1.3, -1.4, -2.9, -10.1, -20.4],
 })
 
-in_schema = DataFrameSchema({
-    "column1": Column(int),
-    "column2": Column(float),
+in_schema = pa.DataFrameSchema({
+    "column1": pa.Column(int),
+    "column2": pa.Column(float),
 })
 
-out_schema = in_schema.add_columns({"column3": Column(float)})
+out_schema = in_schema.add_columns({"column3": pa.Column(float)})
 
 @pa.check_io(df1=in_schema, df2=in_schema, out=out_schema)
 def preprocessor(df1, df2):

--- a/docs/source/drop_invalid_rows.md
+++ b/docs/source/drop_invalid_rows.md
@@ -31,11 +31,10 @@ Dropping invalid rows with {class}`~pandera.api.pandas.container.DataFrameSchema
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, Column, DataFrameSchema
 
 df = pd.DataFrame({"counter": ["1", "2", "3"]})
-schema = DataFrameSchema(
-    {"counter": Column(int, checks=[Check(lambda x: x >= 3)])},
+schema = pa.DataFrameSchema(
+    {"counter": pa.Column(int, checks=[pa.Check(lambda x: x >= 3)])},
     drop_invalid_rows=True,
 )
 
@@ -48,12 +47,11 @@ Dropping invalid rows with {class}`~pandera.api.pandas.array.SeriesSchema`:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, SeriesSchema
 
 series = pd.Series(["1", "2", "3"])
-schema = SeriesSchema(
+schema = pa.SeriesSchema(
     int,
-    checks=[Check(lambda x: x >= 3)],
+    checks=[pa.Check(lambda x: x >= 3)],
     drop_invalid_rows=True,
 )
 
@@ -66,14 +64,13 @@ Dropping invalid rows with {class}`~pandera.api.pandas.components.Column`:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, Column
 
 df = pd.DataFrame({"counter": ["1", "2", "3"]})
-schema = Column(
+schema = pa.Column(
     int,
     name="counter",
     drop_invalid_rows=True,
-    checks=[Check(lambda x: x >= 3)]
+    checks=[pa.Check(lambda x: x >= 3)]
 )
 
 schema.validate(df, lazy=True)
@@ -85,10 +82,9 @@ Dropping invalid rows with {class}`~pandera.api.pandas.model.DataFrameModel`:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, DataFrameModel, Field
 
-class MySchema(DataFrameModel):
-    counter: int = Field(in_range={"min_value": 3, "max_value": 5})
+class MySchema(pa.DataFrameModel):
+    counter: int = pa.Field(in_range={"min_value": 3, "max_value": 5})
 
     class Config:
         drop_invalid_rows = True

--- a/docs/source/fugue.md
+++ b/docs/source/fugue.md
@@ -61,10 +61,11 @@ Validation is then applied using pandera. A `price_validation` function is
 created that runs the validation. None of this will be new.
 
 ```{code-cell} python
-from pandera import Column, DataFrameSchema, Check
+import pandera.pandas as pa
 
-price_check = DataFrameSchema(
-    {"price": Column(int, Check.in_range(min_value=5,max_value=20))}
+
+price_check = pa.DataFrameSchema(
+    {"price": pa.Column(int, pa.Check.in_range(min_value=5,max_value=20))}
 )
 
 def price_validation(data: pd.DataFrame) -> pd.DataFrame:
@@ -112,12 +113,12 @@ Two {class}`~pandera.api.pandas.container.DataFrameSchema` will be created to re
 for the {class}`~pandera.api.checks.Check` differ.
 
 ```{code-cell} python
-price_check_FL = DataFrameSchema({
-    "price": Column(int, Check.in_range(min_value=7,max_value=13)),
+price_check_FL = pa.DataFrameSchema({
+    "price": pa.Column(int, pa.Check.in_range(min_value=7,max_value=13)),
 })
 
-price_check_CA = DataFrameSchema({
-    "price": Column(int, Check.in_range(min_value=15,max_value=21)),
+price_check_CA = pa.DataFrameSchema({
+    "price": pa.Column(int, pa.Check.in_range(min_value=15,max_value=21)),
 })
 
 price_checks = {'CA': price_check_CA, 'FL': price_check_FL}
@@ -133,17 +134,19 @@ through the `partition` argument. This splits up the data across different worke
 each run the `price_validation` function. Again, this is like a groupby-validation.
 
 ```python
-def price_validation(df:pd.DataFrame) -> pd.DataFrame:
+def price_validation(df: pd.DataFrame) -> pd.DataFrame:
     location = df['state'].iloc[0]
     check = price_checks[location]
     check.validate(df)
     return df
 
-spark_df = transform(data,
-            price_validation,
-            schema="*",
-            partition=dict(by="state"),
-            engine=spark)
+spark_df = transform(
+    data,
+    price_validation,
+    schema="*",
+    partition=dict(by="state"),
+    engine=spark,
+)
 
 spark_df.show()
 ```
@@ -188,8 +191,8 @@ check_number:int, failure_case:str, index:int"
 out_columns = ["schema_context", "column", "check",
 "check_number", "failure_case", "index"]
 
-price_check = DataFrameSchema(
-    {"price": Column(int, Check.in_range(min_value=12,max_value=20))}
+price_check = pa.DataFrameSchema(
+    {"price": pa.Column(int, pa.Check.in_range(min_value=12,max_value=20))}
 )
 
 def price_validation(data:pd.DataFrame) -> pd.DataFrame:

--- a/docs/source/hypothesis.md
+++ b/docs/source/hypothesis.md
@@ -28,7 +28,6 @@ which can be called as in this example of a two-sample t-test:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Column, DataFrameSchema, Check, Hypothesis
 
 from scipy import stats
 
@@ -39,10 +38,10 @@ df = (
     })
 )
 
-schema = DataFrameSchema({
-    "height_in_feet": Column(
+schema = pa.DataFrameSchema({
+    "height_in_feet": pa.Column(
         float, [
-            Hypothesis.two_sample_ttest(
+            pa.Hypothesis.two_sample_ttest(
                 sample1="M",
                 sample2="F",
                 groupby="sex",
@@ -50,7 +49,7 @@ schema = DataFrameSchema({
                 alpha=0.05,
                 equal_var=True),
     ]),
-    "sex": Column(str)
+    "sex": pa.Column(str)
 })
 
 try:
@@ -86,10 +85,10 @@ def null_relationship(stat, pvalue, alpha=0.01):
     return pvalue / 2 >= alpha
 
 
-schema = DataFrameSchema({
-    "height_in_feet": Column(
+schema = pa.DataFrameSchema({
+    "height_in_feet": pa.Column(
         float, [
-            Hypothesis(
+            pa.Hypothesis(
                 test=two_sample_ttest,
                 samples=["M", "F"],
                 groupby="sex",
@@ -97,7 +96,7 @@ schema = DataFrameSchema({
                 relationship_kwargs={"alpha": 0.05}
             )
     ]),
-    "sex": Column(str, checks=Check.isin(["M", "F"]))
+    "sex": pa.Column(str, checks=pa.Check.isin(["M", "F"]))
 })
 
 schema.validate(df)
@@ -119,23 +118,22 @@ the tidy dataset and schema might look like this:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, DataFrameSchema, Column, Hypothesis
 
 df = pd.DataFrame({
     "height": [5.6, 7.5, 4.0, 7.9],
     "group": ["A", "B", "A", "B"],
 })
 
-schema = DataFrameSchema({
-    "height": Column(
-        float, Hypothesis.two_sample_ttest(
+schema = pa.DataFrameSchema({
+    "height": pa.Column(
+        float, pa.Hypothesis.two_sample_ttest(
             "A", "B",
             groupby="group",
             relationship="less_than",
             alpha=0.05
         )
     ),
-    "group": Column(str, Check(lambda s: s.isin(["A", "B"])))
+    "group": pa.Column(str, pa.Check(lambda s: s.isin(["A", "B"])))
 })
 
 schema.validate(df)
@@ -147,20 +145,19 @@ The equivalent wide-form schema would look like this:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import DataFrameSchema, Column, Hypothesis
 
 df = pd.DataFrame({
     "height_A": [5.6, 4.0],
     "height_B": [7.5, 7.9],
 })
 
-schema = DataFrameSchema(
+schema = pa.DataFrameSchema(
     columns={
-        "height_A": Column(float),
-        "height_B": Column(float),
+        "height_A": pa.Column(float),
+        "height_B": pa.Column(float),
     },
     # define checks at the DataFrameSchema-level
-    checks=Hypothesis.two_sample_ttest(
+    checks=pa.Hypothesis.two_sample_ttest(
         "height_A", "height_B",
         relationship="less_than",
         alpha=0.05

--- a/docs/source/lazy_validation.md
+++ b/docs/source/lazy_validation.md
@@ -31,11 +31,10 @@ For example:
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, Column, DataFrameSchema
 
 df = pd.DataFrame({"column": ["a", "b", "c"]})
 
-schema = pa.DataFrameSchema({"column": Column(int)})
+schema = pa.DataFrameSchema({"column": pa.Column(int)})
 
 try:
     schema.validate(df)
@@ -54,14 +53,13 @@ import json
 import pandas as pd
 import pandera.pandas as pa
 
-from pandera import Check, Column, DataFrameSchema
 
 schema = pa.DataFrameSchema(
     columns={
-        "int_column": Column(int),
-        "float_column": Column(float, Check.greater_than(0)),
-        "str_column": Column(str, Check.equal_to("a")),
-        "date_column": Column(pa.DateTime),
+        "int_column": pa.Column(int),
+        "float_column": pa.Column(float, pa.Check.greater_than(0)),
+        "str_column": pa.Column(str, pa.Check.equal_to("a")),
+        "date_column": pa.Column(pa.DateTime),
     },
     strict=True
 )

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,8 @@ dependencies:
 
   # pandera dependencies
   - packaging >= 20.0
+  - rich
+  - typing_extensions
   - hypothesis >= 6.92.7
   - pyyaml >= 5.1
   - typing_inspect >= 0.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
 
   # pandera dependencies
   - packaging >= 20.0
-  - rich
   - typing_extensions
   - hypothesis >= 6.92.7
   - pyyaml >= 5.1

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,14 +1,7 @@
 # pylint: disable=wrong-import-position
 """A flexible and expressive dataframe validation library."""
 
-from rich.console import Console
-from rich.panel import Panel
-from rich.markdown import Markdown
-
 from pandera._version import __version__
-
-
-console = Console()
 
 
 _warning_msg = """Pandas and numpy have been removed from the base pandera
@@ -41,15 +34,10 @@ try:
     ]
 
 except ImportError as err:
+    import warnings
+
     if "pandas" in str(err) or "numpy" in str(err):
-        console.print(
-            Panel(
-                Markdown(_warning_msg),
-                title="PandasImportWarning",
-                border_style="yellow",
-            )
-        )
-        console.print_exception()
+        warnings.warn(_warning_msg, UserWarning)
     else:
         raise  # Re-raise any other `ImportError` exceptions
 

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -1,35 +1,55 @@
 # pylint: disable=wrong-import-position
 """A flexible and expressive dataframe validation library."""
 
-from logging import getLogger
-import warnings
+from rich.console import Console
+from rich.panel import Panel
+from rich.markdown import Markdown
+
 from pandera._version import __version__
 
 
-log = getLogger(__name__)
+console = Console()
+
+
+_warning_msg = """Pandas and numpy have been removed from the base pandera
+dependencies. Please install pandas as part of your environment's
+dependencies or install the pandas extra with:
+
+```bash
+pip install pandas pandera
+
+# or
+pip install 'pandera[pandas]'
+```
+"""
 
 
 try:
-    # Only add pandas to the pandera namespace
+    # Only add pandas to the top-level pandera namespace
     # if pandas and numpy are installed
     import pandas as pd
     import numpy as np
 
-    from pandera.pandas import *
-    from pandera.pandas import __all__ as __all_pandas
+    from pandera._pandas_deprecated import *
+    from pandera._pandas_deprecated import __all__ as _pandas_deprecated_all
     from pandera import dtypes
     from pandera import typing
 
     __all__ = [
         "__version__",
-        *__all_pandas,
+        *_pandas_deprecated_all,
     ]
 
 except ImportError as err:
     if "pandas" in str(err) or "numpy" in str(err):
-        log.warning(
-            f"Pandas and Numpy are required for this version of pandera. {err}",
+        console.print(
+            Panel(
+                Markdown(_warning_msg),
+                title="PandasImportWarning",
+                border_style="yellow",
+            )
         )
+        console.print_exception()
     else:
         raise  # Re-raise any other `ImportError` exceptions
 

--- a/pandera/_pandas_deprecated.py
+++ b/pandera/_pandas_deprecated.py
@@ -1,10 +1,17 @@
 # pylint: disable=wrong-import-position,unused-import
-"""A flexible and expressive pandas dataframe validation library."""
+"""A flexible and expressive pandas dataframe validation library.
 
+This module is imported by the top-level pandera module and will be deprecated
+in a future version of pandera.
+"""
+
+import os
 import platform
-import warnings
 
 from packaging.version import parse
+from rich.console import Console
+from rich.panel import Panel
+from rich.markdown import Markdown
 
 import pandas as pd
 import numpy as np
@@ -46,8 +53,8 @@ from pandera.api.dataframe.model_components import (
 from pandera.api.hypotheses import Hypothesis
 from pandera.api.pandas.array import SeriesSchema
 from pandera.api.pandas.components import Column, Index, MultiIndex
-from pandera.api.pandas.container import DataFrameSchema
-from pandera.api.pandas.model import DataFrameModel
+from pandera.api.pandas.container import DataFrameSchema as _DataFrameSchema
+from pandera.api.pandas.model import DataFrameModel as _DataFrameModel
 from pandera.api.parsers import Parser
 from pandera.decorators import check_input, check_io, check_output, check_types
 from pandera.dtypes import (
@@ -96,6 +103,69 @@ from pandera.engines.pandas_engine import (
     pandas_version,
 )
 from pandera.schema_inference.pandas import infer_schema
+
+
+console = Console()
+
+
+_future_warning = """Importing pandas-specific classes and functions from the
+top-level pandera module will be **removed in a future version of pandera**.
+If you're using pandera to validate pandas objects, we highly recommend updating
+your import:
+
+```python
+# old import
+import pandera as pa
+
+# new import
+import pandera.pandas as pa
+```
+
+If you're using pandera to validate objects from other compatible libraries
+like pyspark or polars, see the [supported libraries](https://pandera.readthedocs.io/en/stable/supported_libraries.html)
+section of the documentation for more information on how to import pandera.
+
+To disable this warning, set the environment variable:
+
+```bash
+export DISABLE_PANDERA_IMPORT_WARNING=True
+```
+"""
+
+
+DISABLE_PANDERA_IMPORT_WARNING = (
+    os.environ.get("DISABLE_PANDERA_IMPORT_WARNING", "false").lower() == "true"
+)
+
+
+class DataFrameSchema(_DataFrameSchema):
+    """A light-weight pandas DataFrame validator."""
+
+    def __init__(self, *args, **kwargs):
+        if not DISABLE_PANDERA_IMPORT_WARNING:
+            console.print(
+                Panel(
+                    Markdown(_future_warning),
+                    title="FutureWarning",
+                    border_style="yellow",
+                )
+            )
+        super().__init__(*args, **kwargs)
+
+
+class DataFrameModel(_DataFrameModel):
+    """A DataFrameModel to express class-based pandera schemas."""
+
+    def __init_subclass__(cls, **kwargs):
+        if not DISABLE_PANDERA_IMPORT_WARNING:
+            console.print(
+                Panel(
+                    Markdown(_future_warning),
+                    title="FutureWarning",
+                    border_style="yellow",
+                )
+            )
+        super().__init_subclass__(**kwargs)
 
 
 external_config._set_pyspark_environment_variables()

--- a/pandera/_pandas_deprecated.py
+++ b/pandera/_pandas_deprecated.py
@@ -1,4 +1,4 @@
-# pylint: disable=wrong-import-position,unused-import
+# pylint: disable=wrong-import-position,unused-import,global-statement,unused-wildcard-import
 """A flexible and expressive pandas dataframe validation library.
 
 This module is imported by the top-level pandera module and will be deprecated
@@ -7,11 +7,9 @@ in a future version of pandera.
 
 import os
 import platform
+import warnings
 
 from packaging.version import parse
-from rich.console import Console
-from rich.panel import Panel
-from rich.markdown import Markdown
 
 import pandas as pd
 import numpy as np
@@ -105,15 +103,12 @@ from pandera.engines.pandas_engine import (
 from pandera.schema_inference.pandas import infer_schema
 
 
-console = Console()
-
-
 _future_warning = """Importing pandas-specific classes and functions from the
 top-level pandera module will be **removed in a future version of pandera**.
 If you're using pandera to validate pandas objects, we highly recommend updating
 your import:
 
-```python
+```
 # old import
 import pandera as pa
 
@@ -122,12 +117,14 @@ import pandera.pandas as pa
 ```
 
 If you're using pandera to validate objects from other compatible libraries
-like pyspark or polars, see the [supported libraries](https://pandera.readthedocs.io/en/stable/supported_libraries.html)
-section of the documentation for more information on how to import pandera.
+like pyspark or polars, see the supported libraries section of the documentation
+for more information on how to import pandera:
+
+https://pandera.readthedocs.io/en/stable/supported_libraries.html
 
 To disable this warning, set the environment variable:
 
-```bash
+```
 export DISABLE_PANDERA_IMPORT_WARNING=True
 ```
 """
@@ -137,19 +134,17 @@ DISABLE_PANDERA_IMPORT_WARNING = (
     os.environ.get("DISABLE_PANDERA_IMPORT_WARNING", "false").lower() == "true"
 )
 
+_IMPORT_WARNING_ISSUED = False
+
 
 class DataFrameSchema(_DataFrameSchema):
     """A light-weight pandas DataFrame validator."""
 
     def __init__(self, *args, **kwargs):
-        if not DISABLE_PANDERA_IMPORT_WARNING:
-            console.print(
-                Panel(
-                    Markdown(_future_warning),
-                    title="FutureWarning",
-                    border_style="yellow",
-                )
-            )
+        global _IMPORT_WARNING_ISSUED
+        if not DISABLE_PANDERA_IMPORT_WARNING and not _IMPORT_WARNING_ISSUED:
+            warnings.warn(_future_warning, FutureWarning)
+            _IMPORT_WARNING_ISSUED = True
         super().__init__(*args, **kwargs)
 
 
@@ -157,14 +152,10 @@ class DataFrameModel(_DataFrameModel):
     """A DataFrameModel to express class-based pandera schemas."""
 
     def __init_subclass__(cls, **kwargs):
-        if not DISABLE_PANDERA_IMPORT_WARNING:
-            console.print(
-                Panel(
-                    Markdown(_future_warning),
-                    title="FutureWarning",
-                    border_style="yellow",
-                )
-            )
+        global _IMPORT_WARNING_ISSUED
+        if not DISABLE_PANDERA_IMPORT_WARNING and not _IMPORT_WARNING_ISSUED:
+            warnings.warn(_future_warning, FutureWarning)
+            _IMPORT_WARNING_ISSUED = True
         super().__init_subclass__(**kwargs)
 
 

--- a/pandera/backends/pandas/register.py
+++ b/pandera/backends/pandas/register.py
@@ -42,6 +42,12 @@ def register_pandas_backends(
     from pandera.api.parsers import Parser
     from pandera.api.pandas.types import get_backend_types
 
+    # NOTE: This registers the deprecated DataFrameSchema class. Remove this
+    # once the deprecated class is removed.
+    from pandera._pandas_deprecated import (
+        DataFrameSchema as _DataFrameSchemaDeprecated,
+    )
+
     assert check_cls_fqn is not None, (
         "pandas backend registration requires passing in the fully qualified "
         "check class name"
@@ -57,6 +63,7 @@ def register_pandas_backends(
 
     for t in backend_types.dataframe_datatypes:
         DataFrameSchema.register_backend(t, DataFrameSchemaBackend)
+        _DataFrameSchemaDeprecated.register_backend(t, DataFrameSchemaBackend)
         Column.register_backend(t, ColumnBackend)
         MultiIndex.register_backend(t, MultiIndexBackend)
         Index.register_backend(t, IndexBackend)

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -280,7 +280,7 @@ def deserialize_schema(serialized_schema):
         the schema de-serialized into :class:`~pandera.api.pandas.container.DataFrameSchema`
     """
     # pylint: disable=import-outside-toplevel
-    from pandera import Index, MultiIndex
+    from pandera.pandas import Index, MultiIndex
 
     # GH#475
     serialized_schema = serialized_schema if serialized_schema else {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ classifiers = [
 dependencies = [
     "packaging >= 20.0",
     "pydantic",
+    "rich",
     "typeguard",
+    "typing_extensions",
     "typing_inspect >= 0.6.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 dependencies = [
     "packaging >= 20.0",
     "pydantic",
-    "rich",
     "typeguard",
     "typing_extensions",
     "typing_inspect >= 0.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@
 
 pip
 packaging >= 20.0
+rich
+typing_extensions
 hypothesis >= 6.92.7
 pyyaml >= 5.1
 typing_inspect >= 0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 
 pip
 packaging >= 20.0
-rich
 typing_extensions
 hypothesis >= 6.92.7
 pyyaml >= 5.1

--- a/tests/pandas/test__pandas_deprecated__test_model.py
+++ b/tests/pandas/test__pandas_deprecated__test_model.py
@@ -1,0 +1,20 @@
+# pylint: disable=wrong-import-position,wildcard-import,unused-wildcard-import
+"""Unit tests for the deprecated top-level pandera DataFrameModel class.
+
+Delete this file once the top-level pandera._pandas_deprecated module is
+removed.
+"""
+
+import pytest
+from pandera._pandas_deprecated import DataFrameModel as _DataFrameModel
+
+
+@pytest.fixture(autouse=True)
+def monkeypatch_dataframe_model(monkeypatch):
+    """Monkeypatch DataFrameModel before importing test_schemas"""
+    monkeypatch.setattr(
+        "tests.pandas.test_schemas.DataFrameModel", _DataFrameModel
+    )
+
+
+from tests.pandas.test_schemas import *

--- a/tests/pandas/test__pandas_deprecated__test_schemas.py
+++ b/tests/pandas/test__pandas_deprecated__test_schemas.py
@@ -1,0 +1,20 @@
+# pylint: disable=wrong-import-position,wildcard-import,unused-wildcard-import
+"""Unit tests for the deprecated top-level pandera DataFrameSchema class.
+
+Delete this file once the top-level pandera._pandas_deprecated module is
+removed.
+"""
+
+import pytest
+from pandera._pandas_deprecated import DataFrameSchema as _DataFrameSchema
+
+
+@pytest.fixture(autouse=True)
+def monkeypatch_dataframe_schema(monkeypatch):
+    """Monkeypatch DataFrameSchema before importing test_schemas"""
+    monkeypatch.setattr(
+        "tests.pandas.test_schemas.DataFrameSchema", _DataFrameSchema
+    )
+
+
+from tests.pandas.test_schemas import *

--- a/tests/pandas/test_checks.py
+++ b/tests/pandas/test_checks.py
@@ -5,7 +5,7 @@ import copy
 import pandas as pd
 import pytest
 
-from pandera import (
+from pandera.pandas import (
     Bool,
     Check,
     Column,

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera import (
+from pandera.pandas import (
     Check,
     Column,
     DataFrameModel,

--- a/tests/pandas/test_errors.py
+++ b/tests/pandas/test_errors.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera import Check, Column, DataFrameSchema
+from pandera.pandas import Check, Column, DataFrameSchema
 from pandera.config import ValidationDepth, config_context
 from pandera.engines import numpy_engine, pandas_engine
 from pandera.errors import (

--- a/tests/pandas/test_pandas_config.py
+++ b/tests/pandas/test_pandas_config.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import pandera.pandas as pa
-from pandera import DataFrameModel, DataFrameSchema, SeriesSchema
+from pandera.pandas import DataFrameModel, DataFrameSchema, SeriesSchema
 from pandera.config import ValidationDepth, config_context, get_config_context
 
 

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -13,7 +13,7 @@ import pytest
 import pytz
 from hypothesis import given
 
-from pandera import Field, DataFrameModel, errors
+from pandera.pandas import Field, DataFrameModel, errors
 from pandera.engines import pandas_engine
 from pandera.errors import ParserError, SchemaError
 

--- a/tests/pandas/test_pandas_parallel.py
+++ b/tests/pandas/test_pandas_parallel.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from joblib import Parallel, delayed
 
-from pandera import Column, DataFrameSchema
+from pandera.pandas import Column, DataFrameSchema
 
 schema = DataFrameSchema({"a": Column("int64")}, coerce=True)
 

--- a/tests/pandas/test_schema_components.py
+++ b/tests/pandas/test_schema_components.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera import (
+from pandera.pandas import (
     Check,
     Column,
     DataFrameSchema,

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera import (
+from pandera.pandas import (
     Category,
     Check,
     Column,


### PR DESCRIPTION
This PR:
- Adds a print warning if a user is trying to `import pandera as pa` but doesn't have `pandas` installed in their environment. This let's users who depend on `pandas` as a transitive dependency of `pandera`.
- Adds a print warning if a user is using `DataFrameSchema` or `DataFrameModel` from the top-level `pandera` module. It lets users know to update their import from `import pandera as pa` to `import pandera.pandas as pa` to define schemas for validating pandas objects.
- Adds `typing_extensions` to the base pandera dependencies.