### PR TITLE
bugfix: correctly support dataframe-level polars checks

### DIFF
--- a/pandera/api/polars/types.py
+++ b/pandera/api/polars/types.py
@@ -1,13 +1,13 @@
 """Polars types."""
 
-from typing import NamedTuple, Optional, Union, TypeVar
+from typing import NamedTuple, Union, TypeVar
 
 import polars as pl
 
 
 class PolarsData(NamedTuple):
     lazyframe: pl.LazyFrame
-    key: Optional[str] = None
+    key: str = "*"
 
 
 class CheckResult(NamedTuple):

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -8,7 +8,10 @@ import polars as pl
 
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.api.polars.types import CheckResult, PolarsFrame
-from pandera.api.polars.utils import get_lazyframe_column_dtypes
+from pandera.api.polars.utils import (
+    get_lazyframe_column_dtypes,
+    get_lazyframe_schema,
+)
 from pandera.backends.base import BaseSchemaBackend, CoreCheckResult
 from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.errors import (
@@ -92,7 +95,11 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                 )
             else:
                 # use check_result
-                failure_cases = check_result.failure_cases.collect()
+                _failure_cases = check_result.failure_cases
+                if CHECK_OUTPUT_KEY in get_lazyframe_schema(_failure_cases):
+                    _failure_cases = _failure_cases.drop(CHECK_OUTPUT_KEY)
+
+                failure_cases = _failure_cases.collect()
                 failure_cases_msg = failure_cases.head().rows(named=True)
                 message = (
                     f"{schema.__class__.__name__} '{schema.name}' failed "

--- a/pandera/backends/polars/checks.py
+++ b/pandera/backends/polars/checks.py
@@ -132,6 +132,6 @@ class PolarsCheckBackend(BaseCheckBackend):
         key: Optional[str] = None,
     ) -> CheckResult:
         check_obj = self.preprocess(check_obj, key)
-        polars_data = PolarsData(check_obj, key)
+        polars_data = PolarsData(check_obj, key or "*")
         check_output = self.apply(polars_data)
         return self.postprocess(polars_data, check_output)


### PR DESCRIPTION
- Makes the `PolarsData.key` type into a string, where the default key is `"*"` (select all columns) by default.
- Fix bug and add test to make sure the dataframe-level checks are supported in Polars.