### PR TITLE
enh: enable mypy in more polars places

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,8 +22,8 @@ follow_imports = skip
 [mypy-pandera.engines.polars_engine]
 ignore_errors = True
 
-[mypy-pandera.backends.polars.builtin_checks]
-ignore_errors = True
+; [mypy-pandera.backends.polars.builtin_checks]
+; ignore_errors = True
 
 [mypy-tests.polars.*]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,8 +22,5 @@ follow_imports = skip
 [mypy-pandera.engines.polars_engine]
 ignore_errors = True
 
-; [mypy-pandera.backends.polars.builtin_checks]
-; ignore_errors = True
-
 [mypy-tests.polars.*]
 ignore_errors = True

--- a/pandera/backends/polars/builtin_checks.py
+++ b/pandera/backends/polars/builtin_checks.py
@@ -1,6 +1,7 @@
 """Built-in checks for polars."""
 
 import re
+from collections.abc import Collection
 from typing import Any, Iterable, Optional, TypeVar, Union
 
 import polars as pl
@@ -140,7 +141,7 @@ def in_range(
 @register_builtin_check(
     error="isin({allowed_values})",
 )
-def isin(data: PolarsData, allowed_values: Iterable) -> pl.LazyFrame:
+def isin(data: PolarsData, allowed_values: Collection) -> pl.LazyFrame:
     """Ensure only allowed values occur within a series.
 
     This checks whether all elements of a :class:`polars.Series`
@@ -160,7 +161,7 @@ def isin(data: PolarsData, allowed_values: Iterable) -> pl.LazyFrame:
 @register_builtin_check(
     error="notin({forbidden_values})",
 )
-def notin(data: PolarsData, forbidden_values: Iterable) -> pl.LazyFrame:
+def notin(data: PolarsData, forbidden_values: Collection) -> pl.LazyFrame:
     """Ensure some defined values don't occur within a series.
 
     Like :meth:`Check.isin` this check operates on single characters if


### PR DESCRIPTION
With those changes you made + these two, mypy passes on builtin checks.

These were typed as iterables, which match the documentation, and the pandas case, but polars doesn't directly support an iterable, needs to be a collection (needs to have __len__ and __contains__). In practice this is a non issue (I was going to add a test, but it seems there was never a problem here) as `pa.Check.isin` converts inputs to a frozenset anyway - which is what is recieved here in the polars specific code (but that doesn't come through the type system because of the dynamic dispatching).

It might make more sense to noqa this for consistency? (but it doesn't look like this file gets built into the api docs, so maybe this is just more accurately describing the internals)