### PR TITLE
Bugfix/1937 Serialization of checks does only support one check per check function

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,8 +135,8 @@ html_theme = "furo"
 
 announcement = """
 📢 Pandera 0.24.0 introduces the <i>pandera.pandas</i>
-module, which is the recommended way of defining schemas. Learn more details
-<a href='https://github.com/unionai-oss/pandera/releases/tag/v0.24.0'>here</a>
+module, which is the recommended way of defining schemas for <i>pandas objects</i>.
+Learn more details <a href='https://github.com/unionai-oss/pandera/releases/tag/v0.24.0'>here</a>
 """
 
 html_logo = "_static/pandera-banner.png"

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -508,17 +508,16 @@ MultiIndex(indexes=[{indexes}])
 """
 
 
-def _format_checks(checks_dict):
+def _format_checks(checks_list):
     """Format checks into string representation including options."""
-    if checks_dict is None:
+    if checks_list is None:
         return "None"
 
     checks = []
-    for check_name, check_kwargs in checks_dict.items():
+    for check_kwargs in checks_list:
         if check_kwargs is None:
             warnings.warn(
-                f"Check {check_name} cannot be serialized. "
-                "This check will be ignored"
+                "Check cannot be serialized. This check will be ignored"
             )
             continue
 
@@ -528,6 +527,14 @@ def _format_checks(checks_dict):
             if isinstance(check_kwargs, dict)
             else {}
         )
+
+        if "check_name" not in options:
+            warnings.warn(
+                "Check cannot be serialized. This check will be ignored"
+            )
+            continue
+
+        check_name = options.pop("check_name")
 
         # Format main check arguments
         if isinstance(check_kwargs, dict):

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -232,7 +232,8 @@ def _deserialize_check_stats(check, serialized_check_stats, dtype=None):
     # Apply options if they exist
     if options:
         for option_name, option_value in options.items():
-            setattr(check_instance, option_name, option_value)
+            if option_name != "check_name":
+                setattr(check_instance, option_name, option_value)
 
     return check_instance
 

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -246,6 +246,17 @@ def _deserialize_component_stats(serialized_component_stats):
     title = serialized_component_stats.get("title")
 
     checks = serialized_component_stats.get("checks")
+    # For compatibility with previous versions convert checks in dictionary to list
+    if isinstance(checks, dict):
+        checks_list = []
+        for check_name, check in checks.items():
+            if not isinstance(check, dict):
+                check = {"value": check}
+            if "options" not in check:
+                check["options"] = {}
+            check["options"]["check_name"] = check_name
+            checks_list.append(check)
+        checks = checks_list
     if checks is not None:
         checks = [
             _deserialize_check_stats(
@@ -307,6 +318,18 @@ def deserialize_schema(serialized_schema):
             _deserialize_component_stats(index_component)
             for index_component in index
         ]
+
+    # For compatibility with previous versions convert checks in dictionary to list
+    if isinstance(checks, dict):
+        checks_list = []
+        for check_name, check in checks.items():
+            if not isinstance(check, dict):
+                check = {"value": check}
+            if "options" not in check:
+                check["options"] = {}
+            check["options"]["check_name"] = check_name
+            checks_list.append(check)
+        checks = checks_list
 
     if checks is not None:
         # handles unregistered checks by raising AttributeErrors from getattr

--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -1,7 +1,7 @@
 """Module for inferring the statistics of pandas objects."""
 
 import warnings
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List
 
 import pandas as pd
 
@@ -156,10 +156,9 @@ def get_series_schema_statistics(series_schema):
     return _get_series_base_schema_statistics(series_schema)
 
 
-def parse_checks(checks) -> Union[Dict[str, Any], None]:
+def parse_checks(checks) -> Union[List[Dict[str, Any]], None]:
     """Convert Check object to check statistics including options."""
-    check_statistics = {}
-    _check_memo = {}
+    check_statistics = []
 
     for check in checks:
         if check not in Check:
@@ -175,6 +174,7 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
 
         # Collect check options
         check_options = {
+            "check_name": check.name,
             "raise_warning": check.raise_warning,
             "n_failure_cases": check.n_failure_cases,
             "ignore_na": check.ignore_na,
@@ -186,29 +186,34 @@ def parse_checks(checks) -> Union[Dict[str, Any], None]:
         }
 
         # Combine statistics with options
-        check_statistics[check.name] = base_stats
         if check_options:
-            check_statistics[check.name]["options"] = check_options
-
-        _check_memo[check.name] = check
+            base_stats["options"] = check_options
+            check_statistics.append(base_stats)
 
     # Check for incompatible checks
-    if (
-        "greater_than_or_equal_to" in check_statistics
-        and "less_than_or_equal_to" in check_statistics
-    ):
-        min_value = check_statistics.get(
-            "greater_than_or_equal_to", float("-inf")
-        ).get("min_value", float("-inf"))
-        max_value = check_statistics.get(
-            "less_than_or_equal_to", float("inf")
-        ).get("max_value", float("inf"))
-        if min_value > max_value:
-            raise ValueError(
-                f"checks {_check_memo['greater_than_or_equal_to']} "
-                f"and {_check_memo['less_than_or_equal_to']} are incompatible, reason: "
-                f"min value {min_value} > max value {max_value}"
-            )
+    # incompatibile_checks = {
+    #     "greater_than": "gt",
+    #     "less_than": "lt",
+    #     "greater_than_or_equal_to": "lt",
+    #     "less_than_or_equal_to": "le",
+    #     "in_range": "between",
+    # }
+
+    # incompatibile_checks_count = sum(
+    #     map(
+    #         lambda check: check["options"]["check_name"]
+    #         in incompatibile_checks,
+    #         check_statistics,
+    #     )
+    # )
+    # if incompatibile_checks_count > 1:
+    # error_message = ", ".join(
+    #     [f"{key} ({value})" for key, value in incompatibile_checks.items()]
+    # )
+    # raise ValueError(
+    #    f"use only one check out of "
+    #    f"{error_message}."
+    # )
 
     return check_statistics if check_statistics else None
 

--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -191,29 +191,29 @@ def parse_checks(checks) -> Union[List[Dict[str, Any]], None]:
             check_statistics.append(base_stats)
 
     # Check for incompatible checks
-    # incompatibile_checks = {
-    #     "greater_than": "gt",
-    #     "less_than": "lt",
-    #     "greater_than_or_equal_to": "lt",
-    #     "less_than_or_equal_to": "le",
-    #     "in_range": "between",
-    # }
+    incompatibile_checks = {
+        "equal_to": "eq",
+        "greater_than": "gt",
+        "less_than": "lt",
+        "greater_than_or_equal_to": "lt",
+        "less_than_or_equal_to": "le",
+        "in_range": "between",
+    }
 
-    # incompatibile_checks_count = sum(
-    #     map(
-    #         lambda check: check["options"]["check_name"]
-    #         in incompatibile_checks,
-    #         check_statistics,
-    #     )
-    # )
-    # if incompatibile_checks_count > 1:
-    # error_message = ", ".join(
-    #     [f"{key} ({value})" for key, value in incompatibile_checks.items()]
-    # )
-    # raise ValueError(
-    #    f"use only one check out of "
-    #    f"{error_message}."
-    # )
+    incompatibile_checks_count = sum(
+        map(
+            lambda check: check["options"]["check_name"]
+            in incompatibile_checks,
+            check_statistics,
+        )
+    )
+    if incompatibile_checks_count > 1:
+        error_message = ", ".join(
+            [f"{key} ({value})" for key, value in incompatibile_checks.items()]
+        )
+        warnings.warn(
+            "You do not need more than one check out of " f"{error_message}."
+        )
 
     return check_statistics if check_statistics else None
 

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1164,7 +1164,7 @@ def test_inferred_schema_io():
     schema = pandera.infer_schema(df)
     schema_yaml_str = schema.to_yaml()
     schema_from_yaml = io.from_yaml(schema_yaml_str)
-    assert schema == schema_from_yaml
+    assert str(schema) == str(schema_from_yaml)
 
 
 @pytest.mark.skipif(
@@ -1208,8 +1208,8 @@ def test_from_yaml(yaml_str, schema_creator):
     """Test that from_yaml reads yaml string."""
     schema_from_yaml = io.from_yaml(yaml_str)
     expected_schema = schema_creator()
-    assert schema_from_yaml == expected_schema
-    assert expected_schema == schema_from_yaml
+    assert str(schema_from_yaml) == str(expected_schema)
+    assert str(expected_schema) == str(schema_from_yaml)
 
 
 @pytest.mark.skipif(
@@ -1303,7 +1303,7 @@ def test_io_yaml_file_obj():
         assert output is None
         f.seek(0)
         schema_from_yaml = pandera.DataFrameSchema.from_yaml(f)
-        assert schema_from_yaml == schema
+        assert str(schema_from_yaml) == str(schema)
 
 
 @pytest.mark.skipif(
@@ -1341,38 +1341,38 @@ def test_io_json(index):
         output = io.to_json(schema, pth)
         assert output is None
         schema_from_json = io.from_json(pth)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # DataFrameSchema method
         output = schema.to_json(pth)
         assert output is None
         schema_from_json = schema.from_json(pth)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # Check path as string
         output = io.to_json(schema, str(pth))
         assert output is None
         schema_from_json = io.from_json(str(pth))
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # DataFrameSchema method
         output = schema.to_json(str(pth))
         assert output is None
         schema_from_json = schema.from_json(pth)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # Check schema encoded as a string
         text = io.to_json(schema)
         assert text is not None
         assert isinstance(text, str)
         schema_from_json = io.from_json(text)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # DataFrameSchema method
         text = schema.to_json()
         assert text is not None
         schema_from_json = schema.from_json(text)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # Check schema encoded in a stream
         stream = StringIO()
@@ -1380,7 +1380,7 @@ def test_io_json(index):
         assert output is None
         stream.seek(0)
         schema_from_json = io.from_json(stream)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
         # DataFrameSchema method
         stream = StringIO()
@@ -1388,7 +1388,7 @@ def test_io_json(index):
         assert output is None
         stream.seek(0)
         schema_from_json = schema.from_json(stream)
-        assert schema_from_json == schema
+        assert str(schema_from_json) == str(schema)
 
 
 @pytest.mark.skipif(
@@ -1606,7 +1606,7 @@ def test_serialize_deserialize_custom_datetime_checks():
     )
     yaml_schema = schema.to_yaml()
     schema_from_yaml = schema.from_yaml(yaml_schema)
-    assert schema_from_yaml == schema
+    assert str(schema_from_yaml) == str(schema)
 
 
 FRICTIONLESS_YAML = yaml.safe_load(

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1320,14 +1320,14 @@ def test_io_yaml(index):
         output = io.to_yaml(schema, f.name)
         assert output is None
         schema_from_yaml = io.from_yaml(f.name)
-        assert schema_from_yaml == schema
+        assert str(schema_from_yaml) == str(schema)
 
     # pass in a Path object
     with tempfile.NamedTemporaryFile("w+") as f:
         output = schema.to_yaml(Path(f.name))
         assert output is None
         schema_from_yaml = pandera.DataFrameSchema.from_yaml(Path(f.name))
-        assert schema_from_yaml == schema
+        assert str(schema_from_yaml) == str(schema)
 
 
 @pytest.mark.parametrize("index", ["single", "multi", None])

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -127,24 +127,24 @@ columns:
     dtype: int64
     nullable: false
     checks:
-      greater_than:
-        value: 0
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 10
-        options:
-          raise_warning: false
-          ignore_na: true
-      in_range:
-        min_value: 0
-        max_value: 10
-        include_min: true
-        include_max: true
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: 0
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 10
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
+    - min_value: 0
+      max_value: 10
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -155,24 +155,24 @@ columns:
     dtype: float64
     nullable: false
     checks:
-      greater_than:
-        value: -10
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 20
-        options:
-          raise_warning: false
-          ignore_na: true
-      in_range:
-        min_value: -10
-        max_value: 20
-        include_min: true
-        include_max: true
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: -10
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 20
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
+    - min_value: -10
+      max_value: 20
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -183,21 +183,21 @@ columns:
     dtype: str
     nullable: false
     checks:
-      isin:
-        value:
-        - foo
-        - bar
-        - x
-        - xy
-        options:
-          raise_warning: false
-          ignore_na: true
-      str_length:
-        min_value: 1
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - foo
+      - bar
+      - x
+      - xy
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
+    - min_value: 1
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -208,16 +208,16 @@ columns:
     dtype: datetime64[ns]
     nullable: false
     checks:
-      greater_than:
-        value: '2010-01-01 00:00:00'
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: '2020-01-01 00:00:00'
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: '2010-01-01 00:00:00'
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: '2020-01-01 00:00:00'
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -228,16 +228,16 @@ columns:
     dtype: timedelta64[ns]
     nullable: false
     checks:
-      greater_than:
-        value: 1000
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 10000
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: 1000
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 10000
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -248,12 +248,12 @@ columns:
     dtype: str
     nullable: true
     checks:
-      str_length:
-        min_value: 1
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: 1
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: false
@@ -264,15 +264,15 @@ columns:
     dtype: null
     nullable: false
     checks:
-      isin:
-        value:
-        - foo
-        - bar
-        - x
-        - xy
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - foo
+      - bar
+      - x
+      - xy
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -332,30 +332,37 @@ columns:
     dtype: float64
     nullable: false
     checks:
-      greater_than: -10
-      less_than: 20
-      in_range:
-        min_value: -10
-        max_value: 20
+    - value: -10
+      options:
+        check_name: greater_than
+    - value: 20
+      options:
+        check_name: less_than
+    - min_value: -10
+      max_value: 20
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
   str_column:
     dtype: str
     nullable: false
     checks:
-      isin:
-        value:
-        - foo
-        - bar
-        - x
-        - xy
-        options:
-          raise_warning: false
-          ignore_na: true
-      str_length:
-        min_value: 1
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - foo
+      - bar
+      - x
+      - xy
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
+    - min_value: 1
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
 index: null
 checks: null
 coerce: false
@@ -406,9 +413,10 @@ columns:
   object_column:
     dtype: object
 checks:
-  unregistered_check:
-    stat1: missing_str_stat
-    stat2: 11
+- stat1: missing_str_stat
+  stat2: 11
+  options:
+    check_name: unregistered_check
 index: null
 coerce: false
 strict: false
@@ -422,9 +430,10 @@ columns:
   int_column:
     dtype: int64
     checks:
-      unregistered_check:
-        stat1: missing_str_stat
-        stat2: 11
+    - stat1: missing_str_stat
+      stat2: 11
+      options:
+        check_name: unregistered_check
   float_column:
     dtype: float64
   str_column:
@@ -447,24 +456,24 @@ columns:
     dtype: int64
     nullable: false
     checks:
-      greater_than:
-        value: 0
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 10
-        options:
-          raise_warning: false
-          ignore_na: true
-      in_range:
-        min_value: 0
-        max_value: 10
-        include_min: true
-        include_max: true
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: 0
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 10
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
+    - min_value: 0
+      max_value: 10
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -475,24 +484,24 @@ columns:
     dtype: float64
     nullable: false
     checks:
-      greater_than:
-        value: -10
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 20
-        options:
-          raise_warning: false
-          ignore_na: true
-      in_range:
-        min_value: -10
-        max_value: 20
-        include_min: true
-        include_max: true
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: -10
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 20
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
+    - min_value: -10
+      max_value: 20
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -503,21 +512,21 @@ columns:
     dtype: str
     nullable: false
     checks:
-      isin:
-        value:
-        - foo
-        - bar
-        - x
-        - xy
-        options:
-          raise_warning: false
-          ignore_na: true
-      str_length:
-        min_value: 1
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - foo
+      - bar
+      - x
+      - xy
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
+    - min_value: 1
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -528,16 +537,16 @@ columns:
     dtype: datetime64[ns]
     nullable: false
     checks:
-      greater_than:
-        value: '2010-01-01 00:00:00'
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: '2020-01-01 00:00:00'
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: '2010-01-01 00:00:00'
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: '2020-01-01 00:00:00'
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -548,16 +557,16 @@ columns:
     dtype: timedelta64[ns]
     nullable: false
     checks:
-      greater_than:
-        value: 1000
-        options:
-          raise_warning: false
-          ignore_na: true
-      less_than:
-        value: 10000
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: 1000
+      options:
+        check_name: greater_than
+        raise_warning: false
+        ignore_na: true
+    - value: 10000
+      options:
+        check_name: less_than
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -568,12 +577,12 @@ columns:
     dtype: str
     nullable: true
     checks:
-      str_length:
-        min_value: 1
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: 1
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: false
@@ -584,15 +593,15 @@ columns:
     dtype: null
     nullable: false
     checks:
-      isin:
-        value:
-        - foo
-        - bar
-        - x
-        - xy
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - foo
+      - bar
+      - x
+      - xy
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: false
     required: true
@@ -748,6 +757,7 @@ def test_from_yaml(yaml_str, schema_creator):
     """Test that from_yaml reads yaml string."""
     schema_from_yaml = io.from_yaml(yaml_str)
     expected_schema = schema_creator()
+
     assert schema_from_yaml == expected_schema
     assert expected_schema == schema_from_yaml
 
@@ -1244,14 +1254,14 @@ columns:
     dtype: {INT_DTYPE}
     nullable: false
     checks:
-      in_range:
-        min_value: 10
-        max_value: 99
-        include_min: true
-        include_max: true
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: 10
+      max_value: 99
+      include_min: true
+      include_max: true
+      options:
+        check_name: in_range
+        raise_warning: false
+        ignore_na: true
     unique: true
     coerce: true
     required: true
@@ -1262,11 +1272,11 @@ columns:
     dtype: {INT_DTYPE}
     nullable: true
     checks:
-      less_than_or_equal_to:
-        value: 30
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: 30
+      options:
+        check_name: less_than_or_equal_to
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1277,12 +1287,12 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_length:
-        min_value: 3
-        max_value: 80
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: 3
+      max_value: 80
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1293,11 +1303,11 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_matches:
-        value: ^\\d{{3}}[A-Z]$
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: ^\\d{{3}}[A-Z]$
+      options:
+        check_name: str_matches
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1308,12 +1318,12 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_length:
-        min_value: 3
-        max_value: null
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: 3
+      max_value: null
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1324,12 +1334,12 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      str_length:
-        min_value: null
-        max_value: 3
-        options:
-          raise_warning: false
-          ignore_na: true
+    - min_value: null
+      max_value: 3
+      options:
+        check_name: str_length
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1340,14 +1350,14 @@ columns:
     dtype: category
     nullable: false
     checks:
-      isin:
-        value:
-        - 1.0
-        - 2.0
-        - 3.0
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value:
+      - 1.0
+      - 2.0
+      - 3.0
+      options:
+        check_name: isin
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true
@@ -1368,11 +1378,11 @@ columns:
     dtype: {STR_DTYPE}
     nullable: true
     checks:
-      greater_than_or_equal_to:
-        value: '20201231'
-        options:
-          raise_warning: false
-          ignore_na: true
+    - value: '20201231'
+      options:
+        check_name: greater_than_or_equal_to
+        raise_warning: false
+        ignore_na: true
     unique: false
     coerce: true
     required: true

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -300,6 +300,189 @@ title: null
 description: null
 """
 
+YAML_SCHEMA_DICT_CHECK = f"""
+schema_type: dataframe
+version: {pandera.__version__}
+columns:
+  int_column:
+    title: integer_col
+    description: Integer column with title
+    dtype: int64
+    nullable: false
+    checks:
+      greater_than:
+        value: 0
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10
+        options:
+          raise_warning: false
+          ignore_na: true
+      in_range:
+        min_value: 0
+        max_value: 10
+        include_min: true
+        include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  float_column:
+    title: null
+    description: Float col no title
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than:
+        value: -10
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 20
+        options:
+          raise_warning: false
+          ignore_na: true
+      in_range:
+        min_value: -10
+        max_value: 20
+        include_min: true
+        include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  str_column:
+    title: null
+    description: null
+    dtype: str
+    nullable: false
+    checks:
+      isin:
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
+      str_length:
+        min_value: 1
+        max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  datetime_column:
+    title: null
+    description: null
+    dtype: datetime64[ns]
+    nullable: false
+    checks:
+      greater_than:
+        value: '2010-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: '2020-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  timedelta_column:
+    title: null
+    description: null
+    dtype: timedelta64[ns]
+    nullable: false
+    checks:
+      greater_than:
+        value: 1000
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10000
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  optional_props_column:
+    title: null
+    description: null
+    dtype: str
+    nullable: true
+    checks:
+      str_length:
+        min_value: 1
+        max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: true
+    required: false
+    regex: true
+  notype_column:
+    title: null
+    description: null
+    dtype: null
+    nullable: false
+    checks:
+      isin:
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+checks: null
+index:
+- title: null
+  description: null
+  dtype: int64
+  nullable: false
+  checks: null
+  name: null
+  unique: false
+  coerce: false
+dtype: null
+coerce: false
+strict: true
+name: null
+ordered: false
+unique: null
+report_duplicates: all
+unique_column_names: false
+add_missing_columns: false
+title: null
+description: null
+"""
+
 
 def _create_schema_null_index():
     return pandera.DataFrameSchema(
@@ -369,6 +552,44 @@ coerce: false
 strict: false
 """
 
+YAML_SCHEMA_NULL_INDEX_DICT_CHECK = f"""
+schema_type: dataframe
+version: {pandera.__version__}
+columns:
+  float_column:
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than: -10
+      less_than: 20
+      in_range:
+        min_value: -10
+        max_value: 20
+  str_column:
+    dtype: str
+    nullable: false
+    checks:
+      isin:
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
+      str_length:
+        min_value: 1
+        max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
+index: null
+checks: null
+coerce: false
+strict: false
+"""
+
 
 def _create_schema_python_types():
     return pandera.DataFrameSchema(
@@ -422,6 +643,26 @@ coerce: false
 strict: false
 """
 
+YAML_SCHEMA_MISSING_GLOBAL_CHECK_DICT_CHECK = f"""
+schema_type: dataframe
+version: {pandera.__version__}
+columns:
+  int_column:
+    dtype: int64
+  float_column:
+    dtype: float64
+  str_column:
+    dtype: str
+  object_column:
+    dtype: object
+checks:
+  unregistered_check:
+    stat1: missing_str_stat
+    stat2: 11
+index: null
+coerce: false
+strict: false
+"""
 
 YAML_SCHEMA_MISSING_COLUMN_CHECK = f"""
 schema_type: dataframe
@@ -434,6 +675,27 @@ columns:
       stat2: 11
       options:
         check_name: unregistered_check
+  float_column:
+    dtype: float64
+  str_column:
+    dtype: str
+  object_column:
+    dtype: object
+index: null
+coerce: false
+strict: false
+"""
+
+YAML_SCHEMA_MISSING_COLUMN_CHECK_DICT_CHECK = f"""
+schema_type: dataframe
+version: {pandera.__version__}
+columns:
+  int_column:
+    dtype: int64
+    checks:
+      unregistered_check:
+        stat1: missing_str_stat
+        stat2: 11
   float_column:
     dtype: float64
   str_column:
@@ -629,6 +891,189 @@ title: null
 description: null
 """
 
+YAML_SCHEMA_NO_DESCR_NO_TITLE_DICT_CHECK = f"""
+schema_type: dataframe
+version: {pandera.__version__}
+columns:
+  int_column:
+    title: null
+    description: null
+    dtype: int64
+    nullable: false
+    checks:
+      greater_than:
+        value: 0
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10
+        options:
+          raise_warning: false
+          ignore_na: true
+      in_range:
+        min_value: 0
+        max_value: 10
+        include_min: true
+        include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  float_column:
+    title: null
+    description: null
+    dtype: float64
+    nullable: false
+    checks:
+      greater_than:
+        value: -10
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 20
+        options:
+          raise_warning: false
+          ignore_na: true
+      in_range:
+        min_value: -10
+        max_value: 20
+        include_min: true
+        include_max: true
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  str_column:
+    title: null
+    description: null
+    dtype: str
+    nullable: false
+    checks:
+      isin:
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
+      str_length:
+        min_value: 1
+        max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  datetime_column:
+    title: null
+    description: null
+    dtype: datetime64[ns]
+    nullable: false
+    checks:
+      greater_than:
+        value: '2010-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: '2020-01-01 00:00:00'
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  timedelta_column:
+    title: null
+    description: null
+    dtype: timedelta64[ns]
+    nullable: false
+    checks:
+      greater_than:
+        value: 1000
+        options:
+          raise_warning: false
+          ignore_na: true
+      less_than:
+        value: 10000
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+  optional_props_column:
+    title: null
+    description: null
+    dtype: str
+    nullable: true
+    checks:
+      str_length:
+        min_value: 1
+        max_value: 3
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: true
+    required: false
+    regex: true
+  notype_column:
+    title: null
+    description: null
+    dtype: null
+    nullable: false
+    checks:
+      isin:
+        value:
+        - foo
+        - bar
+        - x
+        - xy
+        options:
+          raise_warning: false
+          ignore_na: true
+    unique: false
+    coerce: false
+    required: true
+    regex: false
+checks: null
+index:
+- title: null
+  description: null
+  dtype: int64
+  nullable: false
+  checks: null
+  name: null
+  unique: false
+  coerce: false
+dtype: null
+coerce: false
+strict: true
+name: null
+ordered: false
+unique: null
+report_duplicates: all
+unique_column_names: false
+add_missing_columns: false
+title: null
+description: null
+"""
+
 
 def _create_schema_no_descr_no_title(index="single"):
     if index == "multi":
@@ -748,31 +1193,46 @@ def test_to_yaml():
     "yaml_str, schema_creator",
     [
         [YAML_SCHEMA, _create_schema],
+        [YAML_SCHEMA_DICT_CHECK, _create_schema],
         [YAML_SCHEMA_NULL_INDEX, _create_schema_null_index],
+        [YAML_SCHEMA_NULL_INDEX_DICT_CHECK, _create_schema_null_index],
         [YAML_SCHEMA_PYTHON_TYPES, _create_schema_python_types],
         [YAML_SCHEMA_NO_DESCR_NO_TITLE, _create_schema_no_descr_no_title],
+        [
+            YAML_SCHEMA_NO_DESCR_NO_TITLE_DICT_CHECK,
+            _create_schema_no_descr_no_title,
+        ],
     ],
 )
 def test_from_yaml(yaml_str, schema_creator):
     """Test that from_yaml reads yaml string."""
     schema_from_yaml = io.from_yaml(yaml_str)
     expected_schema = schema_creator()
-
     assert schema_from_yaml == expected_schema
     assert expected_schema == schema_from_yaml
 
 
-def test_from_yaml_unregistered_checks():
+@pytest.mark.skipif(
+    SKIP_YAML_TESTS,
+    reason="pyyaml >= 5.1.0 required",
+)
+@pytest.mark.parametrize(
+    "yaml_str",
+    [
+        YAML_SCHEMA_MISSING_COLUMN_CHECK,
+        YAML_SCHEMA_MISSING_COLUMN_CHECK_DICT_CHECK,
+        YAML_SCHEMA_MISSING_GLOBAL_CHECK,
+        YAML_SCHEMA_MISSING_GLOBAL_CHECK_DICT_CHECK,
+    ],
+)
+def test_from_yaml_unregistered_checks(yaml_str):
     """
     Test that from_yaml raises an exception when deserializing unregistered
     checks.
     """
 
     with pytest.raises(AttributeError, match=".*custom checks.*"):
-        io.from_yaml(YAML_SCHEMA_MISSING_COLUMN_CHECK)
-
-    with pytest.raises(AttributeError, match=".*custom checks.*"):
-        io.from_yaml(YAML_SCHEMA_MISSING_GLOBAL_CHECK)
+        io.from_yaml(yaml_str)
 
 
 def test_from_yaml_load_required_fields():

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1164,7 +1164,7 @@ def test_inferred_schema_io():
     schema = pandera.infer_schema(df)
     schema_yaml_str = schema.to_yaml()
     schema_from_yaml = io.from_yaml(schema_yaml_str)
-    assert str(schema) == str(schema_from_yaml)
+    assert schema == schema_from_yaml
 
 
 @pytest.mark.skipif(
@@ -1208,8 +1208,8 @@ def test_from_yaml(yaml_str, schema_creator):
     """Test that from_yaml reads yaml string."""
     schema_from_yaml = io.from_yaml(yaml_str)
     expected_schema = schema_creator()
-    assert str(schema_from_yaml) == str(expected_schema)
-    assert str(expected_schema) == str(schema_from_yaml)
+    assert schema_from_yaml == expected_schema
+    assert expected_schema == schema_from_yaml
 
 
 @pytest.mark.skipif(
@@ -1303,7 +1303,7 @@ def test_io_yaml_file_obj():
         assert output is None
         f.seek(0)
         schema_from_yaml = pandera.DataFrameSchema.from_yaml(f)
-        assert str(schema_from_yaml) == str(schema)
+        assert schema_from_yaml == schema
 
 
 @pytest.mark.skipif(
@@ -1320,14 +1320,14 @@ def test_io_yaml(index):
         output = io.to_yaml(schema, f.name)
         assert output is None
         schema_from_yaml = io.from_yaml(f.name)
-        assert str(schema_from_yaml) == str(schema)
+        assert schema_from_yaml == schema
 
     # pass in a Path object
     with tempfile.NamedTemporaryFile("w+") as f:
         output = schema.to_yaml(Path(f.name))
         assert output is None
         schema_from_yaml = pandera.DataFrameSchema.from_yaml(Path(f.name))
-        assert str(schema_from_yaml) == str(schema)
+        assert schema_from_yaml == schema
 
 
 @pytest.mark.parametrize("index", ["single", "multi", None])
@@ -1341,38 +1341,38 @@ def test_io_json(index):
         output = io.to_json(schema, pth)
         assert output is None
         schema_from_json = io.from_json(pth)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # DataFrameSchema method
         output = schema.to_json(pth)
         assert output is None
         schema_from_json = schema.from_json(pth)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # Check path as string
         output = io.to_json(schema, str(pth))
         assert output is None
         schema_from_json = io.from_json(str(pth))
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # DataFrameSchema method
         output = schema.to_json(str(pth))
         assert output is None
         schema_from_json = schema.from_json(pth)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # Check schema encoded as a string
         text = io.to_json(schema)
         assert text is not None
         assert isinstance(text, str)
         schema_from_json = io.from_json(text)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # DataFrameSchema method
         text = schema.to_json()
         assert text is not None
         schema_from_json = schema.from_json(text)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # Check schema encoded in a stream
         stream = StringIO()
@@ -1380,7 +1380,7 @@ def test_io_json(index):
         assert output is None
         stream.seek(0)
         schema_from_json = io.from_json(stream)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
         # DataFrameSchema method
         stream = StringIO()
@@ -1388,7 +1388,7 @@ def test_io_json(index):
         assert output is None
         stream.seek(0)
         schema_from_json = schema.from_json(stream)
-        assert str(schema_from_json) == str(schema)
+        assert schema_from_json == schema
 
 
 @pytest.mark.skipif(
@@ -1606,7 +1606,7 @@ def test_serialize_deserialize_custom_datetime_checks():
     )
     yaml_schema = schema.to_yaml()
     schema_from_yaml = schema.from_yaml(yaml_schema)
-    assert str(schema_from_yaml) == str(schema)
+    assert schema_from_yaml == schema
 
 
 FRICTIONLESS_YAML = yaml.safe_load(

--- a/tests/pandas/test_schema_statistics.py
+++ b/tests/pandas/test_schema_statistics.py
@@ -433,14 +433,20 @@ def test_get_dataframe_schema_statistics():
         columns={
             "int": pa.Column(
                 int,
-                checks=[pa.Check.in_range(0, 100)],
+                checks=[
+                    pa.Check.greater_than_or_equal_to(0),
+                    pa.Check.less_than_or_equal_to(100),
+                ],
                 nullable=True,
                 description="Integer column with title",
                 title="integer_col",
             ),
             "float": pa.Column(
                 float,
-                checks=[pa.Check.between(50, 100)],
+                checks=[
+                    pa.Check.greater_than_or_equal_to(50),
+                    pa.Check.less_than_or_equal_to(100),
+                ],
                 description="Float col no title",
             ),
             "str": pa.Column(
@@ -462,16 +468,21 @@ def test_get_dataframe_schema_statistics():
                 "dtype": DEFAULT_INT,
                 "checks": [
                     {
-                        "include_max": True,
-                        "include_min": True,
                         "min_value": 0,
-                        "max_value": 100,
                         "options": {
-                            "check_name": "in_range",
                             "ignore_na": True,
                             "raise_warning": False,
+                            "check_name": "greater_than_or_equal_to",
                         },
-                    }
+                    },
+                    {
+                        "max_value": 100,
+                        "options": {
+                            "ignore_na": True,
+                            "raise_warning": False,
+                            "check_name": "less_than_or_equal_to",
+                        },
+                    },
                 ],
                 "nullable": True,
                 "unique": False,
@@ -485,16 +496,21 @@ def test_get_dataframe_schema_statistics():
                 "dtype": DEFAULT_FLOAT,
                 "checks": [
                     {
-                        "include_max": True,
-                        "include_min": True,
                         "min_value": 50,
-                        "max_value": 100,
                         "options": {
-                            "check_name": "in_range",
                             "ignore_na": True,
                             "raise_warning": False,
+                            "check_name": "greater_than_or_equal_to",
                         },
-                    }
+                    },
+                    {
+                        "max_value": 100,
+                        "options": {
+                            "ignore_na": True,
+                            "raise_warning": False,
+                            "check_name": "less_than_or_equal_to",
+                        },
+                    },
                 ],
                 "nullable": False,
                 "unique": False,
@@ -510,9 +526,9 @@ def test_get_dataframe_schema_statistics():
                     {
                         "allowed_values": ["foo", "bar", "baz"],
                         "options": {
-                            "check_name": "isin",
                             "ignore_na": True,
                             "raise_warning": False,
+                            "check_name": "isin",
                         },
                     }
                 ],
@@ -532,9 +548,9 @@ def test_get_dataframe_schema_statistics():
                     {
                         "min_value": 0,
                         "options": {
-                            "check_name": "greater_than_or_equal_to",
                             "ignore_na": True,
                             "raise_warning": False,
+                            "check_name": "greater_than_or_equal_to",
                         },
                     }
                 ],
@@ -557,7 +573,10 @@ def test_get_series_schema_statistics():
     schema = pa.SeriesSchema(
         int,
         nullable=False,
-        checks=[pa.Check.greater_than_or_equal_to(0)],
+        checks=[
+            pa.Check.greater_than_or_equal_to(0),
+            pa.Check.less_than_or_equal_to(100),
+        ],
     )
     statistics = schema_statistics.get_series_schema_statistics(schema)
     assert statistics == {
@@ -567,9 +586,17 @@ def test_get_series_schema_statistics():
             {
                 "min_value": 0,
                 "options": {
-                    "check_name": "greater_than_or_equal_to",
                     "ignore_na": True,
                     "raise_warning": False,
+                    "check_name": "greater_than_or_equal_to",
+                },
+            },
+            {
+                "max_value": 100,
+                "options": {
+                    "ignore_na": True,
+                    "raise_warning": False,
+                    "check_name": "less_than_or_equal_to",
                 },
             },
         ],
@@ -587,7 +614,10 @@ def test_get_series_schema_statistics():
         [
             pa.Index(
                 int,
-                checks=[pa.Check.in_range(10, 20)],
+                checks=[
+                    pa.Check.greater_than_or_equal_to(10),
+                    pa.Check.less_than_or_equal_to(20),
+                ],
                 nullable=False,
                 name="int_index",
             ),
@@ -597,16 +627,21 @@ def test_get_series_schema_statistics():
                     "nullable": False,
                     "checks": [
                         {
-                            "include_max": True,
-                            "include_min": True,
                             "min_value": 10,
-                            "max_value": 20,
                             "options": {
-                                "check_name": "in_range",
                                 "ignore_na": True,
                                 "raise_warning": False,
+                                "check_name": "greater_than_or_equal_to",
                             },
-                        }
+                        },
+                        {
+                            "max_value": 20,
+                            "options": {
+                                "ignore_na": True,
+                                "raise_warning": False,
+                                "check_name": "less_than_or_equal_to",
+                            },
+                        },
                     ],
                     "name": "int_index",
                     "coerce": False,
@@ -636,9 +671,9 @@ def test_get_index_schema_statistics(index_schema_component, expectation):
                     {
                         **(check.statistics or {}),
                         "options": {
-                            "check_name": check.name,
                             "ignore_na": True,
                             "raise_warning": False,
+                            "check_name": check.name,
                         },
                     }
                 ],
@@ -660,52 +695,36 @@ def test_get_index_schema_statistics(index_schema_component, expectation):
         # multiple checks at once
         [
             [
-                pa.Check.in_range(10, 50),
+                pa.Check.greater_than_or_equal_to(10),
+                pa.Check.less_than_or_equal_to(50),
                 pa.Check.isin([10, 20, 30, 40, 50]),
             ],
             [
                 {
-                    "include_max": True,
-                    "include_min": True,
                     "min_value": 10,
-                    "max_value": 50,
                     "options": {
-                        "check_name": "in_range",
                         "ignore_na": True,
                         "raise_warning": False,
+                        "check_name": "greater_than_or_equal_to",
+                    },
+                },
+                {
+                    "max_value": 50,
+                    "options": {
+                        "ignore_na": True,
+                        "raise_warning": False,
+                        "check_name": "less_than_or_equal_to",
                     },
                 },
                 {
                     "allowed_values": [10, 20, 30, 40, 50],
                     "options": {
-                        "check_name": "isin",
                         "ignore_na": True,
                         "raise_warning": False,
+                        "check_name": "isin",
                     },
                 },
             ],
-        ],
-        # incompatible checks
-        [
-            [
-                pa.Check.greater_than_or_equal_to(1),
-                pa.Check.less_than_or_equal_to(2),
-            ],
-            ValueError,
-        ],
-        [
-            [
-                pa.Check.ge(1),
-                pa.Check.le(2),
-            ],
-            ValueError,
-        ],
-        [
-            [
-                pa.Check.greater_than(1),
-                pa.Check.in_range(2, 4),
-            ],
-            ValueError,
         ],
     ],
 )
@@ -748,6 +767,7 @@ def test_parse_checks_and_statistics_no_param(extra_registered_checks):
             }
         }
     ]
+
     assert schema_statistics.parse_checks(checks) == expectation
 
     check_statistics = {check.name: check.statistics for check in checks}

--- a/tests/pandas/test_schema_statistics.py
+++ b/tests/pandas/test_schema_statistics.py
@@ -433,20 +433,14 @@ def test_get_dataframe_schema_statistics():
         columns={
             "int": pa.Column(
                 int,
-                checks=[
-                    pa.Check.greater_than_or_equal_to(0),
-                    pa.Check.less_than_or_equal_to(100),
-                ],
+                checks=[pa.Check.in_range(0, 100)],
                 nullable=True,
                 description="Integer column with title",
                 title="integer_col",
             ),
             "float": pa.Column(
                 float,
-                checks=[
-                    pa.Check.greater_than_or_equal_to(50),
-                    pa.Check.less_than_or_equal_to(100),
-                ],
+                checks=[pa.Check.between(50, 100)],
                 description="Float col no title",
             ),
             "str": pa.Column(
@@ -466,16 +460,19 @@ def test_get_dataframe_schema_statistics():
         "columns": {
             "int": {
                 "dtype": DEFAULT_INT,
-                "checks": {
-                    "greater_than_or_equal_to": {
+                "checks": [
+                    {
+                        "include_max": True,
+                        "include_min": True,
                         "min_value": 0,
-                        "options": {"ignore_na": True, "raise_warning": False},
-                    },
-                    "less_than_or_equal_to": {
                         "max_value": 100,
-                        "options": {"ignore_na": True, "raise_warning": False},
-                    },
-                },
+                        "options": {
+                            "check_name": "in_range",
+                            "ignore_na": True,
+                            "raise_warning": False,
+                        },
+                    }
+                ],
                 "nullable": True,
                 "unique": False,
                 "coerce": False,
@@ -486,16 +483,19 @@ def test_get_dataframe_schema_statistics():
             },
             "float": {
                 "dtype": DEFAULT_FLOAT,
-                "checks": {
-                    "greater_than_or_equal_to": {
+                "checks": [
+                    {
+                        "include_max": True,
+                        "include_min": True,
                         "min_value": 50,
-                        "options": {"ignore_na": True, "raise_warning": False},
-                    },
-                    "less_than_or_equal_to": {
                         "max_value": 100,
-                        "options": {"ignore_na": True, "raise_warning": False},
-                    },
-                },
+                        "options": {
+                            "check_name": "in_range",
+                            "ignore_na": True,
+                            "raise_warning": False,
+                        },
+                    }
+                ],
                 "nullable": False,
                 "unique": False,
                 "coerce": False,
@@ -506,12 +506,16 @@ def test_get_dataframe_schema_statistics():
             },
             "str": {
                 "dtype": pandas_engine.Engine.dtype(str),
-                "checks": {
-                    "isin": {
+                "checks": [
+                    {
                         "allowed_values": ["foo", "bar", "baz"],
-                        "options": {"ignore_na": True, "raise_warning": False},
+                        "options": {
+                            "check_name": "isin",
+                            "ignore_na": True,
+                            "raise_warning": False,
+                        },
                     }
-                },
+                ],
                 "nullable": False,
                 "unique": False,
                 "coerce": False,
@@ -524,12 +528,16 @@ def test_get_dataframe_schema_statistics():
         "index": [
             {
                 "dtype": DEFAULT_INT,
-                "checks": {
-                    "greater_than_or_equal_to": {
+                "checks": [
+                    {
                         "min_value": 0,
-                        "options": {"ignore_na": True, "raise_warning": False},
+                        "options": {
+                            "check_name": "greater_than_or_equal_to",
+                            "ignore_na": True,
+                            "raise_warning": False,
+                        },
                     }
-                },
+                ],
                 "nullable": False,
                 "coerce": False,
                 "name": "int_index",
@@ -549,25 +557,22 @@ def test_get_series_schema_statistics():
     schema = pa.SeriesSchema(
         int,
         nullable=False,
-        checks=[
-            pa.Check.greater_than_or_equal_to(0),
-            pa.Check.less_than_or_equal_to(100),
-        ],
+        checks=[pa.Check.greater_than_or_equal_to(0)],
     )
     statistics = schema_statistics.get_series_schema_statistics(schema)
     assert statistics == {
         "dtype": pandas_engine.Engine.dtype(int),
         "nullable": False,
-        "checks": {
-            "greater_than_or_equal_to": {
+        "checks": [
+            {
                 "min_value": 0,
-                "options": {"ignore_na": True, "raise_warning": False},
+                "options": {
+                    "check_name": "greater_than_or_equal_to",
+                    "ignore_na": True,
+                    "raise_warning": False,
+                },
             },
-            "less_than_or_equal_to": {
-                "max_value": 100,
-                "options": {"ignore_na": True, "raise_warning": False},
-            },
-        },
+        ],
         "name": None,
         "coerce": False,
         "unique": False,
@@ -582,10 +587,7 @@ def test_get_series_schema_statistics():
         [
             pa.Index(
                 int,
-                checks=[
-                    pa.Check.greater_than_or_equal_to(10),
-                    pa.Check.less_than_or_equal_to(20),
-                ],
+                checks=[pa.Check.in_range(10, 20)],
                 nullable=False,
                 name="int_index",
             ),
@@ -593,22 +595,19 @@ def test_get_series_schema_statistics():
                 {
                     "dtype": pandas_engine.Engine.dtype(int),
                     "nullable": False,
-                    "checks": {
-                        "greater_than_or_equal_to": {
+                    "checks": [
+                        {
+                            "include_max": True,
+                            "include_min": True,
                             "min_value": 10,
-                            "options": {
-                                "ignore_na": True,
-                                "raise_warning": False,
-                            },
-                        },
-                        "less_than_or_equal_to": {
                             "max_value": 20,
                             "options": {
+                                "check_name": "in_range",
                                 "ignore_na": True,
                                 "raise_warning": False,
                             },
-                        },
-                    },
+                        }
+                    ],
                     "name": "int_index",
                     "coerce": False,
                     "unique": False,
@@ -633,12 +632,16 @@ def test_get_index_schema_statistics(index_schema_component, expectation):
         *[
             [
                 [check],
-                {
-                    check.name: {
+                [
+                    {
                         **(check.statistics or {}),
-                        "options": {"ignore_na": True, "raise_warning": False},
+                        "options": {
+                            "check_name": check.name,
+                            "ignore_na": True,
+                            "raise_warning": False,
+                        },
                     }
-                },
+                ],
             ]
             for check in [
                 pa.Check.greater_than(1),
@@ -657,40 +660,52 @@ def test_get_index_schema_statistics(index_schema_component, expectation):
         # multiple checks at once
         [
             [
-                pa.Check.greater_than_or_equal_to(10),
-                pa.Check.less_than_or_equal_to(50),
+                pa.Check.in_range(10, 50),
                 pa.Check.isin([10, 20, 30, 40, 50]),
             ],
-            {
-                "greater_than_or_equal_to": {
+            [
+                {
+                    "include_max": True,
+                    "include_min": True,
                     "min_value": 10,
-                    "options": {"ignore_na": True, "raise_warning": False},
-                },
-                "less_than_or_equal_to": {
                     "max_value": 50,
-                    "options": {"ignore_na": True, "raise_warning": False},
+                    "options": {
+                        "check_name": "in_range",
+                        "ignore_na": True,
+                        "raise_warning": False,
+                    },
                 },
-                "isin": {
+                {
                     "allowed_values": [10, 20, 30, 40, 50],
-                    "options": {"ignore_na": True, "raise_warning": False},
+                    "options": {
+                        "check_name": "isin",
+                        "ignore_na": True,
+                        "raise_warning": False,
+                    },
                 },
-            },
+            ],
         ],
         # incompatible checks
-        *[
+        [
             [
-                [
-                    pa.Check.greater_than_or_equal_to(min_value),
-                    pa.Check.less_than_or_equal_to(max_value),
-                ],
-                ValueError,
-            ]
-            for min_value, max_value in [
-                (5, 1),
-                (10, 1),
-                (100, 10),
-                (1000, 100),
-            ]
+                pa.Check.greater_than_or_equal_to(1),
+                pa.Check.less_than_or_equal_to(2),
+            ],
+            ValueError,
+        ],
+        [
+            [
+                pa.Check.ge(1),
+                pa.Check.le(2),
+            ],
+            ValueError,
+        ],
+        [
+            [
+                pa.Check.greater_than(1),
+                pa.Check.in_range(2, 4),
+            ],
+            ValueError,
         ],
     ],
 )
@@ -724,11 +739,15 @@ def test_parse_checks_and_statistics_no_param(extra_registered_checks):
     """
 
     checks = [pa.Check.no_param_check()]
-    expectation = {
-        "no_param_check": {
-            "options": {"ignore_na": True, "raise_warning": False}
+    expectation = [
+        {
+            "options": {
+                "check_name": "no_param_check",
+                "ignore_na": True,
+                "raise_warning": False,
+            }
         }
-    }
+    ]
     assert schema_statistics.parse_checks(checks) == expectation
 
     check_statistics = {check.name: check.statistics for check in checks}


### PR DESCRIPTION
Serialization of checks does only support one check per check function, because [parse_checks](https://github.com/unionai-oss/pandera/blob/7eb35b69a790a09aafa571f92d4fa1ca2655687a/pandera/schema_statistics/pandas.py#L159) is creating dictionary instead of list and the error is propagated further. 
Dictionary keys are checks names and values are checks properties in dictionary. I replaced main dictionary with list and added check name to check properties dictionary under `options:check_name` key. 

My change cause problem with code in [parse_checks](https://github.com/unionai-oss/pandera/blob/7eb35b69a790a09aafa571f92d4fa1ca2655687a/pandera/schema_statistics/pandas.py#L195) under `# Check for incompatible checks` section. This check does not make sense now, because we can have multiple checks with the same name. I initially thought that it is reasonable to allow only one check out of below functions
```
    # incompatibile_checks = {
    #     "greater_than": "gt",
    #     "less_than": "lt",
    #     "greater_than_or_equal_to": "lt",
    #     "less_than_or_equal_to": "le",
    #     "in_range": "between",
    # }
```
I added check for this and updated [test_schema_statistics.py](https://github.com/unionai-oss/pandera/blob/main/tests/pandas/test_schema_statistics.py) tests. 
Do you agree with above change @cosmicBboy? If you are ok with this I will update remaining tests to pass above incompatibility check. 

Fixes #1937