### PR TITLE
Minor documentation fix: `polars_version` docstring referenced `modin` not `polars`

### DIFF
--- a/pandera/typing/polars.py
+++ b/pandera/typing/polars.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 def polars_version():
-    """Return the modin version."""
+    """Return the polars version."""
     return version.parse(pl.__version__)
 
 


### PR DESCRIPTION
The docstring of `polars_version` referenced `modin` instead of `polars`.