### PR TITLE
bugfix/1927

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -43,6 +43,8 @@ except ImportError:  # pragma: no cover
 if PYDANTIC_V2:
     from pydantic import GetCoreSchemaHandler
     from pydantic_core import core_schema
+    from packaging import version
+    import pydantic_core
 
 
 Bool = dtypes.Bool  #: ``"bool"`` numpy dtype
@@ -275,32 +277,39 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 schema_model=schema_model,
             )
 
-            if isinstance(schema_model, TypeVar):
+            if version.parse(pydantic_core.__version__).release < (
+                2,
+                30,
+                0,
+            ) or isinstance(schema_model, TypeVar):
                 return core_schema.no_info_plain_validator_function(function)
+            else:
+                schema = schema_model.to_schema()
+                schema_json_columns = schema_model.to_json_schema()[
+                    "properties"
+                ]
+                type_map = {
+                    "string": core_schema.str_schema(),
+                    "integer": core_schema.int_schema(),
+                    "number": core_schema.float_schema(),
+                    "boolean": core_schema.bool_schema(),
+                    "datetime": core_schema.datetime_schema(),
+                    "duration": core_schema.timedelta_schema(),
+                    "any": core_schema.any_schema(),
+                }
 
-            schema = schema_model.to_schema()
-            schema_json_columns = schema_model.to_json_schema()["properties"]
-            type_map = {
-                "string": core_schema.str_schema(),
-                "integer": core_schema.int_schema(),
-                "number": core_schema.float_schema(),
-                "boolean": core_schema.bool_schema(),
-                "datetime": core_schema.datetime_schema(),
-                "duration": core_schema.timedelta_schema(),
-                "any": core_schema.any_schema(),
-            }
-
-            json_schema_input_schema = core_schema.list_schema(
-                core_schema.typed_dict_schema(
-                    {
-                        key: core_schema.typed_dict_field(
-                            type_map[schema_json_columns[key]["items"]["type"]]
-                        )
-                        for key in schema.columns.keys()
-                    },
+                json_schema_input_schema = core_schema.list_schema(
+                    core_schema.typed_dict_schema(
+                        {
+                            key: core_schema.typed_dict_field(
+                                type_map[
+                                    schema_json_columns[key]["items"]["type"]
+                                ]
+                            )
+                            for key in schema.columns.keys()
+                        },
+                    )
                 )
-            )
-            try:
                 # json schema input schema is only available in
                 # pydantic_core >=2.30.0
                 return core_schema.no_info_plain_validator_function(
@@ -312,8 +321,6 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                         return_schema=json_schema_input_schema,
                     ),
                 )
-            except TypeError:
-                return core_schema.no_info_plain_validator_function(function)
 
     else:
 

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -15,7 +15,6 @@ from typing import (  # type: ignore[attr-defined]
     Union,
     _type_check,
 )
-from importlib.metadata import version
 
 import numpy as np
 import pandas as pd
@@ -276,35 +275,32 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 schema_model=schema_model,
             )
 
-            if version("pydantic-core") < "2.30.0":
+            if isinstance(schema_model, TypeVar):
                 return core_schema.no_info_plain_validator_function(function)
-            else:
-                schema = schema_model.to_schema()
-                schema_json_columns = schema_model.to_json_schema()[
-                    "properties"
-                ]
-                type_map = {
-                    "string": core_schema.str_schema(),
-                    "integer": core_schema.int_schema(),
-                    "number": core_schema.float_schema(),
-                    "boolean": core_schema.bool_schema(),
-                    "datetime": core_schema.datetime_schema(),
-                    "duration": core_schema.timedelta_schema(),
-                    "any": core_schema.any_schema(),
-                }
 
-                json_schema_input_schema = core_schema.list_schema(
-                    core_schema.typed_dict_schema(
-                        {
-                            key: core_schema.typed_dict_field(
-                                type_map[
-                                    schema_json_columns[key]["items"]["type"]
-                                ]
-                            )
-                            for key in schema.columns.keys()
-                        },
-                    )
+            schema = schema_model.to_schema()
+            schema_json_columns = schema_model.to_json_schema()["properties"]
+            type_map = {
+                "string": core_schema.str_schema(),
+                "integer": core_schema.int_schema(),
+                "number": core_schema.float_schema(),
+                "boolean": core_schema.bool_schema(),
+                "datetime": core_schema.datetime_schema(),
+                "duration": core_schema.timedelta_schema(),
+                "any": core_schema.any_schema(),
+            }
+
+            json_schema_input_schema = core_schema.list_schema(
+                core_schema.typed_dict_schema(
+                    {
+                        key: core_schema.typed_dict_field(
+                            type_map[schema_json_columns[key]["items"]["type"]]
+                        )
+                        for key in schema.columns.keys()
+                    },
                 )
+            )
+            try:
                 # json schema input schema is only available in
                 # pydantic_core >=2.30.0
                 return core_schema.no_info_plain_validator_function(
@@ -316,6 +312,8 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                         return_schema=json_schema_input_schema,
                     ),
                 )
+            except TypeError:
+                return core_schema.no_info_plain_validator_function(function)
 
     else:
 

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -15,6 +15,7 @@ from typing import (  # type: ignore[attr-defined]
     Union,
     _type_check,
 )
+from importlib.metadata import version
 
 import numpy as np
 import pandas as pd
@@ -32,6 +33,7 @@ from pandera.typing.common import (
 )
 from pandera.typing.formats import Formats
 from pandera.config import config_context
+
 
 try:
     from typing import _GenericAlias  # type: ignore[attr-defined]
@@ -268,32 +270,43 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
             # prevent validation in __setattr__ function in DataFrameBase class
             with config_context(validation_enabled=False):
                 schema_model = _source_type().__orig_class__.__args__[0]
-            schema = schema_model.to_schema()
-            schema_json_columns = schema_model.to_json_schema()["properties"]
-            type_map = {
-                "string": core_schema.str_schema(),
-                "integer": core_schema.int_schema(),
-                "number": core_schema.float_schema(),
-                "boolean": core_schema.bool_schema(),
-                "datetime": core_schema.datetime_schema(),
-                "duration": core_schema.timedelta_schema(),
-                "any": core_schema.any_schema(),
-            }
+
             function = functools.partial(
                 cls.pydantic_validate,
                 schema_model=schema_model,
             )
-            json_schema_input_schema = core_schema.list_schema(
-                core_schema.typed_dict_schema(
-                    {
-                        key: core_schema.typed_dict_field(
-                            type_map[schema_json_columns[key]["items"]["type"]]
-                        )
-                        for key in schema.columns.keys()
-                    },
+
+            if version("pydantic-core") < "2.30.0" or isinstance(
+                schema_model, TypeVar
+            ):
+                return core_schema.no_info_plain_validator_function(function)
+            else:
+                schema = schema_model.to_schema()
+                schema_json_columns = schema_model.to_json_schema()[
+                    "properties"
+                ]
+                type_map = {
+                    "string": core_schema.str_schema(),
+                    "integer": core_schema.int_schema(),
+                    "number": core_schema.float_schema(),
+                    "boolean": core_schema.bool_schema(),
+                    "datetime": core_schema.datetime_schema(),
+                    "duration": core_schema.timedelta_schema(),
+                    "any": core_schema.any_schema(),
+                }
+
+                json_schema_input_schema = core_schema.list_schema(
+                    core_schema.typed_dict_schema(
+                        {
+                            key: core_schema.typed_dict_field(
+                                type_map[
+                                    schema_json_columns[key]["items"]["type"]
+                                ]
+                            )
+                            for key in schema.columns.keys()
+                        },
+                    )
                 )
-            )
-            try:
                 # json schema input schema is only available in
                 # pydantic_core >=2.30.0
                 return core_schema.no_info_plain_validator_function(
@@ -305,8 +318,6 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                         return_schema=json_schema_input_schema,
                     ),
                 )
-            except TypeError:
-                return core_schema.no_info_plain_validator_function(function)
 
     else:
 

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -276,9 +276,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
                 schema_model=schema_model,
             )
 
-            if version("pydantic-core") < "2.30.0" or isinstance(
-                schema_model, TypeVar
-            ):
+            if version("pydantic-core") < "2.30.0":
                 return core_schema.no_info_plain_validator_function(function)
             else:
                 schema = schema_model.to_schema()

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -227,5 +227,3 @@ def test_typed_generic_dataframe():
     valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
 
     schema(df=valid_df)
-
-    schema.model_json_schema()

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -227,6 +227,22 @@ def test_model_with_extensiondtype_column(col_type, dtype, item):
 
 @pytest.mark.skipif(
     not PYDANTIC_V2,
+    reason="Pydantic <2 does not use Pydantic-Core",
+)
+def test_typed_dataframe_model_json_schema():
+    """Test that typed generic DataFrame generates model json schema."""
+
+    # pylint: disable-next=possibly-used-before-assignment
+    if version.parse(pydantic_core.__version__).release >= (
+        2,
+        30,
+        0,
+    ):
+        assert isinstance(TypedDfPydantic.model_json_schema(), dict)
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
     reason="Pydantic <2 cannot catch the invalid dataframe validation error",
 )
 def test_typed_generic_dataframe():

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -224,4 +224,8 @@ def test_typed_generic_dataframe():
 
     schema = TypedDfGenericPydantic[SimpleSchema]
 
-    schema.to_schema()
+    valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
+
+    schema(df=valid_df)
+
+    schema.model_json_schema()

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -225,6 +225,10 @@ def test_model_with_extensiondtype_column(col_type, dtype, item):
     )
 
 
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 cannot catch the invalid dataframe validation error",
+)
 def test_typed_generic_dataframe():
     """Test that typed generic DataFrame is compatible with pydantic."""
     valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
@@ -233,16 +237,6 @@ def test_typed_generic_dataframe():
     invalid_df = pd.DataFrame({"str_col": ["hello", "hello"]})
     with pytest.raises(ValidationError):
         TypedDfGenericPydantic[SimpleSchema](df=invalid_df)
-
-
-@pytest.mark.skipif(
-    not PYDANTIC_V2,
-    reason="Pydantic <2 cannot catch the invalid dataframe model error",
-)
-def test_invalid_typed_generic_dataframe():
-    """Test that an invalid typed generic DataFrame is recognized by pandera."""
-    with pytest.raises(ValidationError):
-        TypedDfGenericPydantic[SimpleSchema](df=1)
 
 
 @pytest.mark.skipif(

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -2,7 +2,10 @@
 
 # pylint:disable=too-few-public-methods,missing-class-docstring
 from typing import Optional
-
+from typing import (
+    Generic,
+    TypeVar,
+)
 import pandas as pd
 import pytest
 
@@ -208,3 +211,17 @@ def test_model_with_extensiondtype_column(col_type, dtype, item):
         ),
         PydanticModel,
     )
+
+
+def test_typed_generic_dataframe():
+    """Test that typed generic DataFrame is created without errors."""
+    TableT = TypeVar("TableT", bound=pa.DataFrameModel)
+
+    class TypedDfGenericPydantic(BaseModel, Generic[TableT]):
+        """Test pydantic model with typed generic dataframe."""
+
+        df: DataFrame[TableT]
+
+    schema = TypedDfGenericPydantic[SimpleSchema]
+
+    schema.to_schema()

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -6,6 +6,7 @@ from typing import (
     Generic,
     TypeVar,
 )
+
 import pandas as pd
 import pytest
 
@@ -22,6 +23,8 @@ except ImportError:
 PYDANTIC_V2 = False
 if pydantic_version().release >= (2, 0, 0):
     PYDANTIC_V2 = True
+    from packaging import version
+    import pydantic_core
 
 
 class SimpleSchema(pa.DataFrameModel):
@@ -55,6 +58,15 @@ class SeriesSchemaPydantic(BaseModel):
     pa_series_schema: Optional[pa.SeriesSchema]
     pa_column: Optional[pa.Column]
     pa_index: Optional[pa.Index]
+
+
+TableT = TypeVar("TableT", bound=pa.DataFrameModel)
+
+
+class TypedDfGenericPydantic(BaseModel, Generic[TableT]):
+    """Test pydantic model with typed generic dataframe."""
+
+    df: DataFrame[TableT]
 
 
 def test_typed_dataframe():
@@ -214,16 +226,38 @@ def test_model_with_extensiondtype_column(col_type, dtype, item):
 
 
 def test_typed_generic_dataframe():
-    """Test that typed generic DataFrame is created without errors."""
-    TableT = TypeVar("TableT", bound=pa.DataFrameModel)
-
-    class TypedDfGenericPydantic(BaseModel, Generic[TableT]):
-        """Test pydantic model with typed generic dataframe."""
-
-        df: DataFrame[TableT]
-
-    schema = TypedDfGenericPydantic[SimpleSchema]
-
+    """Test that typed generic DataFrame is compatible with pydantic."""
     valid_df = pd.DataFrame({"str_col": ["hello", "world"]})
+    TypedDfGenericPydantic[SimpleSchema](df=valid_df)
 
-    schema(df=valid_df)
+    invalid_df = pd.DataFrame({"str_col": ["hello", "hello"]})
+    with pytest.raises(ValidationError):
+        TypedDfGenericPydantic[SimpleSchema](df=invalid_df)
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 cannot catch the invalid dataframe model error",
+)
+def test_invalid_typed_generic_dataframe():
+    """Test that an invalid typed generic DataFrame is recognized by pandera."""
+    with pytest.raises(ValidationError):
+        TypedDfGenericPydantic[SimpleSchema](df=1)
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 does not use Pydantic-Core",
+)
+def test_typed_generic_dataframe_model_json_schema():
+    """Test that typed generic DataFrame generates model json schema."""
+
+    # pylint: disable-next=possibly-used-before-assignment
+    if version.parse(pydantic_core.__version__).release < (
+        2,
+        30,
+        0,
+    ):
+        assert isinstance(
+            TypedDfGenericPydantic[SimpleSchema].model_json_schema(), dict
+        )

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -253,7 +253,7 @@ def test_typed_generic_dataframe_model_json_schema():
     """Test that typed generic DataFrame generates model json schema."""
 
     # pylint: disable-next=possibly-used-before-assignment
-    if version.parse(pydantic_core.__version__).release < (
+    if version.parse(pydantic_core.__version__).release >= (
         2,
         30,
         0,


### PR DESCRIPTION
fixes #1927 https://github.com/Deltares/Ribasim/issues/2120

In `__get_pydantic_core_schema__` function I added condition to check if `pydantic-core` package version is above `2.30.0` or `DataFrame` underlying type is `TypeVar`, when it is positive the function executes `core_schema.no_info_plain_validator_function` without `json_schema_input_schema` and `serializastion` parameters.

I also added a few tests checking if `pydantic` models are created correctly.