### PR TITLE
Bugfix/2017: Fix issue where "pyarrow[string]" gets clobbered by `pd.ArrowDtype(pyarrow.string()`

### DIFF
--- a/foo.py
+++ b/foo.py
@@ -2,6 +2,6 @@ import pandas as pd
 import pandera.pandas as pa
 
 
-df = pd.DataFrame({"col1": ["a", "b"]}, dtype = "string[pyarrow]")
+df = pd.DataFrame({"col1": ["a", "b"]}, dtype="string[pyarrow]")
 schema = pa.DataFrameSchema(columns={"col1": pa.Column("string[pyarrow]")})
 schema.validate(df)

--- a/foo.py
+++ b/foo.py
@@ -1,0 +1,7 @@
+import pandas as pd
+import pandera.pandas as pa
+
+
+df = pd.DataFrame({"col1": ["a", "b"]}, dtype = "string[pyarrow]")
+schema = pa.DataFrameSchema(columns={"col1": pa.Column("string[pyarrow]")})
+schema.validate(df)

--- a/foo.py
+++ b/foo.py
@@ -1,7 +1,0 @@
-import pandas as pd
-import pandera.pandas as pa
-
-
-df = pd.DataFrame({"col1": ["a", "b"]}, dtype="string[pyarrow]")
-schema = pa.DataFrameSchema(columns={"col1": pa.Column("string[pyarrow]")})
-schema.validate(df)

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -67,15 +67,16 @@ def _is_namedtuple(x: Type) -> bool:
 
 
 KT = TypeVar("KT")
-VT = TypeVar("VT") 
+VT = TypeVar("VT")
+
 
 class TypeAwareDict(dict[tuple[Any, Type], Any]):
     """A dictionary that is aware of both the key value and its type.
-    
+
     This is needed because some pandas dtypes, e.g. pd.ArrowDtype, defines
     __eq__ logic that returns true if the string representation of the dtype
     is equal to the string literal, for example:
-    
+
     "string[pyarrow]" == pd.ArrowDtype(pyarrow.string()).
     """
 
@@ -86,6 +87,7 @@ class TypeAwareDict(dict[tuple[Any, Type], Any]):
     def __getitem__(self, key: KT) -> VT:
         # return super().__getitem__(key)
         return super().__getitem__((key, type(key)))
+
 
 @dataclass
 class _DtypeRegistry:
@@ -117,7 +119,9 @@ class Engine(ABCMeta):
         def dtype(data_type: Any) -> DataType:
             raise ValueError(f"Data type '{data_type}' not understood")
 
-        mcs._registry[engine] = _DtypeRegistry(dispatch=dtype, equivalents=TypeAwareDict())
+        mcs._registry[engine] = _DtypeRegistry(
+            dispatch=dtype, equivalents=TypeAwareDict()
+        )
         return engine
 
     def _check_source_dtype(cls, data_type: Any) -> None:
@@ -163,6 +167,7 @@ class Engine(ABCMeta):
         pandera_dtype = pandera_dtype_cls()  # type: ignore
         import pandas as pd
         import pyarrow
+
         for source_dtype in source_dtypes:
             cls._check_source_dtype(source_dtype)
             cls._registry[cls].equivalents[source_dtype] = pandera_dtype
@@ -293,7 +298,9 @@ class Engine(ABCMeta):
         try:
             return registry.dispatch(data_type)
         except (KeyError, ValueError):
-            import ipdb; ipdb.set_trace()
+            import ipdb
+
+            ipdb.set_trace()
             raise TypeError(
                 f"Data type '{data_type}' not understood by {cls.__name__}."
             ) from None

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -355,6 +355,8 @@ def _register_numpy_numbers(
         equivalents = {
             np_dtype,
             # e.g.: pandera.dtypes.Int64
+            f"{builtin_name}{bit_width}",
+            f"{pandera_name}{bit_width}",
             getattr(dtypes, f"{pandera_name}{bit_width}"),
             getattr(dtypes, f"{pandera_name}{bit_width}")(),
         }
@@ -687,7 +689,9 @@ class Category(DataType, dtypes.Category):
 
 if PANDAS_1_3_0_PLUS:
 
-    @Engine.register_dtype(equivalents=["string", pd.StringDtype])
+    @Engine.register_dtype(
+        equivalents=["string", pd.StringDtype, pd.StringDtype()]
+    )
     @immutable(init=True)
     class STRING(DataType, dtypes.String):
         """Semantic representation of a :class:`pandas.StringDtype`."""
@@ -1646,8 +1650,8 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
             pyarrow.utf8,
             pyarrow.string(),
             pyarrow.utf8(),
-            # pd.ArrowDtype(pyarrow.string()),
-            # pd.ArrowDtype(pyarrow.utf8()),
+            pd.ArrowDtype(pyarrow.string()),
+            pd.ArrowDtype(pyarrow.utf8()),
         ]
     )
     @immutable

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -714,8 +714,10 @@ if PANDAS_1_3_0_PLUS:
 
         def __str__(self) -> str:
             return repr(self.type)
-        
-    @Engine.register_dtype(equivalents=["string[pyarrow]", pd.StringDtype(storage="pyarrow")])
+
+    @Engine.register_dtype(
+        equivalents=["string[pyarrow]", pd.StringDtype(storage="pyarrow")]
+    )
     @immutable(init=True)
     class _STRING_PYARROW(DataType, dtypes.String):
         """Semantic representation of a :class:`pandas.StringDtype`."""

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Type
 
 import numpy as np
 import pandas as pd
+import pyarrow
 import pytest
 
 import pandera.pandas as pa
@@ -235,6 +236,16 @@ class SchemaFieldSparseDtype(pa.DataFrameModel):
     )
 
 
+class SchemaStringDtypePyarrow(pa.DataFrameModel):
+    col: Series[pd.StringDtype] = pa.Field(dtype_kwargs={"storage": "pyarrow"})
+
+
+class SchemaArrowDtypeString(pa.DataFrameModel):
+    col: Series[pd.ArrowDtype] = pa.Field(
+        dtype_kwargs={"pyarrow_dtype": pyarrow.string()}
+    )
+
+
 @pytest.mark.parametrize(
     "model, dtype, dtype_kwargs",
     [
@@ -254,6 +265,16 @@ class SchemaFieldSparseDtype(pa.DataFrameModel):
             SchemaFieldSparseDtype,
             pd.SparseDtype,
             {"dtype": np.int32, "fill_value": 0},
+        ),
+        (
+            SchemaStringDtypePyarrow,
+            pd.StringDtype,
+            {"storage": "pyarrow"},
+        ),
+        (
+            SchemaArrowDtypeString,
+            pd.ArrowDtype,
+            {"pyarrow_dtype": pyarrow.string()},
         ),
     ],
 )


### PR DESCRIPTION
Fixes #2017

This PR addresses a issue where `Engine.register_dtype` `equivalents` entries would be overridden due to numpy and pandas behavior where dtypes would evaluate to `True` if they are equal to the string representation of the dtype, e.g. `np.dtype("int64") == "int64"`.

This led to the mapping of `pyarrow[string] -> pd.StringDtype()` to being overridden by `pd.ArrowDtype(pyarrow.string())`.

This PR fixes this by:
- Introducing a `TypeAwareDict`, which `_DtypeRegistry.equivalents` now uses to make sure the dtype value and type are the same when registering and getting pandera data types from the `Engine`.
- Adding unit tests to make sure this works correctly