### PR TITLE
fix pyarrow string issue, fix docs failing issues

### DIFF
--- a/docs/source/_templates/modin_class.rst
+++ b/docs/source/_templates/modin_class.rst
@@ -1,0 +1,19 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in attributes %}
+     ~{{ name }}.{{ item }}
+   {%- endfor %}
+
+   {% endif %}
+   {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,6 +263,7 @@ class FilterExternalPackageModinDocUtilsWarnings(pylogging.Filter):
                     "Inline strong start-string without end-string",
                     "Inline interpreted text or phrase reference start-string "
                     "without end-string",
+                    "Unexpected section title",
                 )
             )
         )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -259,7 +259,11 @@ class FilterExternalPackageModinDocUtilsWarnings(pylogging.Filter):
         return not (
             "modin" in record.location
             and record.getMessage().startswith(
-                "Inline strong start-string without end-string",
+                (
+                    "Inline strong start-string without end-string",
+                    "Inline interpreted text or phrase reference start-string "
+                    "without end-string",
+                )
             )
         )
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -254,8 +254,21 @@ class FilterTypeAnnotationWarnings(pylogging.Filter):
         )
 
 
+class FilterExternalPackageModinDocUtilsWarnings(pylogging.Filter):
+    def filter(self, record: pylogging.LogRecord) -> bool:
+        return not (
+            "modin" in record.location
+            and record.getMessage().startswith(
+                "Inline strong start-string without end-string",
+            )
+        )
+
+
 logging.getLogger("sphinx_autodoc_typehints").logger.addFilter(
     FilterTypeAnnotationWarnings()
+)
+logging.getLogger("sphinx.util.docutils").logger.addFilter(
+    FilterExternalPackageModinDocUtilsWarnings()
 )
 
 

--- a/docs/source/reference/dataframe_models.rst
+++ b/docs/source/reference/dataframe_models.rst
@@ -90,9 +90,11 @@ Pyspark
 Modin
 *****
 
+.. use modin_class.rst because modin has some failing doctest code snippets
+
 .. autosummary::
    :toctree: generated
-   :template: class.rst
+   :template: modin_class.rst
 
    pandera.typing.modin.DataFrame
    pandera.typing.modin.Series

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - protobuf
 
   # geopandas extra
-  - geopandas
+  - geopandas < 1.1.0
   - shapely
 
   # fastapi extra

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -255,7 +255,7 @@ class Engine(ABCMeta):
         datatype_origin = typing_inspect.get_origin(data_type)
         if datatype_origin is not None:
             equivalent_data_type = registry.get_equivalent(datatype_origin)
-            return type(equivalent_data_type)(data_type)
+            return type(equivalent_data_type)(data_type)  # type: ignore
 
         # handle python's special declared type constructs like NamedTuple and
         # TypedDict
@@ -276,7 +276,7 @@ class Engine(ABCMeta):
                 raise TypeError(
                     f"Type '{data_type}' not understood by {cls.__name__}."
                 )
-            return type(equivalent_data_type)(data_type)
+            return type(equivalent_data_type)(data_type)  # type: ignore
 
         equivalent_data_type = registry.get_equivalent(data_type)
         if equivalent_data_type is not None:

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -70,6 +70,21 @@ def _is_namedtuple(x: Type) -> bool:
 class _DtypeRegistry:
     dispatch: Dispatch
     equivalents: Dict[Any, DataType]
+    strict_equivalents: Dict[Any, DataType]
+
+    def get_equivalent(self, data_type: Any) -> DataType:
+        if (data_type, type(data_type)) in self.strict_equivalents:
+            return self.strict_equivalents.get((data_type, type(data_type)))
+        return self.equivalents.get(data_type)
+
+
+@dataclass
+class StrictEquivalent:
+    """
+    Represents data types that are equivalent to the pandera DataType that
+    are meant to be evaluated strictly, i.e. not with `data_type == "string_alias`
+    """
+    dtype: DataType
 
 
 class Engine(ABCMeta):
@@ -96,7 +111,9 @@ class Engine(ABCMeta):
         def dtype(data_type: Any) -> DataType:
             raise ValueError(f"Data type '{data_type}' not understood")
 
-        mcs._registry[engine] = _DtypeRegistry(dispatch=dtype, equivalents={})
+        mcs._registry[engine] = _DtypeRegistry(
+            dispatch=dtype, equivalents={}, strict_equivalents={}
+        )
         return engine
 
     def _check_source_dtype(cls, data_type: Any) -> None:
@@ -141,11 +158,17 @@ class Engine(ABCMeta):
     ) -> None:
         pandera_dtype = pandera_dtype_cls()  # type: ignore
         for source_dtype in source_dtypes:
-            cls._check_source_dtype(source_dtype)
-            cls._registry[cls].equivalents[source_dtype] = pandera_dtype
+            if isinstance(source_dtype, StrictEquivalent):
+                cls._check_source_dtype(source_dtype.dtype)
+                cls._registry[cls].strict_equivalents[
+                    (source_dtype.dtype, type(source_dtype.dtype))
+                ] = pandera_dtype
+            else:
+                cls._check_source_dtype(source_dtype)
+                cls._registry[cls].equivalents[source_dtype] = pandera_dtype
 
     def register_dtype(
-        cls: _EngineType,
+        cls: "Engine",
         pandera_dtype_cls: Optional[Type[_DataType]] = None,
         *,
         equivalents: Optional[List[Any]] = None,
@@ -203,7 +226,7 @@ class Engine(ABCMeta):
 
         return _wrapper
 
-    def dtype(cls: _EngineType, data_type: Any) -> DataType:
+    def dtype(cls: "Engine", data_type: Any) -> DataType:
         """Convert input into a Pandera :class:`DataType` object."""
         # pylint: disable=too-many-return-statements
         if isinstance(data_type, cls._base_pandera_dtypes):
@@ -230,7 +253,7 @@ class Engine(ABCMeta):
         # handle python generic types, e.g. typing.Dict[str, str]
         datatype_origin = typing_inspect.get_origin(data_type)
         if datatype_origin is not None:
-            equivalent_data_type = registry.equivalents.get(datatype_origin)
+            equivalent_data_type = registry.get_equivalent(datatype_origin)
             return type(equivalent_data_type)(data_type)
 
         # handle python's special declared type constructs like NamedTuple and
@@ -246,7 +269,7 @@ class Engine(ABCMeta):
         if datatype_generic_bases:
             equivalent_data_type = None
             for base in datatype_generic_bases:
-                equivalent_data_type = registry.equivalents.get(base)
+                equivalent_data_type = registry.get_equivalent(base)
                 break
             if equivalent_data_type is None:
                 raise TypeError(
@@ -254,14 +277,14 @@ class Engine(ABCMeta):
                 )
             return type(equivalent_data_type)(data_type)
 
-        equivalent_data_type = registry.equivalents.get(data_type)
+        equivalent_data_type = registry.get_equivalent(data_type)
         if equivalent_data_type is not None:
             return equivalent_data_type
         elif isinstance(data_type, DataType):
             # in the case where data_type is a parameterized dtypes.DataType instance that isn't
             # in the equivalents registry, use its type to get the equivalent, and feed
             # the parameters into the recognized data type class.
-            equivalent_data_type = registry.equivalents.get(type(data_type))
+            equivalent_data_type = registry.get_equivalent(type(data_type))
             if equivalent_data_type is not None:
                 return type(equivalent_data_type)(**data_type.__dict__)
 

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -72,7 +72,7 @@ class _DtypeRegistry:
     equivalents: Dict[Any, DataType]
     strict_equivalents: Dict[Any, DataType]
 
-    def get_equivalent(self, data_type: Any) -> DataType:
+    def get_equivalent(self, data_type: Any) -> Optional[DataType]:
         if (data_type, type(data_type)) in self.strict_equivalents:
             return self.strict_equivalents.get((data_type, type(data_type)))
         return self.equivalents.get(data_type)
@@ -84,6 +84,7 @@ class StrictEquivalent:
     Represents data types that are equivalent to the pandera DataType that
     are meant to be evaluated strictly, i.e. not with `data_type == "string_alias`
     """
+
     dtype: DataType
 
 

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1493,7 +1493,7 @@ class PythonTypedDict(PythonGenericType):
             )
 
     def __str__(self) -> str:
-        return str(TypedDict.__name__)  # type: ignore[attr-defined]
+        return "TypedDict"
 
 
 @Engine.register_dtype(equivalents=[NamedTuple, "NamedTuple"])

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1614,8 +1614,15 @@ if PYARROW_INSTALLED and PANDAS_2_0_0_PLUS:
         equivalents=[
             pyarrow.string,
             pyarrow.utf8,
-            pd.ArrowDtype(pyarrow.string()),
-            pd.ArrowDtype(pyarrow.utf8()),
+            # the `string[pyarrow]` string alias is overloaded: it can be either
+            # pd.StringDtype or pd.ArrowDtype(pyarrow.string()). Pandera handles
+            # like this pandas, where `string[pyarrow]` is interpreted as
+            # pd.StringDtype. The StrictEquivalent object ensures that the
+            # engine registers the following two types in terms of the type's
+            # string __repr__ method ("string[pyarrow]") and its type
+            # (pd.ArrowDtype).
+            engine.StrictEquivalent(pd.ArrowDtype(pyarrow.string())),
+            engine.StrictEquivalent(pd.ArrowDtype(pyarrow.utf8())),
         ]
     )
     @immutable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ all = [
     "distributed",
     "pandas-stubs",
     "fastapi",
-    "geopandas",
+    "geopandas < 1.1.0",
     "shapely",
     "polars >= 0.20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ io = [
 mypy = ["pandas-stubs"]
 fastapi = ["fastapi"]
 geopandas = [
-    "geopandas",
+    "geopandas < 1.1.0",
     "shapely",
 ]
 pyspark = ["pyspark[connect] >= 3.2.0, < 4.0.0"]
@@ -107,6 +107,7 @@ all = [
 [dependency-groups]
 dev = [
     "hypothesis >= 6.92.7",
+    "ipdb",
     "isort >= 5.7.0",
     "joblib",
     "mypy == 1.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pyspark[connect] >= 3.2.0, < 4.0.0
 polars >= 0.20.0
 modin
 protobuf
-geopandas
+geopandas < 1.1.0
 shapely
 fastapi
 black >= 24.0

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -57,10 +57,10 @@ def test_pandas_data_type(data_type):
         isinstance(data_type.type, pd.ArrowDtype)
         and data_type.type == "string[pyarrow]"
     ):
-       # the `string[pyarrow]` string alias is overloaded: it can be either
-       # pd.StringDtype or pd.ArrowDtype(pyarrow.string()). Pandera handles
-       # like this pandas, where `string[pyarrow]` is interpreted as pd.StringDtype
-       pass
+        # the `string[pyarrow]` string alias is overloaded: it can be either
+        # pd.StringDtype or pd.ArrowDtype(pyarrow.string()). Pandera handles
+        # like this pandas, where `string[pyarrow]` is interpreted as pd.StringDtype
+        pass
     else:
         assert pd_dtype == pd_dtype_from_str
 

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -201,7 +201,12 @@ def _test_annotated_dtype(
 
     actual = schema.columns["col"].dtype
     expected = pa.Column(dtype(**dtype_kwargs), name="col").dtype
-    assert actual == expected
+
+    if isinstance(actual.type, pd.SparseDtype):
+        assert actual.type.type == expected.type.type
+        assert np.isnan(actual.type.fill_value) == np.isnan(expected.type.fill_value)
+    else:
+        assert actual == expected
 
 
 def _test_default_annotated_dtype(
@@ -235,6 +240,10 @@ class SchemaFieldSparseDtype(pa.DataFrameModel):
     )
 
 
+class SchemaFieldStringDtypeArrow(pa.DataFrameModel):
+    col: Series[pd.StringDtype] = pa.Field(dtype_kwargs={"storage": "pyarrow"})
+
+
 @pytest.mark.parametrize(
     "model, dtype, dtype_kwargs",
     [
@@ -254,6 +263,11 @@ class SchemaFieldSparseDtype(pa.DataFrameModel):
             SchemaFieldSparseDtype,
             pd.SparseDtype,
             {"dtype": np.int32, "fill_value": 0},
+        ),
+        (
+            SchemaFieldStringDtypeArrow,
+            pd.StringDtype,
+            {"storage": "pyarrow"},
         ),
     ],
 )

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -204,7 +204,9 @@ def _test_annotated_dtype(
 
     if isinstance(actual.type, pd.SparseDtype):
         assert actual.type.type == expected.type.type
-        assert np.isnan(actual.type.fill_value) == np.isnan(expected.type.fill_value)
+        assert np.isnan(actual.type.fill_value) == np.isnan(
+            expected.type.fill_value
+        )
     else:
         assert actual == expected
 


### PR DESCRIPTION
Fixes #2017 

This PR addresses a issue where Engine.register_dtype equivalents entries would be overridden due to numpy and pandas behavior where dtypes would evaluate to True if they are equal to the string representation of the dtype, e.g. `np.dtype("int64") == "int64"`.

This led to the mapping of `pyarrow[string] -> pd.StringDtype()` to being overridden by pd.ArrowDtype(pyarrow.string()).

This PR fixes this by:

Introducing a `StrictEquivalent` dataclass to make sure that specific registered datatype equivalents are registered under a `strict_equivalents` registry that keeps track of both the type value and its underlying type so that the problem articulated above doesn't happen.