### PR TITLE
bugfix/2031: Allow strict='filter' and coerce='True' at the same time for PySpark schemas

### DIFF
--- a/pandera/backends/pyspark/container.py
+++ b/pandera/backends/pyspark/container.py
@@ -391,7 +391,9 @@ class DataFrameSchemaBackend(PysparkSchemaBackend):
                     )
 
         if schema.strict == "filter":
+            schema = check_obj.pandera.schema
             check_obj = check_obj.drop(*filter_out_columns)
+            check_obj.pandera.add_schema(schema)
 
         return check_obj
 

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -370,6 +370,7 @@ def test_dataframe_schema_strict(
             if df_out.pandera.errors:
                 raise pa.PysparkSchemaError
 
+        schema.coerce = True
         schema.strict = "filter"
         assert isinstance(schema.validate(df), DataFrame)
 


### PR DESCRIPTION
Fix for https://github.com/unionai-oss/pandera/issues/2031.
The _check_obj.pandera.schema_ attribute is restored after columns are dropped.
The fix is similar to what is done (for example) already here:
https://github.com/unionai-oss/pandera/blob/main/pandera/backends/pyspark/container.py#L455
The modified test would fail without this patch.