### PR TITLE
Expect Python slice index errors after Python 3.10

### DIFF
--- a/tests/mypy/test_pandas_static_type_checking.py
+++ b/tests/mypy/test_pandas_static_type_checking.py
@@ -176,7 +176,7 @@ PANDAS_SERIES_ERRORS_PLUGIN = [
         [
             "python_slice.py",
             "plugin_mypy.ini",
-            PYTHON_SLICE_ERRORS if sys.version_info > (3, 10) else [],
+            PYTHON_SLICE_ERRORS if sys.version_info >= (3, 11) else [],
         ],
         ["pandas_index.py", "no_plugin.ini", []],
         ["pandas_index.py", "plugin_mypy.ini", []],

--- a/tests/mypy/test_pandas_static_type_checking.py
+++ b/tests/mypy/test_pandas_static_type_checking.py
@@ -173,7 +173,11 @@ PANDAS_SERIES_ERRORS_PLUGIN = [
         ["pandas_time.py", "no_plugin.ini", PANDAS_TIME_ERRORS],
         ["pandas_time.py", "plugin_mypy.ini", PANDAS_TIME_ERRORS],
         ["python_slice.py", "no_plugin.ini", PYTHON_SLICE_ERRORS],
-        ["python_slice.py", "plugin_mypy.ini", PYTHON_SLICE_ERRORS],
+        [
+            "python_slice.py",
+            "plugin_mypy.ini",
+            PYTHON_SLICE_ERRORS if sys.version_info > (3, 10) else [],
+        ],
         ["pandas_index.py", "no_plugin.ini", []],
         ["pandas_index.py", "plugin_mypy.ini", []],
         ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS_NO_PLUGIN],

--- a/tests/mypy/test_pandas_static_type_checking.py
+++ b/tests/mypy/test_pandas_static_type_checking.py
@@ -173,7 +173,7 @@ PANDAS_SERIES_ERRORS_PLUGIN = [
         ["pandas_time.py", "no_plugin.ini", PANDAS_TIME_ERRORS],
         ["pandas_time.py", "plugin_mypy.ini", PANDAS_TIME_ERRORS],
         ["python_slice.py", "no_plugin.ini", PYTHON_SLICE_ERRORS],
-        ["python_slice.py", "plugin_mypy.ini", []],
+        ["python_slice.py", "plugin_mypy.ini", PYTHON_SLICE_ERRORS],
         ["pandas_index.py", "no_plugin.ini", []],
         ["pandas_index.py", "plugin_mypy.ini", []],
         ["pandas_series.py", "no_plugin.ini", PANDAS_SERIES_ERRORS_NO_PLUGIN],


### PR DESCRIPTION
Address CI failures from https://github.com/unionai-oss/pandera/pull/2030, as seen in https://github.com/unionai-oss/pandera/actions/runs/15526426636/job/43706977542?pr=2030

~(Going to check whether it runs into the error on `main`, since I rebased and got it, and it was suppressed recently)~ Seems the error is only on 3.11/3.12