### PR TITLE
handle dataframe-level failure cases: convert row to dict

### DIFF
--- a/pandera/backends/ibis/base.py
+++ b/pandera/backends/ibis/base.py
@@ -57,8 +57,19 @@ class IbisSchemaBackend(BaseSchemaBackend):
                     schema, check, check_index
                 )
             else:
+                import pandas as pd
+                from pandera.api.pandas.types import is_table
+
+                check_failure_cases = check_result.failure_cases.to_pandas()
+                if is_table(check_failure_cases):
+                    check_failure_cases = (
+                        pd.Series(check_failure_cases.to_dict("records"))
+                        .rename("failure_case")
+                        .to_frame()
+                    )
+
                 failure_cases = reshape_failure_cases(
-                    check_result.failure_cases.to_pandas(), check.ignore_na
+                    check_failure_cases, check.ignore_na
                 )
                 message = format_vectorized_error_message(
                     schema, check, check_index, failure_cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ dev = [
     "joblib",
     "mypy == 1.10.0",
     "pip",
+    "polars >= 0.20.0",
     "pre_commit",
     "pyarrow >= 13",
     "pylint < 3.3",

--- a/tests/ibis/test_ibis_container.py
+++ b/tests/ibis/test_ibis_container.py
@@ -81,4 +81,4 @@ def test_dataframe_level_checks():
     try:
         t.pipe(schema.validate, lazy=True)
     except pa.errors.SchemaErrors as err:
-        assert err.failure_cases.shape[0] == 12
+        assert err.failure_cases.shape[0] == 6


### PR DESCRIPTION
hey @deepyaman, here's a potential implementation to handle dataframe-level checks to prevent pivoting failure cases to long-form data, as discussed here: https://github.com/unionai-oss/pandera/pull/2041#discussion_r2155282953