### PR TITLE
[🦩 ibis] Limit reported failure cases if Check.n_failure_cases is defined.

### DIFF
--- a/pandera/backends/ibis/checks.py
+++ b/pandera/backends/ibis/checks.py
@@ -157,6 +157,10 @@ class IbisCheckBackend(BaseCheckBackend):
         failure_cases = check_obj.table.filter(~check_output)
         if check_obj.key is not None:
             failure_cases = failure_cases.select(check_obj.key)
+
+        if self.check.n_failure_cases is not None:
+            failure_cases = failure_cases.limit(self.check.n_failure_cases)
+
         return CheckResult(
             check_output=check_output,
             check_passed=check_output.all(),
@@ -177,6 +181,10 @@ class IbisCheckBackend(BaseCheckBackend):
         )
         if check_obj.key is not None:
             failure_cases = failure_cases.select(check_obj.key)
+
+        if self.check.n_failure_cases is not None:
+            failure_cases = failure_cases.limit(self.check.n_failure_cases)
+
         return CheckResult(
             check_output=check_output.select(CHECK_OUTPUT_KEY),
             check_passed=passed,

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -194,6 +194,7 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                     column=pl.lit(err.schema.name),
                     check=pl.lit(check_identifier),
                     check_number=pl.lit(err.check_index),
+                    # index=index.limit(failure_cases_df.shape[0]),
                     index=index,
                 ).cast(
                     {

--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -194,8 +194,7 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                     column=pl.lit(err.schema.name),
                     check=pl.lit(check_identifier),
                     check_number=pl.lit(err.check_index),
-                    # index=index.limit(failure_cases_df.shape[0]),
-                    index=index,
+                    index=index.limit(failure_cases_df.shape[0]),
                 ).cast(
                     {
                         "failure_case": pl.Utf8,

--- a/pandera/backends/polars/checks.py
+++ b/pandera/backends/polars/checks.py
@@ -101,6 +101,10 @@ class PolarsCheckBackend(BaseCheckBackend):
 
         if check_obj.key != "*":
             failure_cases = failure_cases.select(check_obj.key)
+
+        if self.check.n_failure_cases is not None:
+            failure_cases = failure_cases.limit(self.check.n_failure_cases)
+
         return CheckResult(
             check_output=results,
             check_passed=passed,

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -72,8 +72,12 @@ def polars_object_coercible(
 ) -> pl.LazyFrame:
     """Checks whether a polars object is coercible with respect to a type."""
     key = data_container.key or "*"
+
+    # do a strict cast for list types since is_not_null() cannot correctly
+    # evaluate null values in lists.
+    strict = isinstance(type_, pl.List)
     coercible = data_container.lazyframe.cast(
-        {key: type_}, strict=False
+        {key: type_}, strict=strict
     ).select(pl.col(key).is_not_null())
     # reduce to a single boolean column
     return coercible.select(pl.all_horizontal(key).alias(CHECK_OUTPUT_KEY))

--- a/tests/ibis/test_ibis_check.py
+++ b/tests/ibis/test_ibis_check.py
@@ -252,3 +252,29 @@ def test_ibis_custom_check():
         {"column1": [None], "column2": [None]}
     )
     assert failure_cases.equals(expected_failure_cases)
+
+
+def test_ibis_column_check_n_failure_cases(column_t):
+    n_failure_cases = 2
+    check = pa.Check(
+        lambda data: data.table.select(s.across(s.numeric(), _ < 0)),
+        n_failure_cases=n_failure_cases,
+    )
+    schema = pa.DataFrameSchema({"col": pa.Column(checks=check)})
+    try:
+        schema.validate(column_t, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == n_failure_cases
+
+
+def test_ibis_dataframe_check_n_failure_cases(t):
+    n_failure_cases = 2
+    check = pa.Check(
+        lambda data: data.table.select(s.across(s.numeric(), _ < 0)),
+        n_failure_cases=n_failure_cases,
+    )
+    schema = pa.DataFrameSchema(checks=check)
+    try:
+        schema.validate(t, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == n_failure_cases

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -232,3 +232,31 @@ def test_polars_custom_check():
 
     with pytest.raises(pa.errors.SchemaError):
         schema.validate(invalid_lf)
+
+
+def test_polars_column_check_n_failure_cases(column_lf):
+    n_failure_cases = 2
+    check = pa.Check(
+        lambda data: data.lazyframe.select(pl.col("*").lt(0)),
+        n_failure_cases=n_failure_cases,
+    )
+    schema = pa.DataFrameSchema({"col": pa.Column(checks=check)})
+
+    try:
+        schema.validate(column_lf, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == n_failure_cases
+
+
+def test_polars_dataframe_check_n_failure_cases(lf):
+    n_failure_cases = 2
+    check = pa.Check(
+        lambda data: data.lazyframe.select(pl.col("*").lt(0)),
+        n_failure_cases=n_failure_cases,
+    )
+    schema = pa.DataFrameSchema(checks=check)
+
+    try:
+        schema.validate(lf, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == n_failure_cases


### PR DESCRIPTION
This PR implements a parity feature that's available in the pandas backend. Essentially, if Check(..., n_failure_cases=<int>) is specified, the failure cases reported for that check will be limited by <int>