### PR TITLE
Fix passing an empty column list to check duplicates

### DIFF
--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -813,6 +813,8 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
         )
         for lst in temp_unique:
             subset = [x for x in lst if x in check_obj]
+            if not subset:
+                continue
             duplicates = check_obj.duplicated(  # type: ignore
                 subset=subset, keep=keep_setting  # type: ignore
             )


### PR DESCRIPTION
Addresses #1442 

Fixes column uniqueness checking by skipping verification for columns that don't exist in a DataFrame