### PR TITLE
Replace `Literal` imports from `typing_extensions`

### DIFF
--- a/pandera/api/base/types.py
+++ b/pandera/api/base/types.py
@@ -1,17 +1,10 @@
 """Base type definitions for pandera."""
 
-from typing import Union
+from typing import Literal, Union
 
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
 from pandera.api.parsers import Parser
-
-try:
-    # python 3.8+
-    from typing import Literal  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore[assignment]
-
 
 StrictType = Union[bool, Literal["filter"]]
 CheckList = Union[Check, list[Union[Check, Hypothesis]]]

--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -9,6 +9,7 @@ from abc import ABC
 from typing import (
     Any,
     Callable,
+    Literal,
     Optional,
     TypeVar,
     Union,
@@ -16,12 +17,6 @@ from typing import (
 from collections.abc import Iterable
 
 from typing_extensions import overload
-
-try:
-    # python 3.8+
-    from typing import Literal  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore[assignment]
 
 
 class DataType(ABC):

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -13,6 +13,7 @@ import warnings
 from typing import (
     Any,
     Callable,
+    Literal,
     NamedTuple,
     Optional,
     Union,
@@ -76,13 +77,6 @@ if sys.version_info >= (3, 12):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict  # noqa
-
-
-try:
-    # python 3.8+
-    from typing import Literal  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore[assignment]
 
 
 def is_extension_dtype(

--- a/pandera/typing/formats.py
+++ b/pandera/typing/formats.py
@@ -1,13 +1,7 @@
 """Serialization formats for dataframes."""
 
 from enum import Enum
-from typing import Union
-
-try:
-    # python 3.8+
-    from typing import Literal  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore[assignment]
+from typing import Literal, Union
 
 
 class Formats(Enum):

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -27,12 +27,6 @@ from pandera.pandas import (
 from pandera.engines.pandas_engine import Engine
 from pandera.typing import DataFrame, Index, Series
 
-try:
-    # python 3.8+
-    from typing import Literal  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover
-    from typing_extensions import Literal  # type: ignore[assignment]
-
 
 def test_check_function_decorators() -> None:
     """
@@ -794,7 +788,7 @@ def test_check_types_with_literal_type(arg_examples):
     """Test that using typing module types works with check_types"""
 
     for example in arg_examples:
-        arg_type = Literal[example]  # type: ignore
+        arg_type = typing.Literal[example]  # type: ignore
 
         @check_types
         def transform_with_literal(


### PR DESCRIPTION
Remove some Python 3.8 relics