### PR TITLE
limit polars version on Mac OS

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -157,10 +157,11 @@ def _testing_requirements(
             req = "ibis-framework[duckdb,polars]"
         if req == "polars" or req.startswith("polars "):
             # TODO(deepyaman): Support latest Polars.
+            req = "polars < 1.30.0"
             if sys.platform == "darwin":
-                req = "polars-lts-cpu < 1.30.0"
-            else:
-                req = "polars < 1.30.0"
+                # On macOS, add polars-lts-cpu in addition to polars (which tends to get pulled in as a transitive dependency)
+                _updated_requirements.append("polars-lts-cpu < 1.30.0")
+
         # for some reason uv will try to install an old version of dask,
         # have to specifically pin dask[dataframe] to a higher version
         if (


### PR DESCRIPTION
This fixes an issue where `polars` Mac tests fail because `polars==1.32.0` is installed, for instance [these test failures](https://github.com/unionai-oss/pandera/actions/runs/16700768675/job/47271373014) on a PR that only touches the pandas backend. It seems that although `pandera` only explicitly requires `polars-lts-cpu` on Mac, `polars` gets pulled in as a transitive dependency. Without the version constraint, an unsupported version is installed, causing the the test failures. For instance, on the above-linked run, the following versions were installed:
```
polars                        1.32.0
polars-lts-cpu                1.29.0
```