### PR TITLE
fix MultiIndex check regression

### DIFF
--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -311,7 +311,7 @@ class IndexBackend(ArraySchemaBackend):
 
         try:
             _validated_obj = super().validate(
-                check_obj.index.to_series().reset_index(drop=True),
+                check_obj.index.to_series(),  # Don't drop the index name
                 schema,
                 head=head,
                 tail=tail,


### PR DESCRIPTION
#2103 broke checks on MultiIndexes that require accessing the level by name, see #2115. This PR restores the previous behavior.