### PR TITLE
fix: collect `failure_cases` in `check_column_values_are_unique`

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -621,13 +621,19 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             if all(isinstance(x, str) for x in schema.unique)
             else schema.unique
         )
+        check_output = None
         for lst in temp_unique:
             subset = [
                 x for x in lst if x in get_lazyframe_column_names(check_obj)
             ]
             duplicates = check_obj.select(subset).collect().is_duplicated()
+
+            check_output = check_obj.with_columns(
+                duplicates.not_().alias("check_output")
+            ).collect()
+
             if duplicates.any():
-                failure_cases = check_obj.filter(duplicates)
+                failure_cases = check_obj.filter(duplicates).collect()
 
                 passed = False
                 message = f"columns '{*subset,}' not unique:\n{failure_cases}"
@@ -638,4 +644,5 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             reason_code=SchemaErrorReason.DUPLICATES,
             message=message,
             failure_cases=failure_cases,
+            check_output=check_output,
         )

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -564,6 +564,19 @@ def test_dataframe_validation_errors_unique():
         assert exc.failure_cases.shape[0] == 4
 
 
+def test_dataframe_validation_errors_unique_key():
+    schema = DataFrameSchema(
+        {"a": Column(str), "b": Column(str)}, unique=["a", "b"]
+    )
+    invalid_df = pl.DataFrame(
+        {"a": ["1", "1", "1", "1"], "b": ["1", "1", "2", "3"]}
+    )
+    try:
+        schema.validate(invalid_df, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == 2
+
+
 @pytest.fixture
 def lf_with_nested_types():
     return pl.LazyFrame(

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -583,6 +583,26 @@ def test_dataframe_validation_errors_unique_key():
         schema.validate(invalid_df, lazy=True)
         assert False, "Expected SchemaErrors"
     except pa.errors.SchemaErrors as exc:
+        assert len(exc.schema_errors) == 1
+        schema_error = exc.schema_errors[0]
+
+        # Check type of 'schema_error.failure_cases' dataframe
+        assert isinstance(schema_error.failure_cases, pl.DataFrame)
+
+        # Check that the 'schema_error.check_output' is set correctly
+        check_output_df = schema_error.check_output
+        assert isinstance(check_output_df, pl.DataFrame)
+        assert_frame_equal(
+            check_output_df,
+            pl.DataFrame(
+                {
+                    "key_part_a": ["1", "1", "1", "1"],
+                    "key_part_b": ["a", "b", "c", "c"],
+                    "check_output": [True, True, False, False],
+                }
+            ),
+        )
+
         # We expect two failure cases for the unique key constraint
         # for the 2 rows where key_part_a="1" and key_part_b="c"
         assert exc.failure_cases.shape[0] == 2

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -586,10 +586,13 @@ def test_dataframe_validation_errors_unique_key():
         assert len(exc.schema_errors) == 1
         schema_error = exc.schema_errors[0]
 
-        # Check type of 'schema_error.failure_cases' dataframe
+        # Ensure type of 'schema_error.failure_cases' is a Dataframe, since
+        # handling of LazyFrame is not currently supported further downstream
         assert isinstance(schema_error.failure_cases, pl.DataFrame)
 
-        # Check that the 'schema_error.check_output' is set correctly
+        # Ensure check_output property exists and is set correctly, since
+        # it is required for assigning row numbers to the resulting failure_cases
+        # further downstream
         check_output_df = schema_error.check_output
         assert isinstance(check_output_df, pl.DataFrame)
         assert_frame_equal(


### PR DESCRIPTION
Previously, `failure_cases` was not collected, so was set as a `LazyFrame`. This resulted in an error when `failure_cases_metadata` checks the type of `failure_cases`.

This PR also adds the required `check_output` to the `CoreCheckResult`

Fixes #2119