### PR TITLE
`scipy-stubs`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
 
   # mypy extra
   - pandas-stubs
+  - scipy-stubs
 
   # pyspark extra
   - pyspark[connect] >= 3.2.0, < 4.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,10 @@ io = [
     "black",
     "frictionless <= 4.40.8",
 ]
-mypy = ["pandas-stubs"]
+mypy = [
+    "pandas-stubs",
+    "scipy-stubs; python_version>='3.10'",
+]
 fastapi = ["fastapi"]
 geopandas = [
     "geopandas < 1.1.0",
@@ -90,6 +93,7 @@ polars = ["polars >= 0.20.0"]
 all = [
     "hypothesis >= 6.92.7",
     "scipy",
+    "scipy-stubs; python_version>='3.10'",
     "pyyaml >= 5.1",
     "black",
     "frictionless <= 4.40.8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pyarrow >= 13
 pydantic
 scipy
 pandas-stubs
+scipy-stubs
 pyspark[connect] >= 3.2.0, < 4.0.0
 polars >= 0.20.0
 modin


### PR DESCRIPTION
Seeing as `pandas-stubs` is already a development dependency, I'm sure you see the value in adding [`scipy-stubs`](https://github.com/scipy/scipy-stubs) there, as well :).

The earliest `scipy-stubs` release targets SciPy 1.14, which requires `python>=3.10`. Since `pandera` support `python>=3.9`, I used a python restriction so that this doesn't implicitly drop support for 3.9. 