### PR TITLE
Add descriptors to DataFrameModel

### DIFF
--- a/pandera/api/base/model.py
+++ b/pandera/api/base/model.py
@@ -3,6 +3,7 @@
 import os
 from typing import (
     Any,
+    ClassVar,
     Optional,
     TypeVar,
     Union,
@@ -32,13 +33,15 @@ class BaseModel(metaclass=MetaModel):
 
     Config: type[BaseModelConfig] = BaseModelConfig
     __extras__: Optional[dict[str, Any]] = None
-    __schema__: Optional[Any] = None
+    __schema__: ClassVar[Optional[Any]] = None
     __config__: Optional[type[BaseModelConfig]] = None
 
     #: Key according to `FieldInfo.name`
-    __fields__: Mapping[str, tuple[AnnotationInfo, BaseFieldInfo]] = {}
-    __checks__: dict[str, list[Check]] = {}
-    __root_checks__: list[Check] = []
+    __fields__: ClassVar[
+        Mapping[str, tuple[AnnotationInfo, BaseFieldInfo]]
+    ] = {}
+    __checks__: ClassVar[dict[str, list[Check]]] = {}
+    __root_checks__: ClassVar[list[Check]] = []
 
     # This is syntantic sugar that delegates to the validate method
     def __new__(cls, *args, **kwargs) -> Any:


### PR DESCRIPTION
Fixes: #2135

This proposed change changes several of the `__attributes__` of the `DataFrameModel` class to Descriptors.

The objective is to make those attributes Idempotent, and lazy loaded, so that we only compute them when needed.

This addresses the inconsistent behavior where `MyModel.__fields__ == {}`, until you run `MyModel.to_schema()` after which it will be a fully populated dict.

There may be additional performance benefits where the lazy loading allows us to avoid unnecessary computation.