### PR TITLE
Fix failure case count for Ibis tables and strings

### DIFF
--- a/pandera/api/base/error_handler.py
+++ b/pandera/api/base/error_handler.py
@@ -19,7 +19,7 @@ class ErrorCategory(Enum):
 
 
 class ErrorHandler:
-    """Handler for Schema & Data level errors during validation."""
+    """Handler for schema- and data-level errors during validation."""
 
     def __init__(self, lazy: bool = True) -> None:
         """Initialize ErrorHandler.
@@ -36,6 +36,18 @@ class ErrorHandler:
     def lazy(self) -> bool:
         """Whether or not the schema error handler raises errors immediately."""
         return self._lazy
+
+    @staticmethod
+    def _count_failure_cases(failure_cases: Any) -> int:
+        # Failure cases can be a dataframe-like object or a scalar value. Try
+        # getting the number of elements in failure cases or set to one.
+        if isinstance(failure_cases, str):  # Avoid returning str length
+            return 1
+
+        try:
+            return len(failure_cases)
+        except TypeError:
+            return 0 if failure_cases is None else 1
 
     def collect_error(
         self,
@@ -63,15 +75,11 @@ class ErrorHandler:
 
         self._schema_errors.append(schema_error)
 
-        # Failure cases can be a dataframe-like object or a scalar value. Try
-        # getting the number of elements in failure cases column or set to one.
-        try:
-            failure_cases_count = len(schema_error.failure_cases)
-        except TypeError:
-            if schema_error.failure_cases is None:
-                failure_cases_count = 0
-            else:
-                failure_cases_count = 1
+        failure_cases_count = (
+            0
+            if schema_error.failure_cases is None
+            else self._count_failure_cases(schema_error.failure_cases)
+        )
 
         self._collected_errors.append(
             {

--- a/pandera/api/ibis/error_handler.py
+++ b/pandera/api/ibis/error_handler.py
@@ -1,0 +1,18 @@
+"""Handle schema errors."""
+
+import ibis
+
+from pandera.api.base.error_handler import ErrorHandler as _ErrorHandler
+
+
+class ErrorHandler(_ErrorHandler):
+    """Handler for schema- and data-level errors during validation."""
+
+    @staticmethod
+    def _count_failure_cases(failure_cases: ibis.Table) -> int:
+        # Failure cases can be a table object or a scalar value. Try
+        # getting the number of elements in failure cases or set to one.
+        if isinstance(failure_cases, ibis.Table):
+            return failure_cases.count().to_pyarrow().as_py()
+        else:
+            return 1

--- a/pandera/backends/ibis/base.py
+++ b/pandera/backends/ibis/base.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import ibis
 
-from pandera.api.base.error_handler import ErrorHandler
+from pandera.api.ibis.error_handler import ErrorHandler
 from pandera.api.ibis.types import CheckResult
 from pandera.backends.base import BaseSchemaBackend, CoreCheckResult
 from pandera.backends.pandas.error_formatters import (

--- a/pandera/backends/ibis/components.py
+++ b/pandera/backends/ibis/components.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 import ibis
 import ibis.selectors as s
 
-from pandera.api.base.error_handler import ErrorHandler
+from pandera.api.ibis.error_handler import ErrorHandler
 from pandera.backends.base import CoreCheckResult
 from pandera.backends.ibis.base import IbisSchemaBackend
 from pandera.config import ValidationScope

--- a/pandera/backends/ibis/container.py
+++ b/pandera/backends/ibis/container.py
@@ -11,7 +11,7 @@ import ibis
 from ibis import _, selectors as s
 from ibis.common.exceptions import IbisError
 
-from pandera.api.base.error_handler import ErrorHandler
+from pandera.api.ibis.error_handler import ErrorHandler
 from pandera.config import ValidationScope
 from pandera.backends.base import CoreCheckResult, ColumnInfo
 from pandera.backends.utils import convert_uniquesettings


### PR DESCRIPTION
Resolves #2132 by introducing an Ibis-backend-specific `ErrorHandler` class, overriding a newly-introduce `_count_failure_cases()` function.

Also fixes failure case counting for objects (specifically `string`; not sure if there are others) that you can call `len()` on but shouldn't in this scenario. Alternatively considered doing a type check (`if type(failure_cases).__name__ == "DataFrame"`), but I _think_ failure cases is sometimes a dict in PySpark backend? Wasn't sure what all the possibilities are.