### PR TITLE
Support nonnullable equivalents for all data types

### DIFF
--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -99,6 +99,7 @@ class Engine(
         dtypes.Bool(),
         dt.Boolean,
         dt.boolean,
+        dt.Boolean(nullable=False),
     ]
 )
 @immutable
@@ -114,7 +115,14 @@ class Bool(DataType, dtypes.Bool):
 
 
 @Engine.register_dtype(
-    equivalents=[np.int8, dtypes.Int8, dtypes.Int8(), dt.Int8, dt.int8]
+    equivalents=[
+        np.int8,
+        dtypes.Int8,
+        dtypes.Int8(),
+        dt.Int8,
+        dt.int8,
+        dt.Int8(nullable=False),
+    ]
 )
 @immutable
 class Int8(DataType, dtypes.Int8):
@@ -124,7 +132,14 @@ class Int8(DataType, dtypes.Int8):
 
 
 @Engine.register_dtype(
-    equivalents=[np.int16, dtypes.Int16, dtypes.Int16(), dt.Int16, dt.int16]
+    equivalents=[
+        np.int16,
+        dtypes.Int16,
+        dtypes.Int16(),
+        dt.Int16,
+        dt.int16,
+        dt.Int16(nullable=False),
+    ]
 )
 @immutable
 class Int16(DataType, dtypes.Int16):
@@ -134,7 +149,14 @@ class Int16(DataType, dtypes.Int16):
 
 
 @Engine.register_dtype(
-    equivalents=[np.int32, dtypes.Int32, dtypes.Int32(), dt.Int32, dt.int32]
+    equivalents=[
+        np.int32,
+        dtypes.Int32,
+        dtypes.Int32(),
+        dt.Int32,
+        dt.int32,
+        dt.Int32(nullable=False),
+    ]
 )
 @immutable
 class Int32(DataType, dtypes.Int32):
@@ -151,6 +173,7 @@ class Int32(DataType, dtypes.Int32):
         dtypes.Int64(),
         dt.Int64,
         dt.int64,
+        dt.Int64(nullable=False),
     ]
 )
 @immutable
@@ -166,7 +189,14 @@ class Int64(DataType, dtypes.Int64):
 
 
 @Engine.register_dtype(
-    equivalents=[np.uint8, dtypes.UInt8, dtypes.UInt8(), dt.UInt8, dt.uint8]
+    equivalents=[
+        np.uint8,
+        dtypes.UInt8,
+        dtypes.UInt8(),
+        dt.UInt8,
+        dt.uint8,
+        dt.UInt8(nullable=False),
+    ]
 )
 @immutable
 class UInt8(DataType, dtypes.UInt8):
@@ -182,6 +212,7 @@ class UInt8(DataType, dtypes.UInt8):
         dtypes.UInt16(),
         dt.UInt16,
         dt.uint16,
+        dt.UInt16(nullable=False),
     ]
 )
 @immutable
@@ -198,6 +229,7 @@ class UInt16(DataType, dtypes.UInt16):
         dtypes.UInt32(),
         dt.UInt32,
         dt.uint32,
+        dt.UInt32(nullable=False),
     ]
 )
 @immutable
@@ -214,6 +246,7 @@ class UInt32(DataType, dtypes.UInt32):
         dtypes.UInt64(),
         dt.UInt64,
         dt.uint64,
+        dt.UInt64(nullable=False),
     ]
 )
 @immutable
@@ -235,6 +268,7 @@ class UInt64(DataType, dtypes.UInt64):
         dtypes.Float32(),
         dt.Float32,
         dt.float32,
+        dt.Float32(nullable=False),
     ]
 )
 @immutable
@@ -252,6 +286,7 @@ class Float32(DataType, dtypes.Float32):
         dtypes.Float64(),
         dt.Float64,
         dt.float64,
+        dt.Float64(nullable=False),
     ]
 )
 @immutable
@@ -274,6 +309,7 @@ class Float64(DataType, dtypes.Float64):
         dtypes.String(),
         dt.String,
         dt.string,
+        dt.String(nullable=False),
     ]
 )
 @immutable
@@ -291,6 +327,7 @@ class String(DataType, dtypes.String):
         dtypes.Binary(),
         dt.Binary,
         dt.binary,
+        dt.Binary(nullable=False),
     ]
 )
 @immutable
@@ -313,6 +350,7 @@ class Binary(DataType, dtypes.Binary):
         dtypes.Date(),
         dt.Date,
         dt.date,
+        dt.Date(nullable=False),
     ]
 )
 @immutable
@@ -331,6 +369,7 @@ class Date(DataType, dtypes.Date):
         dtypes.DateTime(),
         dt.Timestamp,
         dt.timestamp,
+        dt.Timestamp(nullable=False),
     ]
 )
 @immutable(init=True)
@@ -343,16 +382,23 @@ class DateTime(DataType, dtypes.DateTime):
         self,
         timezone: Optional[str] = None,
         scale: Optional[Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]] = None,
+        nullable: Optional[bool] = True,
     ):
         object.__setattr__(
-            self, "type", dt.Timestamp(timezone=timezone, scale=scale)
+            self,
+            "type",
+            dt.Timestamp(timezone=timezone, scale=scale, nullable=nullable),
         )
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Timestamp):
         """Convert a :class:`dt.Timestamp` to a Pandera
         :class:`~pandera.engines.ibis_engine.DateTime`."""
-        return cls(timezone=ibis_dtype.timezone, scale=ibis_dtype.scale)
+        return cls(
+            timezone=ibis_dtype.timezone,
+            scale=ibis_dtype.scale,
+            nullable=ibis_dtype.nullable,
+        )
 
 
 @Engine.register_dtype(
@@ -361,6 +407,7 @@ class DateTime(DataType, dtypes.DateTime):
         datetime.time,
         dt.Time,
         dt.time,
+        dt.Time(nullable=False),
     ]
 )
 @immutable
@@ -386,11 +433,15 @@ class Timedelta(DataType, dtypes.DateTime):
 
     type: type[dt.Interval]
 
-    def __init__(self, unit: IntervalUnit = "us"):
-        object.__setattr__(self, "type", dt.Interval(unit=unit))
+    def __init__(
+        self, unit: IntervalUnit = "us", nullable: Optional[bool] = True
+    ):
+        object.__setattr__(
+            self, "type", dt.Interval(unit=unit, nullable=nullable)
+        )
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Interval):
         """Convert a :class:`dt.Interval` to a Pandera
         :class:`~pandera.engines.ibis_engine.Timedelta`."""
-        return cls(unit=ibis_dtype.unit)
+        return cls(unit=ibis_dtype.unit, nullable=ibis_dtype.nullable)

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -382,12 +382,9 @@ class DateTime(DataType, dtypes.DateTime):
         self,
         timezone: Optional[str] = None,
         scale: Optional[Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]] = None,
-        nullable: Optional[bool] = True,
     ):
         object.__setattr__(
-            self,
-            "type",
-            dt.Timestamp(timezone=timezone, scale=scale, nullable=nullable),
+            self, "type", dt.Timestamp(timezone=timezone, scale=scale)
         )
 
     @classmethod
@@ -397,7 +394,6 @@ class DateTime(DataType, dtypes.DateTime):
         return cls(
             timezone=ibis_dtype.timezone,
             scale=ibis_dtype.scale,
-            nullable=ibis_dtype.nullable,
         )
 
 
@@ -433,15 +429,11 @@ class Timedelta(DataType, dtypes.DateTime):
 
     type: type[dt.Interval]
 
-    def __init__(
-        self, unit: IntervalUnit = "us", nullable: Optional[bool] = True
-    ):
-        object.__setattr__(
-            self, "type", dt.Interval(unit=unit, nullable=nullable)
-        )
+    def __init__(self, unit: IntervalUnit = "us"):
+        object.__setattr__(self, "type", dt.Interval(unit=unit))
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Interval):
         """Convert a :class:`dt.Interval` to a Pandera
         :class:`~pandera.engines.ibis_engine.Timedelta`."""
-        return cls(unit=ibis_dtype.unit, nullable=ibis_dtype.nullable)
+        return cls(unit=ibis_dtype.unit)

--- a/tests/ibis/test_ibis_dtypes.py
+++ b/tests/ibis/test_ibis_dtypes.py
@@ -69,3 +69,22 @@ def test_coerce_cast(from_dtype, to_dtype, strategy, data):
     coerced = to_dtype.coerce(data_container=s)
     for dtype in coerced.schema().values():
         assert dtype == to_dtype.type
+
+
+@pytest.mark.parametrize("dtype", ALL_TYPES)
+def test_check_not_equivalent(dtype):
+    """Test that check() rejects non-equivalent dtypes."""
+    if str(ie.Engine.dtype(dtype)) == "string":
+        actual_dtype = ie.Engine.dtype(int)
+    else:
+        actual_dtype = ie.Engine.dtype(str)
+    expected_dtype = ie.Engine.dtype(dtype)
+    assert not actual_dtype.check(expected_dtype)
+
+
+@pytest.mark.parametrize("dtype", ALL_TYPES)
+def test_check_equivalent(dtype):
+    """Test that check() accepts equivalent dtypes."""
+    actual_dtype = ie.Engine.dtype(dtype)
+    expected_dtype = ie.Engine.dtype(dtype)
+    assert actual_dtype.check(expected_dtype)

--- a/tests/ibis/test_ibis_dtypes.py
+++ b/tests/ibis/test_ibis_dtypes.py
@@ -88,3 +88,29 @@ def test_check_equivalent(dtype):
     actual_dtype = ie.Engine.dtype(dtype)
     expected_dtype = ie.Engine.dtype(dtype)
     assert actual_dtype.check(expected_dtype)
+
+
+@pytest.mark.parametrize(
+    "first_dtype, second_dtype, equivalent",
+    [
+        (ie.Int8, ie.Int16, False),
+        (ie.DateTime(), ie.Date, False),
+        (
+            ie.DateTime(timezone=None, scale=1),
+            ie.DateTime(timezone=None, scale=2),
+            False,
+        ),
+        (
+            ie.DateTime(timezone=None, scale=1),
+            ie.DateTime(timezone=None, scale=1),
+            True,
+        ),
+        (ie.Timedelta(unit="us"), ie.Timedelta(unit="ns"), False),
+        (ie.Timedelta(unit="us"), ie.Timedelta(unit="us"), True),
+    ],
+)
+def test_check_equivalent_custom(first_dtype, second_dtype, equivalent):
+    """Test that check() rejects non-equivalent dtypes."""
+    first_engine_dtype = ie.Engine.dtype(first_dtype)
+    second_engine_dtype = ie.Engine.dtype(second_dtype)
+    assert first_engine_dtype.check(second_engine_dtype) is equivalent

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -259,7 +259,7 @@ def test_check_not_equivalent(dtype):
     else:
         actual_dtype = pe.Engine.dtype(object)
     expected_dtype = pe.Engine.dtype(dtype)
-    assert actual_dtype.check(expected_dtype) is False
+    assert not actual_dtype.check(expected_dtype)
 
 
 @pytest.mark.parametrize("dtype", all_types + special_types)
@@ -267,7 +267,7 @@ def test_check_equivalent(dtype):
     """Test that check() accepts equivalent dtypes."""
     actual_dtype = pe.Engine.dtype(dtype)
     expected_dtype = pe.Engine.dtype(dtype)
-    assert actual_dtype.check(expected_dtype) is True
+    assert actual_dtype.check(expected_dtype)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2130 

@cosmicBboy I thought about adding a `nullable` property to the base Ibis engine `DataType`, but that would make it different from all of the other backends. I wasn't sure how it would get used (pandera nullable checks don't look at the column schema right now, and instead check for the presence of nullls), so I didn't add it. Any thoughts?

With this PR, `ibis.expr.datatypes.DataType(nullable=True)` is being treated as equivalent to `ibis.expr.datatypes.DataType(nullable=False)` FWIW. I don't know if this is ideal, but it does circumvent the open issue. ~I think I also need to confirm that parametrized datatypes are considered equivalent between parametrized version (i.e. the equality should ignore the `nullable` field?). This could be done by overriding `DataType.check()`, similar to how `polars.engines.polars_engine.Decimal.check()` is overridden.~ Update: Actually, don't know if this is necessary, as long as don't expose `nullable` in any pandera type constructors.

Any thoughts on whether this is a reasonable approach overall?