### PR TITLE
Fix: Add enum.Enum serialization support for to_json()

### DIFF
--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -1,5 +1,6 @@
 """Module for reading and writing schema objects."""
 
+import enum
 import json
 import warnings
 from collections.abc import Mapping
@@ -55,6 +56,10 @@ def _serialize_check_stats(check_stats, dtype=None):
     """Serialize check statistics into json/yaml-compatible format."""
 
     def handle_stat_dtype(stat):
+        # Handle enum types by converting them to a list of values
+        if isinstance(stat, type) and issubclass(stat, enum.Enum):
+            return [e.value for e in stat]
+
         if pandas_engine.Engine.dtype(dtypes.DateTime).check(
             dtype
         ) and hasattr(stat, "strftime"):

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -2033,3 +2033,125 @@ def test_frictionless_schema_with_description_and_title(
     schema = pandera.io.from_frictionless_schema(frictionless_schema)
     assert schema.columns["street_id"].description == "Id of the street"
     assert schema.columns["street_id"].title == "street identifier"
+
+
+def test_enum_isin_json_serialization():
+    """Test that StrEnum and Enum can be used with isin and serialized to JSON."""
+    import sys
+    import json
+
+    # StrEnum was introduced in Python 3.11
+    if sys.version_info >= (3, 11):
+        from enum import StrEnum
+
+        class Status(StrEnum):
+            ACTIVE = "active"
+            INACTIVE = "inactive"
+            PENDING = "pending"
+
+        # Test with StrEnum
+        schema = pandera.DataFrameSchema(
+            {"status": pandera.Column(str, checks=pandera.Check.isin(Status))}
+        )
+
+        # Should not raise TypeError
+        json_output = schema.to_json()
+
+        # Verify the enum values are properly serialized
+        schema_dict = json.loads(json_output)
+        assert "columns" in schema_dict
+        assert "status" in schema_dict["columns"]
+        status_checks = schema_dict["columns"]["status"]["checks"]
+        assert len(status_checks) > 0
+
+        # Find the isin check
+        isin_check = None
+        for check in status_checks:
+            if isinstance(check, dict) and "options" in check:
+                if check["options"]["check_name"] == "isin":
+                    isin_check = check
+                    break
+
+        assert isin_check is not None
+        # The enum should be serialized as a list of values
+        assert "value" in isin_check
+        assert set(isin_check["value"]) == {"active", "inactive", "pending"}
+
+    # Test with regular Enum (available in all Python versions)
+    from enum import Enum
+
+    class Priority(Enum):
+        HIGH = "high"
+        MEDIUM = "medium"
+        LOW = "low"
+
+    schema = pandera.DataFrameSchema(
+        {"priority": pandera.Column(str, checks=pandera.Check.isin(Priority))}
+    )
+
+    # Should not raise TypeError
+    json_output = schema.to_json()
+
+    # Verify the enum values are properly serialized
+    schema_dict = json.loads(json_output)
+    assert "columns" in schema_dict
+    assert "priority" in schema_dict["columns"]
+    priority_checks = schema_dict["columns"]["priority"]["checks"]
+    assert len(priority_checks) > 0
+
+    # Find the isin check
+    isin_check = None
+    for check in priority_checks:
+        if isinstance(check, dict) and "options" in check:
+            if check["options"]["check_name"] == "isin":
+                isin_check = check
+                break
+
+    assert isin_check is not None
+    # The enum should be serialized as a list of values
+    assert "value" in isin_check
+    assert set(isin_check["value"]) == {"high", "medium", "low"}
+
+
+def test_enum_isin_dataframe_model_json_serialization():
+    """Test that StrEnum can be used in DataFrameModel with isin and serialized to JSON."""
+    import sys
+    import json
+
+    # StrEnum was introduced in Python 3.11
+    if sys.version_info >= (3, 11):
+        from enum import StrEnum
+        from pandera.typing import Series
+
+        class Color(StrEnum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        # Create a schema using the StrEnum in isin parameter
+        class ColorTable(pandera.DataFrameModel):
+            color: Series[str] = pandera.Field(isin=Color)
+
+        # Attempt to generate JSON schema
+        schema = ColorTable.to_schema()
+        json_output = schema.to_json()  # Should not raise TypeError
+
+        # Verify the enum values are in the JSON
+        schema_dict = json.loads(json_output)
+        assert "columns" in schema_dict
+        assert "color" in schema_dict["columns"]
+        color_checks = schema_dict["columns"]["color"]["checks"]
+        assert len(color_checks) > 0
+
+        # Find the isin check
+        isin_check = None
+        for check in color_checks:
+            if isinstance(check, dict) and "options" in check:
+                if check["options"]["check_name"] == "isin":
+                    isin_check = check
+                    break
+
+        assert isin_check is not None
+        # The enum should be serialized as a list of values
+        assert "value" in isin_check
+        assert set(isin_check["value"]) == {"red", "green", "blue"}


### PR DESCRIPTION
## Description
Fixes issue where using Python's `enum.Enum` or `StrEnum` as the value for the `isin` parameter causes `schema.to_json()` to raise a `TypeError: Object of type EnumType is not JSON serializable`.

## Changes
- Added special handling in `_serialize_check_stats()` to detect Enum types and convert them to lists of values
- Added `import enum` to `pandera/io/pandas_io.py`
- Added comprehensive tests for both `Enum` and `StrEnum` (Python 3.11+) serialization
- Tests cover both `DataFrameSchema` and `DataFrameModel` usage patterns

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Added `test_enum_isin_json_serialization()` for basic Enum/StrEnum with DataFrameSchema
- Added `test_enum_isin_dataframe_model_json_serialization()` for DataFrameModel pattern
- All 46 tests in `tests/io/test_pandas_io.py` pass
- Pre-commit checks pass

## Example
Before this fix, the following code would raise `TypeError`:
```python
from enum import StrEnum
import pandera as pa
from pandera.typing import Series

class Status(StrEnum):
            ACTIVE = "active"
            INACTIVE = "inactive"
            PENDING = "pending"

class StatusTable(pa.DataFrameModel):
    statis_type: Series[str] = pa.Field(isin=Status)

schema = StatusTable.to_schema()
json_output = schema.to_json()  # ❌ TypeError