### PR TITLE
fix: remove pandas.concat signature hook

### DIFF
--- a/tests/mypy/test_pandas_static_type_checking.py
+++ b/tests/mypy/test_pandas_static_type_checking.py
@@ -220,7 +220,10 @@ def test_pandas_stubs_false_positives(
         str(test_module_dir / "config" / config),
     ]
     # pylint: disable=subprocess-run-check
-    subprocess.run(commands, text=True)
+    result = subprocess.run(commands, text=True)
+    # NOTE: mypy return code is 0 if no errors were found, 1 if errors were found
+    # or 2 if there was a failure in checking
+    assert result.returncode in (0, 1)
     resulting_errors = _get_mypy_errors(module, capfd.readouterr().out)
     assert len(expected_errors) == len(resulting_errors)
     for expected, error in zip(expected_errors, resulting_errors):


### PR DESCRIPTION
Hi maintainers! Thank you for nice project!

## Summary

Fixes #2124 - Remove pandas.concat signature hook that causes mypy to crash

## Problem

MyPy 1.17.1+ crashes with `AttributeError: 'Instance' object has no attribute 'items'` when analyzing code that uses `pd.concat()`. This occurs because:

1. pandas-stubs 2.3.2.250827 now returns either `Instance` or `UnionType` for concat's first argument
2. Our `pandas_concat_callback` hook assumes the argument type is `UnionType` and tries to access its `.items` attribute
3. This assumption is no longer valid with the updated pandas-stubs

## Solution

Remove the `pandas_concat_callback` hook and its associated `get_function_signature_hook` method entirely because:

- In #1007, we removed `PANDAS_CONCAT_FALSE_POSITIVES` workarounds since pandas-stubs (now officially maintained by pandas-dev) provides correct types
- The signature manipulation is no longer necessary with modern pandas-stubs
- This aligns with the project's direction to rely on official pandas type stubs rather than custom workarounds

## Changes

- Remove `get_function_signature_hook` method from `PanderaPlugin`
- Remove `pandas_concat_callback` method
- Add return code validation in tests to catch mypy failures

## Testing

- Tested locally with mypy 1.18.2 to verify the fix resolves the crash
- Note: The project dependencies keep mypy at 1.10.0 because upgrading mypy causes widespread type errors across the codebase that are outside the scope of this fix
- Existing mypy tests pass without crashes

