### PR TITLE
schema descriptor should raise AttributeError if build_schema_ is not implemented

### DIFF
--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -158,7 +158,17 @@ class _SchemaDescriptor:
             else:
                 kwargs = {}
 
-            MODEL_CACHE[(cls, thread_id)] = cls.build_schema_(**kwargs)
+            try:
+                MODEL_CACHE[(cls, thread_id)] = cls.build_schema_(**kwargs)
+            except NotImplementedError as e:
+                # Raise AttributeError to signal that this attribute is not available
+                # for abstract/incomplete model classes. This allows introspection tools
+                # like pydoc to continue without crashing.
+                raise AttributeError(
+                    f"'{cls.__name__}' does not implement build_schema_() and cannot "
+                    f"generate a schema. To be able to generate a schema, subclass the"
+                    "DataFrameModel for a specific backend."
+                ) from e
 
         return MODEL_CACHE[(cls, thread_id)]  # type: ignore
 


### PR DESCRIPTION
As of https://github.com/unionai-oss/pandera/pull/2136, pandera uses a schema descriptor which can cause some problems when inspecting models that extend `DataFrameModel` classes:

```python
import pydoc

import pandas as pd
import pandera.pandas as pa
from pandera.typing import Series
from pandera.api.dataframe.model import DataFrameModel as BaseDataFrameModel
from pandera.pandas import DataFrameModel as PandasDataFrameModel
from pandera.polars import DataFrameModel as PolarsDataFrameModel


class BaseModel(BaseDataFrameModel):
    name: Series[pa.String] = pa.Field()


class PandasModel(PandasDataFrameModel, BaseModel):
    pass


class PolarsModel(PolarsDataFrameModel, BaseModel):
    pass


print(pydoc.render_doc(PandasModel))

```

The `pydoc.render_doc(PandasModel)` raises `NotImplementedError`, because pydoc walks the MRO and attempts to access the `__schema__` attribute on `pandera.api.dataframe.model.DataFrameModel`.

The fix here is to modify the `_SchemaDescriptor` to catch the `NotImplementedError` and raise an `AttributeError`, which is handled better by pydoc.