### PR TITLE
Add map datatype to the Ibis engine implementation

### DIFF
--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -260,11 +260,11 @@ class Engine(ABCMeta):
             or ((NamedTuple,) if _is_namedtuple(data_type) else ())
             or typing_inspect.get_generic_bases(data_type)
         )
-        if datatype_generic_bases:
-            equivalent_data_type = None
-            for base in datatype_generic_bases:
-                equivalent_data_type = registry.get_equivalent(base)
-                break
+        if datatype_generic_bases and (base := datatype_generic_bases[0]) in {
+            *sys.stdlib_module_names,
+            "typing_extensions",
+        }:
+            equivalent_data_type = registry.get_equivalent(base)
             if equivalent_data_type is None:
                 raise TypeError(
                     f"Type '{data_type}' not understood by {cls.__name__}."

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -260,7 +260,7 @@ class Engine(ABCMeta):
             or ((NamedTuple,) if _is_namedtuple(data_type) else ())
             or typing_inspect.get_generic_bases(data_type)
         )
-        if datatype_generic_bases and (base := datatype_generic_bases[0]) in {
+        if datatype_generic_bases and inspect.getmodule(base := datatype_generic_bases[0]).__name__ in {
             *sys.stdlib_module_names,
             "typing_extensions",
         }:

--- a/pandera/engines/engine.py
+++ b/pandera/engines/engine.py
@@ -260,7 +260,9 @@ class Engine(ABCMeta):
             or ((NamedTuple,) if _is_namedtuple(data_type) else ())
             or typing_inspect.get_generic_bases(data_type)
         )
-        if datatype_generic_bases and inspect.getmodule(base := datatype_generic_bases[0]).__name__ in {
+        if datatype_generic_bases and inspect.getmodule(
+            base := datatype_generic_bases[0]
+        ).__name__ in {  # type: ignore[union-attr]
             *sys.stdlib_module_names,
             "typing_extensions",
         }:

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -507,7 +507,10 @@ class Map(DataType):
         object.__setattr__(
             self,
             "type",
-            dt.Map(key_type=ibis.dtype(key_type), value_type=ibis.dtype(value_type)),
+            dt.Map(
+                key_type=ibis.dtype(key_type),
+                value_type=ibis.dtype(value_type),
+            ),
         )
 
     @classmethod

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -501,14 +501,13 @@ class Timedelta(DataType, dtypes.DateTime):
 class Map(DataType):
     """Semantic representation of a :class:`dt.Map`."""
 
-    type: type[dt.Map]
+    type: dt.Map
 
-    def __init__(self, key_type: Any = dt.null, value_type: Any = dt.null):
-        object.__setattr__(
-            self,
-            "type",
-            dt.Map(key_type=ibis.dtype(key_type), value_type=ibis.dtype(value_type)),
-        )
+    def __init__(
+        self, key_type: dt.DataType | None = None, value_type: dt.DataType | None = None
+    ):
+        if key_type is not None and value_type is not None:
+            object.__setattr__(self, "type", dt.Map(key_type, value_type))
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Map):

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -58,7 +58,7 @@ class DataType(dtypes.DataType):
         data_container: ibis.Table | None = None,
     ) -> Union[bool, Iterable[bool]]:
         try:
-            return self.type == pandera_dtype.type
+            return self.type == Engine.dtype(pandera_dtype).type
         except TypeError:
             return False
 

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -501,13 +501,14 @@ class Timedelta(DataType, dtypes.DateTime):
 class Map(DataType):
     """Semantic representation of a :class:`dt.Map`."""
 
-    type: dt.Map
+    type: type[dt.Map]
 
-    def __init__(
-        self, key_type: dt.DataType | None = None, value_type: dt.DataType | None = None
-    ):
-        if key_type is not None and value_type is not None:
-            object.__setattr__(self, "type", dt.Map(key_type, value_type))
+    def __init__(self, key_type: Any = dt.null, value_type: Any = dt.null):
+        object.__setattr__(
+            self,
+            "type",
+            dt.Map(key_type=ibis.dtype(key_type), value_type=ibis.dtype(value_type)),
+        )
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Map):

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -484,3 +484,37 @@ class Timedelta(DataType, dtypes.DateTime):
         """Convert a :class:`dt.Interval` to a Pandera
         :class:`~pandera.engines.ibis_engine.Timedelta`."""
         return cls(unit=ibis_dtype.unit)
+
+
+###############################################################################
+# nested
+###############################################################################
+
+
+@Engine.register_dtype(
+    equivalents=[
+        dict,
+        dt.Map,
+    ]
+)
+@immutable(init=True)
+class Map(DataType):
+    """Semantic representation of a :class:`dt.Map`."""
+
+    type: type[dt.Map]
+
+    def __init__(self, key_type: Any = dt.null, value_type: Any = dt.null):
+        object.__setattr__(
+            self,
+            "type",
+            dt.Map(key_type=ibis.dtype(key_type), value_type=ibis.dtype(value_type)),
+        )
+
+    @classmethod
+    def from_parametrized_dtype(cls, ibis_dtype: dt.Map):
+        """Convert a :class:`dt.Map` to a Pandera
+        :class:`~pandera.engines.ibis_engine.Map`."""
+        return cls(
+            key_type=ibis_dtype.key_type,
+            value_type=ibis_dtype.value_type,
+        )

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -501,17 +501,15 @@ class Timedelta(DataType, dtypes.DateTime):
 class Map(DataType):
     """Semantic representation of a :class:`dt.Map`."""
 
-    type: type[dt.Map]
+    type: dt.Map
 
-    def __init__(self, key_type: Any = dt.null, value_type: Any = dt.null):
-        object.__setattr__(
-            self,
-            "type",
-            dt.Map(
-                key_type=ibis.dtype(key_type),
-                value_type=ibis.dtype(value_type),
-            ),
-        )
+    def __init__(
+        self,
+        key_type: dt.DataType | None = None,
+        value_type: dt.DataType | None = None,
+    ):
+        if key_type is not None and value_type is not None:
+            object.__setattr__(self, "type", dt.Map(key_type, value_type))
 
     @classmethod
     def from_parametrized_dtype(cls, ibis_dtype: dt.Map):

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -623,7 +623,7 @@ class Array(DataType):
         elif shape is not None:
             kwargs["shape"] = shape
 
-        if inner:
+        if inner is not None:
             object.__setattr__(self, "type", pl.Array(inner=inner, **kwargs))
 
     @classmethod
@@ -655,7 +655,7 @@ class List(DataType):
         self,
         inner: PolarsDataType | None = None,
     ) -> None:
-        if inner:
+        if inner is not None:
             object.__setattr__(self, "type", pl.List(inner=inner))
 
     @classmethod
@@ -674,7 +674,7 @@ class Struct(DataType):
         self,
         fields: Union[Sequence[pl.Field], SchemaDict] | None = None,
     ) -> None:
-        if fields:
+        if fields is not None:
             object.__setattr__(self, "type", pl.Struct(fields=fields))
 
     @classmethod

--- a/tests/ibis/test_ibis_dtypes.py
+++ b/tests/ibis/test_ibis_dtypes.py
@@ -5,9 +5,11 @@ import ibis.expr.datatypes as dt
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from ibis import _
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
+import pandera.ibis as pa
 from pandera.engines import ibis_engine as ie
 
 NUMERIC_TYPES = [
@@ -144,3 +146,47 @@ def test_ibis_map_nested_type(key_dtype, value_dtype):
 
     assert pandera_dtype.check(ibis_dtype)
     assert pandera_dtype.check(pandera_dtype)
+
+
+def test_ibis_map_type():
+    # https://github.com/unionai-oss/pandera/issues/2201
+    data = {
+        "id": ["01", "02", "03"],
+        "key_col": [
+            [1, 2, 3],
+            [
+                1,
+                2,
+            ],
+            None,
+        ],
+        "value_col": [
+            ["value_1A", "value_1B", "value_1C"],
+            ["value_2A", "value_2B"],
+            None,
+        ],
+    }
+    df = (
+        ibis.memtable(data)
+        .mutate(dict_col=ibis.map(_.key_col, _.value_col))
+        .drop("key_col", "value_col")
+    )
+
+    class ValidateSchema(pa.DataFrameModel):
+        id: str = pa.Field(nullable=False)
+        dict_col: ibis.dtype("map<int64, string>") = pa.Field(nullable=True)
+
+    ValidateSchema.validate(df)
+
+    class ValidateSchema(pa.DataFrameModel):
+        id: str = pa.Field(nullable=False)
+        dict_col: dt.Map = pa.Field(nullable=True)
+
+    ValidateSchema.validate(df)
+
+    class ValidateSchema(pa.DataFrameModel):
+        id: str = pa.Field(nullable=False)
+        dict_col: ibis.dtype("map<string, string>") = pa.Field(nullable=True)
+
+    with pytest.raises(pa.errors.SchemaError):
+        ValidateSchema.validate(df)

--- a/tests/ibis/test_ibis_dtypes.py
+++ b/tests/ibis/test_ibis_dtypes.py
@@ -134,3 +134,13 @@ def test_ibis_decimal_from_parametrized_dtype(ibis_dtype, expected_dtype):
 
     assert pandera_dtype.precision == expected_dtype.precision
     assert pandera_dtype.scale == expected_dtype.scale
+
+
+@pytest.mark.parametrize("key_dtype", ALL_TYPES)
+@pytest.mark.parametrize("value_dtype", ALL_TYPES)
+def test_ibis_map_nested_type(key_dtype, value_dtype):
+    ibis_dtype = dt.Map(key_dtype.type(), value_dtype.type())
+    pandera_dtype = ie.Engine.dtype(ibis_dtype)
+
+    assert pandera_dtype.check(ibis_dtype)
+    assert pandera_dtype.check(pandera_dtype)

--- a/tests/ibis/test_ibis_dtypes.py
+++ b/tests/ibis/test_ibis_dtypes.py
@@ -22,6 +22,10 @@ OTHER_TYPES = [
     ie.String,
 ]
 
+SPECIAL_TYPES = [
+    ie.Map,
+]
+
 ALL_TYPES = NUMERIC_TYPES + TEMPORAL_TYPES + OTHER_TYPES
 
 
@@ -71,7 +75,7 @@ def test_coerce_cast(from_dtype, to_dtype, strategy, data):
         assert dtype == to_dtype.type
 
 
-@pytest.mark.parametrize("dtype", ALL_TYPES)
+@pytest.mark.parametrize("dtype", ALL_TYPES + SPECIAL_TYPES)
 def test_check_not_equivalent(dtype):
     """Test that check() rejects non-equivalent dtypes."""
     if str(ie.Engine.dtype(dtype)) == "string":
@@ -82,7 +86,7 @@ def test_check_not_equivalent(dtype):
     assert not actual_dtype.check(expected_dtype)
 
 
-@pytest.mark.parametrize("dtype", ALL_TYPES)
+@pytest.mark.parametrize("dtype", ALL_TYPES + SPECIAL_TYPES)
 def test_check_equivalent(dtype):
     """Test that check() accepts equivalent dtypes."""
     actual_dtype = ie.Engine.dtype(dtype)

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -354,7 +354,7 @@ def test_polars_decimal_from_parametrized_dtype(polars_dtype, expected_dtype):
 )
 @given(st.integers(min_value=2, max_value=10))
 @settings(max_examples=5)
-def test_polars_nested_array_type_check(inner_dtype_cls, width):
+def test_polars_array_nested_type(inner_dtype_cls, width):
     polars_dtype = pl.Array(inner_dtype_cls(), width)
     pandera_dtype = pe.Engine.dtype(polars_dtype)
 


### PR DESCRIPTION
Resolves #2201 

Also restricts the logic for looking up generic bases in the registry. Ibis datatypes like `dt.Map` have generic bases, too, and so the code was getting caught in that code path. It seems reasonable to only check generic bases for builtins (and near-builtins, like `typing_extensions`, which backports some bases to older Python versions).