### PR TITLE
Unify builtin comparison checks with Narwhals impl

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - frictionless <= 4.40.8  # v5.* introduces breaking changes
   - pyarrow >= 13 # https://github.com/apache/arrow/pull/35113
   - pydantic
+  - narwhals >= 1.0.0
 
   # hypotheses extra
   - scipy

--- a/pandera/api/base/types.py
+++ b/pandera/api/base/types.py
@@ -1,6 +1,6 @@
 """Base type definitions for pandera."""
 
-from typing import Literal, Union
+from typing import Any, Literal, Protocol, Union
 
 from pandera.api.checks import Check
 from pandera.api.hypotheses import Hypothesis
@@ -9,3 +9,17 @@ from pandera.api.parsers import Parser
 StrictType = Union[bool, Literal["filter"]]
 CheckList = Union[Check, list[Union[Check, Hypothesis]]]
 ParserList = Union[Parser, list[Parser]]
+
+
+class CheckData(Protocol):
+    """Protocol for data wrappers passed to check functions."""
+
+    @property
+    def frame(self) -> Any:
+        """The native dataframe (LazyFrame, Table, DataFrame, etc.)."""
+        ...
+
+    @property
+    def key(self) -> str | None:
+        """The column name to check, or None for all columns."""
+        ...

--- a/pandera/api/ibis/types.py
+++ b/pandera/api/ibis/types.py
@@ -10,6 +10,11 @@ class IbisData(NamedTuple):
     table: ibis.Table
     key: str | None = None
 
+    @property
+    def frame(self) -> ibis.Table:
+        """The native dataframe (Table)."""
+        return self.table
+
 
 class CheckResult(NamedTuple):
     """Check result for user-defined checks."""

--- a/pandera/api/polars/types.py
+++ b/pandera/api/polars/types.py
@@ -9,6 +9,11 @@ class PolarsData(NamedTuple):
     lazyframe: pl.LazyFrame
     key: str = "*"
 
+    @property
+    def frame(self) -> pl.LazyFrame:
+        """The native dataframe (LazyFrame)."""
+        return self.lazyframe
+
 
 class CheckResult(NamedTuple):
     """Check result for user-defined checks."""

--- a/pandera/backends/base/builtin_checks.py
+++ b/pandera/backends/base/builtin_checks.py
@@ -9,41 +9,62 @@ specific implementations based on the data object type, e.g.
 
 import re
 from collections.abc import Iterable
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar, Union
 
+import narwhals as nw
+
+from pandera.api.base.types import CheckData
 from pandera.api.checks import Check
 
 T = TypeVar("T")
 
 
 @Check.register_builtin_check_fn
-def equal_to(data: Any, value: Any) -> Any:
-    raise NotImplementedError
+def equal_to(data: CheckData, value: Any) -> Any:
+    """Ensure all elements of a column equal a certain value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) == value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn
-def not_equal_to(data: Any, value: Any) -> Any:
-    raise NotImplementedError
+def not_equal_to(data: CheckData, value: Any) -> Any:
+    """Ensure no element of a column equals a certain value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) != value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn
-def greater_than(data: Any, min_value: Any) -> Any:
-    raise NotImplementedError
+def greater_than(data: CheckData, min_value: Any) -> Any:
+    """Ensure values are strictly greater than a minimum value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) > min_value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn
-def greater_than_or_equal_to(data: Any, min_value: Any) -> Any:
-    raise NotImplementedError
+def greater_than_or_equal_to(data: CheckData, min_value: Any) -> Any:
+    """Ensure all values are greater than or equal to a minimum value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) >= min_value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn
-def less_than(data: Any, max_value: Any) -> Any:
-    raise NotImplementedError
+def less_than(data: CheckData, max_value: Any) -> Any:
+    """Ensure values are strictly less than a maximum value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) < max_value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn
-def less_than_or_equal_to(data: Any, max_value: Any) -> Any:
-    raise NotImplementedError
+def less_than_or_equal_to(data: CheckData, max_value: Any) -> Any:
+    """Ensure all values are less than or equal to a maximum value."""
+    nw_frame = nw.from_native(data.frame)
+    result = nw_frame.select(nw.col(data.key) <= max_value)
+    return nw.to_native(result)
 
 
 @Check.register_builtin_check_fn

--- a/pandera/backends/ibis/builtin_checks.py
+++ b/pandera/backends/ibis/builtin_checks.py
@@ -3,7 +3,7 @@
 import datetime
 import re
 from collections.abc import Iterable
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 import ibis
 from ibis import _
@@ -11,6 +11,7 @@ from ibis import selectors as s
 
 from pandera.api.extensions import register_builtin_check
 from pandera.api.ibis.types import IbisData
+from pandera.backends.base import builtin_checks as base_checks
 from pandera.backends.ibis.utils import select_column
 
 T = TypeVar("T")
@@ -41,15 +42,9 @@ def _across(table: ibis.Table, selection: str | None, func) -> ibis.Table:
     error="equal_to({value})",
 )
 def equal_to(data: IbisData, value: Any) -> ibis.Table:
-    """Ensure all elements of a column equal a certain value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param value: Values in this Ibis data structure must be
-        equal to this value.
-    """
+    """Ensure all elements of a column equal a certain value."""
     value = _infer_interval_with_mixed_units(value)
-    return _across(data.table, data.key, _ == value)
+    return base_checks.equal_to(data, value)
 
 
 @register_builtin_check(
@@ -57,14 +52,9 @@ def equal_to(data: IbisData, value: Any) -> ibis.Table:
     error="not_equal_to({value})",
 )
 def not_equal_to(data: IbisData, value: Any) -> ibis.Table:
-    """Ensure no element of a column equals a certain value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param value: This value must not occur in the checked data structure.
-    """
+    """Ensure no element of a column equals a certain value."""
     value = _infer_interval_with_mixed_units(value)
-    return _across(data.table, data.key, _ != value)
+    return base_checks.not_equal_to(data, value)
 
 
 @register_builtin_check(
@@ -72,16 +62,9 @@ def not_equal_to(data: IbisData, value: Any) -> ibis.Table:
     error="greater_than({min_value})",
 )
 def greater_than(data: IbisData, min_value: Any) -> ibis.Table:
-    """Ensure values of a column are strictly greater than a minimum
-    value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param min_value: Lower bound to be exceeded. Must be a type comparable
-        to the dtype of the :class:`ibis.Column` to be validated.
-    """
-    value = _infer_interval_with_mixed_units(min_value)
-    return _across(data.table, data.key, _ > value)
+    """Ensure values are strictly greater than a minimum value."""
+    min_value = _infer_interval_with_mixed_units(min_value)
+    return base_checks.greater_than(data, min_value)
 
 
 @register_builtin_check(
@@ -89,15 +72,9 @@ def greater_than(data: IbisData, min_value: Any) -> ibis.Table:
     error="greater_than_or_equal_to({min_value})",
 )
 def greater_than_or_equal_to(data: IbisData, min_value: Any) -> ibis.Table:
-    """Ensure all values are greater than or equal to a minimum value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param min_value: Allowed minimum value. Must be a type comparable
-        to the dtype of the :class:`ibis.Column` to be validated.
-    """
-    value = _infer_interval_with_mixed_units(min_value)
-    return _across(data.table, data.key, _ >= value)
+    """Ensure all values are greater than or equal to a minimum value."""
+    min_value = _infer_interval_with_mixed_units(min_value)
+    return base_checks.greater_than_or_equal_to(data, min_value)
 
 
 @register_builtin_check(
@@ -105,16 +82,9 @@ def greater_than_or_equal_to(data: IbisData, min_value: Any) -> ibis.Table:
     error="less_than({max_value})",
 )
 def less_than(data: IbisData, max_value: Any) -> ibis.Table:
-    """Ensure values of a column are strictly less than a maximum value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param max_value: All elements of a column must be strictly smaller
-        than this. Must be a type comparable to the dtype of the
-        :class:`ibis.Column` to be validated.
-    """
-    value = _infer_interval_with_mixed_units(max_value)
-    return _across(data.table, data.key, _ < value)
+    """Ensure values are strictly less than a maximum value."""
+    max_value = _infer_interval_with_mixed_units(max_value)
+    return base_checks.less_than(data, max_value)
 
 
 @register_builtin_check(
@@ -122,15 +92,9 @@ def less_than(data: IbisData, max_value: Any) -> ibis.Table:
     error="less_than_or_equal_to({max_value})",
 )
 def less_than_or_equal_to(data: IbisData, max_value: Any) -> ibis.Table:
-    """Ensure all values are less than or equal to a maximum value.
-
-    :param data: NamedTuple IbisData contains the table and column name for the check. The key
-        to access the table is "table", and the key to access the column name is "key".
-    :param max_value: Upper bound not to be exceeded. Must be a type comparable to the dtype of the
-        :class:`ibis.Column` to be validated.
-    """
-    value = _infer_interval_with_mixed_units(max_value)
-    return _across(data.table, data.key, _ <= value)
+    """Ensure all values are less than or equal to a maximum value."""
+    max_value = _infer_interval_with_mixed_units(max_value)
+    return base_checks.less_than_or_equal_to(data, max_value)
 
 
 @register_builtin_check(

--- a/pandera/backends/polars/builtin_checks.py
+++ b/pandera/backends/polars/builtin_checks.py
@@ -2,12 +2,13 @@
 
 import re
 from collections.abc import Collection, Iterable
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 import polars as pl
 
 from pandera.api.extensions import register_builtin_check
 from pandera.api.polars.types import PolarsData
+from pandera.backends.base import builtin_checks as base_checks
 
 T = TypeVar("T")
 
@@ -17,14 +18,8 @@ T = TypeVar("T")
     error="equal_to({value})",
 )
 def equal_to(data: PolarsData, value: Any) -> pl.LazyFrame:
-    """Ensure all elements of a column equal a certain value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key to access the column name is "key".
-    :param value: Values in this Polars data structure must be
-        equal to this value.
-    """
-    return data.lazyframe.select(pl.col(data.key).eq(value))
+    """Ensure all elements of a column equal a certain value."""
+    return base_checks.equal_to(data, value)
 
 
 @register_builtin_check(
@@ -32,13 +27,8 @@ def equal_to(data: PolarsData, value: Any) -> pl.LazyFrame:
     error="not_equal_to({value})",
 )
 def not_equal_to(data: PolarsData, value: Any) -> pl.LazyFrame:
-    """Ensure no element of a column equals a certain value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key the to access the column name is "key".
-    :param value: This value must not occur in the checked data structure.
-    """
-    return data.lazyframe.select(pl.col(data.key).ne(value))
+    """Ensure no element of a column equals a certain value."""
+    return base_checks.not_equal_to(data, value)
 
 
 @register_builtin_check(
@@ -46,16 +36,8 @@ def not_equal_to(data: PolarsData, value: Any) -> pl.LazyFrame:
     error="greater_than({min_value})",
 )
 def greater_than(data: PolarsData, min_value: Any) -> pl.LazyFrame:
-    """
-    Ensure values of a column are strictly greater than a minimum
-    value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key the to access the column name is "key".
-    :param min_value: Lower bound to be exceeded. Must be
-        a type comparable to the dtype of the series datatype of Polars.
-    """
-    return data.lazyframe.select(pl.col(data.key).gt(min_value))
+    """Ensure values are strictly greater than a minimum value."""
+    return base_checks.greater_than(data, min_value)
 
 
 @register_builtin_check(
@@ -63,14 +45,8 @@ def greater_than(data: PolarsData, min_value: Any) -> pl.LazyFrame:
     error="greater_than_or_equal_to({min_value})",
 )
 def greater_than_or_equal_to(data: PolarsData, min_value: Any) -> pl.LazyFrame:
-    """Ensure all values are greater than or equal to a minimum value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key the to access the column name is "key".
-    :param min_value: Allowed minimum value. Must be a type comparable
-        to the dtype of the :class:`pl.Series` to be validated.
-    """
-    return data.lazyframe.select(pl.col(data.key).ge(min_value))
+    """Ensure all values are greater than or equal to a minimum value."""
+    return base_checks.greater_than_or_equal_to(data, min_value)
 
 
 @register_builtin_check(
@@ -78,15 +54,8 @@ def greater_than_or_equal_to(data: PolarsData, min_value: Any) -> pl.LazyFrame:
     error="less_than({max_value})",
 )
 def less_than(data: PolarsData, max_value: Any) -> pl.LazyFrame:
-    """Ensure values of a column are strictly less than a maximum value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key the to access the column name is "key".
-    :param max_value: All elements of a series must be strictly smaller
-        than this. Must be a type comparable to the dtype of the
-        :class:`pl.Series` to be validated.
-    """
-    return data.lazyframe.select(pl.col(data.key).lt(max_value))
+    """Ensure values are strictly less than a maximum value."""
+    return base_checks.less_than(data, max_value)
 
 
 @register_builtin_check(
@@ -94,14 +63,8 @@ def less_than(data: PolarsData, max_value: Any) -> pl.LazyFrame:
     error="less_than_or_equal_to({max_value})",
 )
 def less_than_or_equal_to(data: PolarsData, max_value: Any) -> pl.LazyFrame:
-    """Ensure all values are less than or equal to a maximum value.
-
-    :param data: NamedTuple PolarsData contains the dataframe and column name for the check. The key
-        to access the dataframe is "dataframe", and the key the to access the column name is "key".
-    :param max_value: Upper bound not to be exceeded. Must be a type comparable to the dtype of the
-        :class:`pl.Series` to be validated.
-    """
-    return data.lazyframe.select(pl.col(data.key).le(max_value))
+    """Ensure all values are less than or equal to a maximum value."""
+    return base_checks.less_than_or_equal_to(data, max_value)
 
 
 @register_builtin_check(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
+    "narwhals >= 1.0.0",
     "packaging >= 20.0",
     "pydantic",
     "typeguard",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ typing_inspect >= 0.6.0
 frictionless <= 4.40.8
 pyarrow >= 13
 pydantic
+narwhals >= 1.0.0
 scipy
 pandas-stubs
 scipy-stubs


### PR DESCRIPTION
Refactor builtin check implementations for Polars and Ibis to use Narwhals as a common abstraction layer, enabling code sharing between backends. This change implements equal_to, not_equal_to, greater_than, greater_than_or_equal_to, less_than, and less_than_or_equal_to checks using Narwhals.

- Add narwhals dependency to polars and ibis optional dependency groups
- Add CheckData protocol with frame and key properties for type safety
- Add frame property to PolarsData and IbisData for uniform access
- Replace NotImplementedError stubs in base with Narwhals implementations
- Update Polars and Ibis backends to delegate to base implementations