### PR TITLE
fix: ensure index fields have persistent metadata

### DIFF
--- a/pandera/api/dataframe/model_components.py
+++ b/pandera/api/dataframe/model_components.py
@@ -91,6 +91,7 @@ class FieldInfo(BaseFieldInfo):
             title=self.title,
             description=self.description,
             default=self.default,
+            metadata=self.metadata,
         )
 
     @property

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -2005,6 +2005,19 @@ def test_pandas_fields_metadata():
     assert PanderaSchema.get_metadata() == expected
 
 
+def test_index_field_metadata_persistence() -> None:
+    test_metadata = {"test_key": "test_value"}
+
+    class MyModel(pa.DataFrameModel):
+        index_field: Index[float] = pa.Field(
+            title="Index Field", metadata=test_metadata
+        )
+
+    class_schema = MyModel.to_schema()
+
+    assert class_schema.index.metadata == test_metadata
+
+
 def test_parse_single_column():
     """Test that a single column can be parsed from a DataFrame"""
 


### PR DESCRIPTION
Should fix bug reported in https://github.com/unionai-oss/pandera/issues/2215.

A test has been added, is this test in the right place? The test suite does not seem to contain any low-level tests for e.g. `FieldInfo.index_properties()`, therefore `tests/pandas/test_model.py` seemed to be most fitting. Especially since the test `test_pandas_fields_metadata` lives there. However, any suggestions are welcome!
