### PR TITLE
Add exact_value support to str_length_strategy

### DIFF
--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -727,12 +727,12 @@ def str_length_strategy(
     if exact_value is not None:
         min_value = exact_value
         max_value = exact_value
-    
+
     if min_value is None or max_value is None:
         raise ValueError(
             "Must provide either 'exact_value' or both 'min_value' and 'max_value'"
         )
-    
+
     if strategy is None:
         return st.text(min_size=min_value, max_size=max_value).map(
             to_numpy_dtype(pandera_dtype).type

--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -709,8 +709,9 @@ def str_length_strategy(
     pandera_dtype: Union[numpy_engine.DataType, pandas_engine.DataType],
     strategy: SearchStrategy | None = None,
     *,
-    min_value: int,
-    max_value: int,
+    min_value: int | None = None,
+    max_value: int | None = None,
+    exact_value: int | None = None,
 ) -> SearchStrategy:
     """Strategy to generate strings of a particular length
 
@@ -719,8 +720,19 @@ def str_length_strategy(
         pandas dtype strategy will be chained onto this strategy.
     :param min_value: minimum string length.
     :param max_value: maximum string length.
+    :param exact_value: exact string length.
     :returns: ``hypothesis`` strategy
     """
+    # Handle exact_value by setting min and max to the same value
+    if exact_value is not None:
+        min_value = exact_value
+        max_value = exact_value
+    
+    if min_value is None or max_value is None:
+        raise ValueError(
+            "Must provide either 'exact_value' or both 'min_value' and 'max_value'"
+        )
+    
     if strategy is None:
         return st.text(min_size=min_value, max_size=max_value).map(
             to_numpy_dtype(pandera_dtype).type

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -398,6 +398,17 @@ def test_str_length_checks(chained, data, value_range):
 
 
 @hypothesis.given(st.data())
+def test_str_length_exact_value(data):
+    """Test str_length_strategy with exact_value parameter."""
+    exact_value = 5
+    str_length_st = strategies.str_length_strategy(
+        pa.String, exact_value=exact_value
+    )
+    example = data.draw(str_length_st)
+    assert len(example) == exact_value
+
+
+@hypothesis.given(st.data())
 def test_register_check_strategy(data) -> None:
     """Test registering check strategy on a custom check."""
 


### PR DESCRIPTION
## Summary

Fixes issue #2219: The `str_length_strategy` function was not updated to support the `exact_value` parameter that was added to the `str_length` check in PR #2198.

## Changes

- Updated `str_length_strategy` signature in `pandera/strategies/pandas_strategies.py` to accept `exact_value` parameter
- Made `min_value` and `max_value` optional when `exact_value` is provided
- Added validation to require either `exact_value` or both `min_value` and `max_value`
- Added test case `test_str_length_exact_value` in `tests/strategies/test_strategies.py`

## Verification

- ✓ Original failing case now works: `schema.example()` with `Check.str_length(exact_value=3)` generates strings of exactly length 3
- ✓ All existing tests pass (`test_str_length_checks` with both `chained=True` and `chained=False`)
- ✓ New test `test_str_length_exact_value` passes
- ✓ Backward compatibility maintained: single positional argument still works
- ✓ Validation works correctly for both generation and verification

## Test Plan

```python
# Original failing case from issue
schema = pa.DataFrameSchema({
    "colA": pa.Column(str, [pa.Check.str_length(exact_value=3)])
})
example = schema.example(5)  # Now works! All strings have length 3

# Validation also works
valid_df = pd.DataFrame({"col": ["abc", "def", "ghi"]})
schema.validate(valid_df)  # Passes

invalid_df = pd.DataFrame({"col": ["ab", "def", "ghij"]})
schema.validate(invalid_df)  # Raises validation error
```