### PR TITLE
Replace `pre-commit` with `prek` and fix existing violations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,18 +79,18 @@ Moreover to add new extra dependencies in `pyproject.toml`, it is necessary to
 add it to the `dependencies` and `[project.optional-dependencies]` section.
 
 
-#### Set up `pre-commit`
+#### Set up `prek`
 
-This project uses [pre-commit](https://pre-commit.com/) to ensure that code
+This project uses [prek](https://prek.j178.dev/) to ensure that code
 standard checks pass locally before pushing to the remote project repo. Follow
-the [installation instructions](https://pre-commit.com/#installation), then
-set up hooks with `pre-commit install`. After, `black`, `pylint` and `mypy`
+the [installation instructions](https://prek.j178.dev/installation/), then
+set up hooks with `prek install`. After, `black`, `pylint` and `mypy`
 checks should be run with every commit.
 
 Make sure everything is working correctly by running
 
 ```bash
-pre-commit run --all
+prek run --all
 ```
 
 ### Making Changes

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
-          python -m pip install 'uv<0.7.0' nox pre_commit \
+          python -m pip install uv nox prek \
             mypy==0.982 \
             types-click \
             types-pytz \
@@ -69,11 +69,11 @@ jobs:
         run: nox -db uv -r --non-interactive --python ${{ matrix.python-version }} --session requirements-${{ matrix.python-version }}
 
       - if: always()
-        run: pre-commit run ruff-check --all-files
+        run: prek run ruff-check --all-files
 
       - name: Mypy Type Checking
         if: always()
-        run: pre-commit run mypy --all-files
+        run: prek run mypy --all-files
 
   # test base functionality
   unit-tests-base:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: (^asv_bench|setup.py|requirements-dev.txt)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
         description: Simply check whether files parse as valid python
@@ -28,25 +28,25 @@ repos:
         args: ["--line-length=79", "--skip=docs/source/conf.py", "--diff"]
 
   - repo: https://github.com/ikamensh/flynt
-    rev: "0.76"
+    rev: "1.0.6"
     hooks:
       - id: flynt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: v0.15.5
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py39-plus, --keep-runtime-typing]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -63,7 +63,7 @@ repos:
         verbose: true
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -81,7 +81,7 @@ dependencies:
   - asv >= 0.5.1
 
   # optional
-  - pre_commit
+  - prek
 
   - pip:
       # dask extra

--- a/noxfile.py
+++ b/noxfile.py
@@ -298,7 +298,9 @@ def docs(session: Session) -> None:
 
     session.install("-e", ".")
     session.install(
-        *_testing_requirements(session, extra="all", pandas=PANDAS_VERSIONS[0]),
+        *_testing_requirements(
+            session, extra="all", pandas=PANDAS_VERSIONS[0]
+        ),
         *nox.project.dependency_groups(PYPROJECT, "dev", "testing", "docs"),
     )
     session.run("uv", "pip", "list")

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -1,5 +1,6 @@
 """Check backend for pandas."""
 
+from collections.abc import Hashable
 from functools import partial
 from typing import Optional, Union, cast
 
@@ -46,7 +47,7 @@ class PandasCheckBackend(BaseCheckBackend):
     def _format_groupby_input(
         groupby_obj: GroupbyObject,
         groups: list[str] | None,
-    ) -> Union[dict[str, pd.Series], dict[str, pd.DataFrame]]:
+    ) -> dict[Hashable, pd.Series] | dict[Hashable, pd.DataFrame]:
         """Format groupby object into dict of groups to Series or DataFrame.
 
         :param groupby_obj: a pandas groupby object.
@@ -56,7 +57,7 @@ class PandasCheckBackend(BaseCheckBackend):
         # NOTE: this behavior should be deprecated such that the user deals with
         # pandas groupby objects instead of dicts.
         if groups is None:
-            return {  # type: ignore[return-value]
+            return {
                 (k if isinstance(k, bool) else k[0] if len(k) == 1 else k): v
                 for k, v in groupby_obj  # type: ignore[union-attr]
             }

--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -202,8 +202,9 @@ def parse_checks(checks) -> Union[list[dict[str, Any]], None]:
 
     incompatibile_checks_count = sum(
         map(
-            lambda check: check["options"]["check_name"]
-            in incompatibile_checks,
+            lambda check: (
+                check["options"]["check_name"] in incompatibile_checks
+            ),
             check_statistics,
         )
     )

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -232,10 +232,11 @@ class AnnotationInfo:
 
         if metadata:
             self.is_annotated_type = True
-            try:
-                inspect.signature(self.arg)
-            except ValueError:
-                metadata = None
+            if self.arg is not None:
+                try:
+                    inspect.signature(self.arg)
+                except ValueError:
+                    metadata = None
 
         elif metadata := getattr(self.arg, "__metadata__", None):
             self.arg = get_args(self.arg)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dev = [
     "nox",
     "pip",
     "polars >= 0.20.0",
-    "pre_commit",
+    "prek",
     "pyarrow >= 13",
     "python-multipart",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,4 +190,4 @@ ignore = [
 ]
 
 [tool.codespell]
-ignore-words-list = ["notin", "splitted", "fo", "strat"]
+ignore-words-list = ["notin", "splitted", "fo", "strat", "ttest"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ recommonmark
 myst-nb
 twine
 asv >= 0.5.1
-pre_commit
+prek
 dask[dataframe]
 distributed
 ibis-framework >= 9.0.0

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1971,7 +1971,11 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
     # Pandas 3.0+ may report string columns as 'str' (StringDtype) or 'object'
     # depending on how the series was created
     dtype_failure = next(
-        (fc for (check, fc) in actual_failure_cases if check == "dtype('float64')"),
+        (
+            fc
+            for (check, fc) in actual_failure_cases
+            if check == "dtype('float64')"
+        ),
         None,
     )
     assert dtype_failure in ("str", "object"), (

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -44,11 +44,13 @@ def test_idempotent_magics() -> None:
 
         # DataFrame-level check, used to populate __root_checks__
         @pa.dataframe_check
+        @classmethod
         def root_check_test(cls, df: pd.DataFrame) -> Iterable[bool]:
             return df["a"] >= 0
 
         # DataFrame-level parser, used to populate __root_parsers__
         @pa.dataframe_parser
+        @classmethod
         def root_parser_test(cls, df: pd.DataFrame) -> pd.DataFrame:
             df = df.copy()
             df["a"] = df["a"].abs()

--- a/tests/pandas/test_pandas_parallel.py
+++ b/tests/pandas/test_pandas_parallel.py
@@ -13,9 +13,7 @@ def test_polars_parallel():
         return schema.validate(pd.DataFrame({"a": [1]}))
 
     # Use threads to avoid loky process spawn issues on Windows CI (TerminatedWorkerError)
-    results = Parallel(2, prefer="threads")(
-        [delayed(fn)() for _ in range(10)]
-    )
+    results = Parallel(2, prefer="threads")([delayed(fn)() for _ in range(10)])
     assert len(results) == 10
     for result in results:
         assert result.dtypes["a"] == "int64"

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -22,7 +22,9 @@ def test_dataframe_schema_parse() -> None:
     schema_check_return_bool = DataFrameSchema(
         parsers=Parser(lambda df: df.transform("sqrt"))
     )
-    assert schema_check_return_bool.validate(data).equals(data.transform("sqrt"))
+    assert schema_check_return_bool.validate(data).equals(
+        data.transform("sqrt")
+    )
 
 
 def test_dataframe_schema_parse_with_element_wise() -> None:
@@ -33,9 +35,7 @@ def test_dataframe_schema_parse_with_element_wise() -> None:
     )
     # pandas 3.0 removed applymap, use map instead
     result = (
-        data.map(np.sqrt)
-        if PANDAS_3_0_0_PLUS
-        else data.applymap(np.sqrt)  # type: ignore[attr-defined]
+        data.map(np.sqrt) if PANDAS_3_0_0_PLUS else data.applymap(np.sqrt)  # type: ignore[attr-defined]
     )
     assert schema_check_return_bool.validate(data).equals(result)
 

--- a/tests/polars/test_polars_parallel.py
+++ b/tests/polars/test_polars_parallel.py
@@ -13,9 +13,7 @@ def test_polars_parallel():
         return schema.validate(pl.DataFrame({"a": [1]}))
 
     # Use threads to avoid loky process spawn issues on Windows CI (TerminatedWorkerError)
-    results = Parallel(2, prefer="threads")(
-        [delayed(fn)() for _ in range(10)]
-    )
+    results = Parallel(2, prefer="threads")([delayed(fn)() for _ in range(10)])
     assert len(results) == 10
     for result in results:
         assert result.schema["a"] == pl.Int32


### PR DESCRIPTION
This PR migrates the repository’s Git hook management from `pre-commit` to `prek`. `prek` is fully compatible with the existing `.pre-commit-config.yaml` but offers better speed (uses uv under the hood) and usability. See also: [Why prek?](https://prek.j178.dev/#why-prek)