### PR TITLE
Remove vestigial `ordering` parameter from polars `Categorical`

### DIFF
--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -724,24 +724,18 @@ class Categorical(DataType):
 
     type = pl.Categorical
 
-    ordering = None
-
-    def __init__(
-        self,
-        ordering: Literal["physical", "lexical"] | None = "lexical",
-    ) -> None:
-        object.__setattr__(self, "ordering", ordering)
+    def __init__(self) -> None:
         object.__setattr__(self, "type", pl.Categorical())
 
     def __deepcopy__(self, memo):
         """Custom deepcopy to avoid pickling issues with pl.Categorical()."""
-        return self.__class__(ordering=self.ordering)
+        return self.__class__()
 
     @classmethod
     def from_parametrized_dtype(cls, polars_dtype: pl.Categorical):
         """Convert a :class:`polars.Categorical` to
         a Pandera :class:`pandera.engines.polars_engine.Categorical`."""
-        return cls(ordering=polars_dtype.ordering)
+        return cls()
 
 
 @Engine.register_dtype(equivalents=[pl.Enum])

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -540,3 +540,28 @@ def test_datetime_time_zone_agnostic(dtype):
         dtype.type, "time_zone", None
     ):
         assert not tz_sensitive_utc.check(dtype)
+
+
+def test_polars_import_no_warnings():
+    """Regression test for https://github.com/unionai-oss/pandera/issues/2104.
+
+    Importing pandera.polars should not emit DeprecationWarning or
+    FutureWarning related to polars Categorical/Enum changes.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-W",
+            "error::FutureWarning",
+            "-c",
+            "import pandera.polars",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Import raised a warning:\n{result.stderr}"


### PR DESCRIPTION
Related: #2113
Closes: #2104
Depends on: #2225

## Motivation

Polars 1.32 deprecated `Categorical(ordering=...)` — ordering is now always lexical. Pandera v0.26.0 already stopped passing `ordering` through to `pl.Categorical()` (commit `24fe938f`), but the parameter remained on pandera's own `Categorical` class as a no-op. This caused:

- **Misleading API**: users could pass `ordering="physical"` and believe it had an effect
- **Import-time deprecation warnings**: accessing `polars_dtype.ordering` in `from_parametrized_dtype` triggered `DeprecationWarning` on every `import pandera.polars`
- **Forward-compatibility risk**: polars may remove the `.ordering` attribute entirely in a future release

## Changes

- Removed `ordering` class attribute and `__init__` parameter from `Categorical`
- Simplified `__deepcopy__` and `from_parametrized_dtype` (no ordering to propagate)
- Added regression test verifying `import pandera.polars` emits no `DeprecationWarning` or `FutureWarning`

## Migration

If you were passing `ordering` to `Categorical`:

```python
# Before
import pandera.polars as pa
schema = pa.DataFrameSchema({"col": pa.Column(pa.Categorical(ordering="physical"))})

# After — just remove the argument (it was already a no-op since v0.26.0)
schema = pa.DataFrameSchema({"col": pa.Column(pa.Categorical())})
```

No behavioral change — `ordering` had no effect since v0.26.0.
