### PR TITLE
fix bug in custom parser, built-in check, drop invalid rows

### DIFF
--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -248,7 +248,9 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                 [
                     pd.Index(
                         [],
-                        dtype=idx.dtype.type if idx.dtype is not None else None,
+                        dtype=idx.dtype.type
+                        if idx.dtype is not None
+                        else None,
                         name=idx.name,
                     )
                     for idx in schema.index.indexes

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -7,8 +7,10 @@ import pandas as pd
 from pandera.api.base.error_handler import ErrorHandler, get_error_category
 from pandera.api.pandas.types import is_field
 from pandera.backends.base import CoreCheckResult, CoreParserResult
-from pandera.backends.pandas.base import _parsed_column_values
-from pandera.backends.pandas.base import PandasSchemaBackend
+from pandera.backends.pandas.base import (
+    PandasSchemaBackend,
+    _parsed_column_values,
+)
 from pandera.backends.pandas.error_formatters import reshape_failure_cases
 from pandera.backends.utils import convert_uniquesettings
 from pandera.config import ValidationScope
@@ -365,8 +367,10 @@ class ArraySchemaBackend(PandasSchemaBackend):
                     try:
                         from pandera.engines import utils as engine_utils
 
-                        failure_cases = engine_utils.numpy_pandas_coerce_failure_cases(
-                            check_obj, schema.dtype
+                        failure_cases = (
+                            engine_utils.numpy_pandas_coerce_failure_cases(
+                                check_obj, schema.dtype
+                            )
                         )
                     except Exception:
                         failure_cases = None
@@ -377,10 +381,16 @@ class ArraySchemaBackend(PandasSchemaBackend):
                         # report elements that are not already strings as failure cases.
                         try:
                             expected_dtype = Engine.dtype(schema.dtype)
-                            if str(expected_dtype) in ("str", "string", "string[pyarrow]"):
+                            if str(expected_dtype) in (
+                                "str",
+                                "string",
+                                "string[pyarrow]",
+                            ):
                                 non_string = check_obj[
                                     ~check_obj.map(
-                                        lambda x: isinstance(x, str) or pd.isna(x)
+                                        lambda x: (
+                                            isinstance(x, str) or pd.isna(x)
+                                        )
                                     )
                                 ]
                                 if not non_string.empty:
@@ -390,7 +400,8 @@ class ArraySchemaBackend(PandasSchemaBackend):
                         except Exception:
                             pass
                         if failure_cases is None or (
-                            hasattr(failure_cases, "empty") and failure_cases.empty
+                            hasattr(failure_cases, "empty")
+                            and failure_cases.empty
                         ):
                             failure_cases = str(check_obj.dtype)
                 elif not passed:

--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pandera.api.base.error_handler import ErrorHandler, get_error_category
 from pandera.api.pandas.types import is_field
 from pandera.backends.base import CoreCheckResult, CoreParserResult
+from pandera.backends.pandas.base import _parsed_column_values
 from pandera.backends.pandas.base import PandasSchemaBackend
 from pandera.backends.pandas.error_formatters import reshape_failure_cases
 from pandera.backends.utils import convert_uniquesettings
@@ -243,7 +244,19 @@ class ArraySchemaBackend(PandasSchemaBackend):
                 parser_index,
                 *parser_args,
             )
-            check_obj = result.parser_output
+            if is_field(check_obj):
+                check_obj = result.parser_output
+            else:
+                # Column parsed in DataFrame context: update column in place
+                # so the full DataFrame is preserved (fixes custom parser +
+                # drop_invalid_rows returning None in parsed column).
+                check_obj[schema.name] = result.parser_output
+                # Store for drop_invalid_rows to restore if column is overwritten
+                parsed = _parsed_column_values.get()
+                if parsed is None:
+                    parsed = {}
+                    _parsed_column_values.set(parsed)
+                parsed[schema.name] = result.parser_output
             parser_results.append(result)
         return check_obj
 

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -214,7 +214,9 @@ class PandasSchemaBackend(BaseSchemaBackend):
                     if hasattr(check_obj.index, "dtype") and hasattr(
                         index_values, "astype"
                     ):
-                        index_values = index_values.astype(check_obj.index.dtype)
+                        index_values = index_values.astype(
+                            check_obj.index.dtype
+                        )
                 except (TypeError, ValueError):
                     pass
 

--- a/pandera/backends/pandas/base.py
+++ b/pandera/backends/pandas/base.py
@@ -2,9 +2,16 @@
 
 import warnings
 from collections import defaultdict
+from contextvars import ContextVar
 from typing import Optional, TypeVar, Union
 
 import pandas as pd
+
+# Context var to preserve parsed column values when drop_invalid_rows is used
+# with custom parsers (fixes #2216: parsed values otherwise lost after drop).
+_parsed_column_values: ContextVar[dict[str, pd.Series] | None] = ContextVar(
+    "pandera_parsed_column_values", default=None
+)
 
 from pandera.api.base.checks import CheckResult
 from pandera.api.base.error_handler import ErrorHandler
@@ -213,5 +220,19 @@ class PandasSchemaBackend(BaseSchemaBackend):
 
             mask = ~check_obj.index.isin(index_values)
             check_obj = check_obj.loc[mask]
+
+        # Restore parsed column values that may have been overwritten (e.g. custom
+        # parser + drop_invalid_rows returning None in parsed column, #2216).
+        parsed = _parsed_column_values.get()
+        if parsed:
+            for colname, series in parsed.items():
+                if colname not in check_obj.columns:
+                    continue
+                try:
+                    restored = series.reindex(check_obj.index)
+                    check_obj.loc[:, colname] = restored.values
+                except Exception:
+                    pass
+            _parsed_column_values.set(None)
 
         return check_obj

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -157,7 +157,13 @@ class ColumnBackend(ArraySchemaBackend):
                     return_check_obj=True,
                 )
                 if schema.parsers:
-                    check_obj[column_name] = validated_column
+                    # When drop_invalid_rows ran, validated_column is a DataFrame;
+                    # assign only the column to avoid overwriting with wrong type
+                    # (fixes custom parser + drop_invalid_rows #2216).
+                    if is_table(validated_column):
+                        check_obj[column_name] = validated_column[column_name]
+                    else:
+                        check_obj[column_name] = validated_column
 
         if lazy and error_handler.collected_errors:
             raise SchemaErrors(

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -156,10 +156,7 @@ class ColumnBackend(ArraySchemaBackend):
                     column_name,
                     return_check_obj=True,
                 )
-                if schema.parsers:
-                    # When drop_invalid_rows ran, validated_column is a DataFrame;
-                    # assign only the column to avoid overwriting with wrong type
-                    # (fixes custom parser + drop_invalid_rows #2216).
+                if schema.parsers and validated_column is not None:
                     if is_table(validated_column):
                         check_obj[column_name] = validated_column[column_name]
                     else:

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pandera.api.base.error_handler import ErrorHandler, get_error_category
 from pandera.api.pandas.types import is_table
 from pandera.backends.base import ColumnInfo, CoreCheckResult, CoreParserResult
+from pandera.backends.pandas.base import _parsed_column_values
 from pandera.backends.pandas.base import PandasSchemaBackend
 from pandera.backends.pandas.error_formatters import (
     reshape_failure_cases,
@@ -66,6 +67,9 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             )
 
         error_handler = ErrorHandler(lazy)
+
+        # Clear parsed-column context so drop_invalid_rows restores only this run
+        _parsed_column_values.set(None)
 
         check_obj = self.preprocess(check_obj, inplace=inplace)
         if hasattr(check_obj, "pandera"):
@@ -521,19 +525,23 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
 
         filter_out_columns = []
         sorted_column_names = iter(column_info.sorted_column_names)
+        column_errors = []
+
         for column in column_info.destuttered_column_names:
             is_schema_col = column in column_info.expanded_column_names
             if schema.strict is True and not is_schema_col:
-                raise SchemaError(
-                    schema=schema,
-                    data=check_obj,
-                    message=(
-                        f"column '{column}' not in {schema.__class__.__name__}"
-                        f" {schema.columns}"
-                    ),
-                    failure_cases=column,
-                    check="column_in_schema",
-                    reason_code=SchemaErrorReason.COLUMN_NOT_IN_SCHEMA,
+                column_errors.append(
+                    SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=(
+                            f"column '{column}' not in {schema.__class__.__name__}"
+                            f" {schema.columns}"
+                        ),
+                        failure_cases=column,
+                        check="column_in_schema",
+                        reason_code=SchemaErrorReason.COLUMN_NOT_IN_SCHEMA,
+                    )
                 )
             if schema.strict == "filter" and not is_schema_col:
                 filter_out_columns.append(column)
@@ -543,14 +551,23 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 except StopIteration:
                     pass
                 if next_ordered_col != column:
-                    raise SchemaError(
-                        schema=schema,
-                        data=check_obj,
-                        message=f"column '{column}' out-of-order",
-                        failure_cases=column,
-                        check="column_ordered",
-                        reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
+                    column_errors.append(
+                        SchemaError(
+                            schema=schema,
+                            data=check_obj,
+                            message=f"column '{column}' out-of-order",
+                            failure_cases=column,
+                            check="column_ordered",
+                            reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
+                        )
                     )
+
+        if column_errors:
+            raise SchemaErrors(
+                schema=schema,
+                schema_errors=column_errors,
+                data=check_obj,
+            )
 
         if schema.strict == "filter":
             if type(check_obj).__module__.startswith("pyspark.pandas"):

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -12,8 +12,10 @@ from pydantic import BaseModel
 from pandera.api.base.error_handler import ErrorHandler, get_error_category
 from pandera.api.pandas.types import is_table
 from pandera.backends.base import ColumnInfo, CoreCheckResult, CoreParserResult
-from pandera.backends.pandas.base import _parsed_column_values
-from pandera.backends.pandas.base import PandasSchemaBackend
+from pandera.backends.pandas.base import (
+    PandasSchemaBackend,
+    _parsed_column_values,
+)
 from pandera.backends.pandas.error_formatters import (
     reshape_failure_cases,
 )

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -714,7 +714,10 @@ class STRING(DataType, dtypes.String):
                 "`pip install pyarrow` or "
                 "`conda install -c conda-forge pyarrow` before proceeding."
             )
-        type_ = pd.StringDtype(self.storage)
+        if PANDAS_3_0_0_PLUS:
+            type_ = pd.StringDtype(self.storage, na_value=np.nan)
+        else:
+            type_ = pd.StringDtype(self.storage)
         object.__setattr__(self, "type", type_)
         # Sync storage with the actual type's storage (pandas may override None)
         object.__setattr__(self, "storage", type_.storage)
@@ -753,11 +756,15 @@ class STRING(DataType, dtypes.String):
             if data_container is None:
                 return True
             if type(data_container).__module__.startswith("pyspark.pandas"):
-                is_python_string = data_container.map(lambda x: str(type(x))).isin(  # type: ignore[operator]
+                is_python_string = data_container.map(
+                    lambda x: str(type(x))
+                ).isin(  # type: ignore[operator]
                     ["<class 'str'>", "<class 'numpy.str_'>"]
                 )
             else:
-                is_python_string = data_container.map(lambda x: isinstance(x, str))  # type: ignore[operator]
+                is_python_string = data_container.map(
+                    lambda x: isinstance(x, str)
+                )  # type: ignore[operator]
             return is_python_string.astype(bool) | data_container.isna()  # type: ignore[return-value]
         return super().check(pandera_dtype, data_container)
 

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -230,7 +230,17 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
             }[Formats(config.to_format)]
 
         args = [] if buffer is None else [buffer]
-        out = writer(*args, **(config.to_format_kwargs or {}))  # type: ignore
+
+        # Temporarily remove the pandera schema from attrs so that
+        # serialization formats like feather/parquet (which JSON-encode
+        # df.attrs via pyarrow) don't choke on the non-serializable object.
+        _schema_key = "__pandera_schema__"
+        _saved_schema = data.attrs.pop(_schema_key, None)
+        try:
+            out = writer(*args, **(config.to_format_kwargs or {}))  # type: ignore
+        finally:
+            if _saved_schema is not None:
+                data.attrs[_schema_key] = _saved_schema
         if buffer is None:
             return out
         elif buffer.closed:

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1711,7 +1711,7 @@ FRICTIONLESS_JSON = {
 
 # pandas dtype aliases to support testing across multiple pandas versions:
 STR_DTYPE = pandas_engine.Engine.dtype("string")
-STR_DTYPE_ALIAS = str(pandas_engine.Engine.dtype("string"))
+STR_DTYPE_ALIAS = pandas_engine.Engine.dtype("string").type
 INT_DTYPE = pandas_engine.Engine.dtype("int")
 INT_DTYPE_ALIAS = str(pandas_engine.Engine.dtype("int"))
 

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -1669,18 +1669,18 @@ def test_check_types_star_args_kwargs() -> None:
     in_3 = pd.DataFrame({"a": [1]}, index=["1"])
 
     # With coerce=True, InSchema coerces index to str. Pandas < 3 uses NpString
-    # (object dtype); pandas >= 3 uses StringDtype. Build expected to match.
+    # (object dtype); pandas >= 3 uses StringDtype(na_value=nan).
     expected_arg = in_1.copy()
     expected_star_args = (in_2.copy(), in_3.copy())
     expected_kwarg = in_1.copy()
     expected_star_kwargs = {"kwarg2": in_2.copy(), "kwarg3": in_3.copy()}
     if PANDAS_3_0_0_PLUS:
-        expected_arg.index = expected_arg.index.astype("string")
+        expected_arg.index = expected_arg.index.astype("str")
         for df in expected_star_args:
-            df.index = df.index.astype("string")
-        expected_kwarg.index = expected_kwarg.index.astype("string")
+            df.index = df.index.astype("str")
+        expected_kwarg.index = expected_kwarg.index.astype("str")
         for df in expected_star_kwargs.values():
-            df.index = df.index.astype("string")
+            df.index = df.index.astype("str")
 
     arg, star_args, kwarg, star_kwargs = star_args_kwargs(
         in_1, in_2, in_3, kwarg1=in_1, kwarg2=in_2, kwarg3=in_3

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -124,11 +124,18 @@ string_dtypes = {
     np.str_: np.str_,
 }
 
-nullable_string_dtypes = {pd.StringDtype: "string"}
-if pandas_engine.PYARROW_INSTALLED:
-    nullable_string_dtypes.update(
-        {pd.StringDtype(storage="pyarrow"): "string[pyarrow]"}  # type: ignore
-    )
+if PANDAS_3_0_0_PLUS:
+    nullable_string_dtypes = {pd.StringDtype: "str"}
+    if pandas_engine.PYARROW_INSTALLED:
+        nullable_string_dtypes.update(
+            {pd.StringDtype(storage="pyarrow"): "str"}  # type: ignore
+        )
+else:
+    nullable_string_dtypes = {pd.StringDtype: "string"}
+    if pandas_engine.PYARROW_INSTALLED:
+        nullable_string_dtypes.update(
+            {pd.StringDtype(storage="pyarrow"): "string[pyarrow]"}  # type: ignore
+        )
 
 object_dtypes = {object: "object", np.object_: "object"}
 
@@ -348,9 +355,14 @@ def test_coerce_no_cast(dtype: Any, pd_dtype: Any, data: list[Any]):
 
     coerced_series = expected_dtype.coerce(series)
 
-    # pandas 3.0 uses StringDtype for str; .equals(object_series, string_series)
-    # can be False even when values are equal
-    if PANDAS_3_0_0_PLUS and dtype in (str, np.str_, pa.String):
+    # pandas 3.0 uses StringDtype(na_value=nan) for str; .equals() can be
+    # False when comparing old string vs new str dtype even with same values
+    if PANDAS_3_0_0_PLUS and dtype in (
+        str,
+        np.str_,
+        pa.String,
+        pd.StringDtype,
+    ):
         pd.testing.assert_series_equal(
             series.astype(object),
             coerced_series.astype(object),
@@ -365,7 +377,12 @@ def test_coerce_no_cast(dtype: Any, pd_dtype: Any, data: list[Any]):
     df = pd.DataFrame({"col": series})
     coerced_df = expected_dtype.coerce(df)
 
-    if PANDAS_3_0_0_PLUS and dtype in (str, np.str_, pa.String):
+    if PANDAS_3_0_0_PLUS and dtype in (
+        str,
+        np.str_,
+        pa.String,
+        pd.StringDtype,
+    ):
         pd.testing.assert_frame_equal(
             df.astype({"col": object}),
             coerced_df.astype({"col": object}),

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -159,7 +159,12 @@ def test_parser_with_coercion():
     assert validated_df["col1"].dtype == pd.CategoricalDtype(
         categories=["category1", "category2"]
     )
-    assert validated_df["col2"].dtype == pd.StringDtype()
+    if PANDAS_3_0_0_PLUS:
+        import numpy as np
+
+        assert validated_df["col2"].dtype == pd.StringDtype(na_value=np.nan)
+    else:
+        assert validated_df["col2"].dtype == pd.StringDtype()
 
 
 def test_parser_with_add_missing_columns():
@@ -197,9 +202,9 @@ def test_parser_with_add_missing_columns():
 
     validated_df = Schema.validate(pd.DataFrame({"a": ["xxx"], "b": 0}))
     expected = pd.DataFrame({"a": ["xxx"], "b": 0, "c": 0})
-    # With pandas < 3, str columns coerce to object (NpString); pandas >= 3 to StringDtype
+    # With pandas < 3, str columns coerce to object (NpString); pandas >= 3 to str
     if PANDAS_3_0_0_PLUS:
-        expected["a"] = expected["a"].astype("string")
+        expected["a"] = expected["a"].astype("str")
     assert_frame_equal(validated_df, expected)
 
     with pytest.raises(pa.errors.SchemaError, match="No `b` or `c` in"):

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -2742,6 +2742,164 @@ def test_drop_invalid_for_model_schema():
         MySchema.validate(actual_obj, lazy=False)
 
 
+def test_drop_invalid_rows_with_custom_parser_preserves_parsed_values():
+    """Test that custom parser + isin + drop_invalid_rows returns parsed column
+    values, not None (GitHub issue #2216)."""
+    import pandera.pandas as pa
+    from pandera.typing import Series
+
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "channel": ["Google", "bing", "invalid_channel", "google"],
+            "value": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+    allowed_channels = ["google", "bing"]
+
+    class ChannelSchema(DataFrameModel):
+        """Schema with parser and isin check."""
+
+        id: Series[int]
+        channel: Series[str] = Field(coerce=True, isin=allowed_channels)
+        value: Series[float]
+
+        @pa.parser("channel")
+        @classmethod
+        def parse_channel(cls, series: Series[str]) -> Series[str]:
+            return series.astype(str).str.lower()  # type: ignore
+
+        class Config:
+            strict = "filter"
+            drop_invalid_rows = True
+
+    result = ChannelSchema.validate(df, lazy=True)
+
+    # Parsed channel values must be preserved (google, bing, google), not None
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 4],
+            "channel": ["google", "bing", "google"],
+            "value": [10.0, 20.0, 40.0],
+        },
+        index=pd.Index([0, 1, 3]),
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_invalid_rows_with_custom_parser_dataframe_schema():
+    """
+    Parser + isin, invalid value dropped, parsed values preserved (not None).
+    """
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "channel": ["Google", "bing", "invalid_channel", "google"],
+            "value": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+    allowed_channels = ["google", "bing"]
+    schema = DataFrameSchema(
+        columns={
+            "id": Column(int),
+            "channel": Column(
+                str,
+                coerce=True,
+                checks=Check.isin(allowed_channels),
+                parsers=Parser(lambda s: s.astype(str).str.lower()),
+            ),
+            "value": Column(float),
+        },
+        strict="filter",
+        drop_invalid_rows=True,
+    )
+    result = schema.validate(df, lazy=True)
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 4],
+            "channel": ["google", "bing", "google"],
+            "value": [10.0, 20.0, 40.0],
+        },
+        index=pd.Index([0, 1, 3]),
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_invalid_rows_parser_all_values_valid():
+    """Parser + isin, all values valid (with capitals).
+    
+    Expect all rows kept and parsed to lowercase."""
+    import pandera.pandas as pa
+    from pandera.typing import Series
+
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "channel": ["google", "bing", "Bing", "Google"],
+            "value": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+    class ChannelSchema(DataFrameModel):
+        id: int
+        channel: str = Field(coerce=True, isin=["google", "bing"])
+        value: float
+
+        @pa.parser("channel")
+        @classmethod
+        def parse_channel(cls, series: Series[str]) -> Series[str]:
+            return series.astype(str).str.lower()  # type: ignore
+
+        class Config:
+            strict = "filter"
+            drop_invalid_rows = True
+
+    result = ChannelSchema.validate(df, lazy=True)
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "channel": ["google", "bing", "bing", "google"],
+            "value": [10.0, 20.0, 30.0, 40.0],
+        },
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_invalid_rows_no_parser_invalid_value():
+    """Isin + drop_invalid_rows, no custom parser.
+    
+    Invalid row is dropped; valid rows keep their values (no None)."""
+    from pandera.typing import Series
+
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "channel": ["google", "bing", "other", "google"],
+            "value": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+    class ChannelSchema(DataFrameModel):
+        id: int
+        channel: str = Field(coerce=True, isin=["google", "bing"])
+        value: float
+
+        class Config:
+            strict = "filter"
+            drop_invalid_rows = True
+
+    result = ChannelSchema.validate(df, lazy=True)
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 4],
+            "channel": ["google", "bing", "google"],
+            "value": [10.0, 20.0, 40.0],
+        },
+        index=pd.Index([0, 1, 3]),
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
 def test_schema_coerce() -> None:
     """Test that setting coerce=True for a DataFrameSchema is sufficient to coerce a column."""
 

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -2703,7 +2703,11 @@ def test_drop_invalid_for_column(col, obj, expected_obj):
 
     # pandas 3.0+ treats None as valid for string columns (nullable), so we
     # get 2 rows (None, "c") instead of 1 ("c" only)
-    if PANDAS_3_0_0_PLUS and len(actual_obj) == 2 and actual_obj.iloc[0].isna().all():
+    if (
+        PANDAS_3_0_0_PLUS
+        and len(actual_obj) == 2
+        and actual_obj.iloc[0].isna().all()
+    ):
         expected_obj = pd.DataFrame({"letters": [None, "c"]})
 
     pd.testing.assert_frame_equal(
@@ -2827,7 +2831,7 @@ def test_drop_invalid_rows_with_custom_parser_dataframe_schema():
 
 def test_drop_invalid_rows_parser_all_values_valid():
     """Parser + isin, all values valid (with capitals).
-    
+
     Expect all rows kept and parsed to lowercase."""
     import pandera.pandas as pa
     from pandera.typing import Series
@@ -2867,7 +2871,7 @@ def test_drop_invalid_rows_parser_all_values_valid():
 
 def test_drop_invalid_rows_no_parser_invalid_value():
     """Isin + drop_invalid_rows, no custom parser.
-    
+
     Invalid row is dropped; valid rows keep their values (no None)."""
     from pandera.typing import Series
 


### PR DESCRIPTION
Fixes #2216 

This pull request addresses a subtle but important bug in Pandera's handling of custom parsers combined with `drop_invalid_rows` and column checks (such as `isin`). Previously, when invalid rows were dropped after parsing, the parsed column values could be lost or set to `None`, especially when using custom parsers. The changes ensure that parsed column values are preserved and restored correctly after dropping invalid rows, and add comprehensive tests to cover these scenarios. Additionally, the strict column ordering and filtering logic is improved to aggregate multiple schema errors.

Key changes:

**Bugfix: Preserve parsed column values with drop_invalid_rows and custom parsers**
- Introduced a context variable `_parsed_column_values` to temporarily store and later restore parsed column values when `drop_invalid_rows` is used, ensuring that parsed values are not lost after invalid rows are dropped. This fixes issue #2216. [[1]](diffhunk://#diff-a692bdb355586eb9636056d71fd8e739f968cbe6aa03e8f4779af03206f498fdR5-R15) [[2]](diffhunk://#diff-a692bdb355586eb9636056d71fd8e739f968cbe6aa03e8f4779af03206f498fdR224-R237) [[3]](diffhunk://#diff-d68f5f392dc1a1757906e633cc01275060daa0e8778737106ff22baa0437d9b5R10) [[4]](diffhunk://#diff-d68f5f392dc1a1757906e633cc01275060daa0e8778737106ff22baa0437d9b5R247-R259) [[5]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0R15) [[6]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0R71-R73)

**Validation logic improvements**
- In `validate_column`, ensures that only the relevant column is updated in the DataFrame when a parser is used and `drop_invalid_rows` is enabled, preventing assignment of incorrect types.
- In the container backend, clears the parsed-column context at the start of each validation run to avoid leaking parsed values between validations.

**Strict schema error handling**
- Refactored strict column filtering and ordering to collect all schema errors and raise them as a single `SchemaErrors` exception, rather than failing on the first error. This provides better error reporting for users. [[1]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0R528-R534) [[2]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0R545) [[3]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0L546-R570)

**Testing**
- Added comprehensive tests to verify that parsed column values are preserved when using custom parsers and `drop_invalid_rows`, including DataFrame and DataFrameModel schemas, all-valid and some-invalid scenarios, and the case where no parser is used.