### PR TITLE
Refactor Pandera accessors to use schema registry for managing schemas

### DIFF
--- a/pandera/accessors/_schema_registry.py
+++ b/pandera/accessors/_schema_registry.py
@@ -1,0 +1,27 @@
+"""Weakref-backed store for pandera schemas on pandas/dask objects."""
+
+from __future__ import annotations
+
+import weakref
+from typing import Any
+
+_reg: dict[int, Any] = {}
+_refs: dict[int, weakref.ref] = {}
+
+
+def register_schema(obj: object, schema: Any) -> None:
+    """Associate schema with obj without using df.attrs (serializable I/O)."""
+    oid = id(obj)
+    _reg[oid] = schema
+    if oid not in _refs:
+
+        def cleanup(_: weakref.ref) -> None:
+            _reg.pop(oid, None)
+            _refs.pop(oid, None)
+
+        _refs[oid] = weakref.ref(obj, cleanup)
+
+
+def get_schema(obj: object) -> Any | None:
+    """Return the schema registered for obj, if any."""
+    return _reg.get(id(obj))

--- a/pandera/accessors/dask_accessor.py
+++ b/pandera/accessors/dask_accessor.py
@@ -7,6 +7,7 @@ from dask.dataframe.extensions import (
     register_series_accessor,
 )
 
+from pandera.accessors._schema_registry import get_schema, register_schema
 from pandera.api.pandas.array import SeriesSchema
 from pandera.api.pandas.container import DataFrameSchema
 
@@ -14,15 +15,7 @@ Schemas = Union[DataFrameSchema, SeriesSchema]
 
 
 class PanderaDaskAccessor:
-    """Pandera accessor for dask objects.
-
-    Unlike pandas DataFrames/Series, Dask objects don't support the `.attrs`
-    attribute directly. Instead, we store the schema in the underlying
-    `._meta` object which is a pandas DataFrame/Series.
-    """
-
-    # Key used to store schema in the meta object's attrs
-    _PANDERA_SCHEMA_KEY = "__pandera_schema__"
+    """Pandera accessor for dask objects."""
 
     def __init__(self, dask_obj):
         """Initialize the pandera accessor."""
@@ -34,16 +27,15 @@ class PanderaDaskAccessor:
         raise NotImplementedError
 
     def add_schema(self, schema):
-        """Add a schema to the dask object via its _meta attribute."""
+        """Add a schema to the dask object."""
         self.check_schema_type(schema)
-        # Store schema in the _meta object's attrs (which is a pandas object)
-        self._dask_obj._meta.attrs[self._PANDERA_SCHEMA_KEY] = schema
+        register_schema(self._dask_obj, schema)
         return self._dask_obj
 
     @property
     def schema(self) -> Schemas | None:
-        """Access schema metadata from the _meta object."""
-        return self._dask_obj._meta.attrs.get(self._PANDERA_SCHEMA_KEY)
+        """Access schema metadata."""
+        return get_schema(self._dask_obj)
 
 
 class PanderaDaskDataFrameAccessor(PanderaDaskAccessor):

--- a/pandera/accessors/pandas_accessor.py
+++ b/pandera/accessors/pandas_accessor.py
@@ -1,20 +1,20 @@
 """Register pandas accessor for pandera schema metadata."""
 
-from typing import Optional, Union
+from typing import Union
 
 import pandas as pd
 
+from pandera.accessors._schema_registry import get_schema, register_schema
 from pandera.api.pandas.array import SeriesSchema
 from pandera.api.pandas.container import DataFrameSchema
 
 Schemas = Union[DataFrameSchema, SeriesSchema]
 
+_ATTRS_SCHEMA_KEY = "__pandera_schema__"
+
 
 class PanderaAccessor:
     """Pandera accessor for pandas object."""
-
-    # Key used to store schema in pandas object's attrs
-    _PANDERA_SCHEMA_KEY = "__pandera_schema__"
 
     def __init__(self, pandas_obj):
         """Initialize the pandera accessor."""
@@ -28,18 +28,15 @@ class PanderaAccessor:
     def add_schema(self, schema):
         """Add a schema to the pandas object."""
         self.check_schema_type(schema)
-        # Store schema in the pandas object's attrs for persistence
-        # Some pandas-like objects (e.g., PySpark pandas) don't have attrs
         if hasattr(self._pandas_obj, "attrs"):
-            self._pandas_obj.attrs[self._PANDERA_SCHEMA_KEY] = schema
+            self._pandas_obj.attrs.pop(_ATTRS_SCHEMA_KEY, None)
+        register_schema(self._pandas_obj, schema)
         return self._pandas_obj
 
     @property
     def schema(self) -> Schemas | None:
         """Access schema metadata."""
-        if hasattr(self._pandas_obj, "attrs"):
-            return self._pandas_obj.attrs.get(self._PANDERA_SCHEMA_KEY)
-        return None
+        return get_schema(self._pandas_obj)
 
 
 @pd.api.extensions.register_dataframe_accessor("pandera")

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -231,16 +231,7 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
 
         args = [] if buffer is None else [buffer]
 
-        # Temporarily remove the pandera schema from attrs so that
-        # serialization formats like feather/parquet (which JSON-encode
-        # df.attrs via pyarrow) don't choke on the non-serializable object.
-        _schema_key = "__pandera_schema__"
-        _saved_schema = data.attrs.pop(_schema_key, None)
-        try:
-            out = writer(*args, **(config.to_format_kwargs or {}))  # type: ignore
-        finally:
-            if _saved_schema is not None:
-                data.attrs[_schema_key] = _saved_schema
+        out = writer(*args, **(config.to_format_kwargs or {}))  # type: ignore
         if buffer is None:
             return out
         elif buffer.closed:

--- a/tests/pandas/test_pandas_accessor.py
+++ b/tests/pandas/test_pandas_accessor.py
@@ -1,5 +1,6 @@
 """Unit tests for pandas_accessor module."""
 
+import io
 from typing import Union
 from unittest.mock import patch
 
@@ -74,3 +75,27 @@ def test_dataframe_series_add_schema(
 
             with pytest.raises(BackendNotFoundError):
                 schema2(invalid_data)  # type: ignore
+
+
+def test_validate_does_not_pollute_attrs():
+    """Validation should not add non-serializable objects to df.attrs."""
+    schema = pa.DataFrameSchema(
+        columns={
+            "a": pa.Column(int, pa.Check(lambda x: x > 0)),
+            "b": pa.Column(int, pa.Check(lambda x: x > 0)),
+        }
+    )
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    original_attrs = df.attrs.copy()
+
+    cleaned_df = schema.validate(df)
+
+    assert cleaned_df.attrs == original_attrs
+    assert cleaned_df.pandera.schema == schema
+
+    buf = io.BytesIO()
+    cleaned_df.to_parquet(buf)
+    buf.seek(0)
+    roundtripped = pd.read_parquet(buf)
+    pd.testing.assert_frame_equal(cleaned_df, roundtripped)
+    schema.validate(roundtripped)


### PR DESCRIPTION
Fixes #2240

Improve attribute handling in pandas and dask objects. Add unit test to ensure validation does not alter DataFrame attributes.