### PR TITLE
Bugfix/2213: handle schema errors correctly when strict and ordered are True

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import logging as pylogging
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,55 @@ from sphinx.util import logging
 import pandera
 
 sys.path.insert(0, os.path.abspath("../.."))
+
+
+def _java_specification_major() -> int | None:
+    """Return Java major version, or None if java is missing or unparsable."""
+    try:
+        proc = subprocess.run(
+            ["java", "-XshowSettings:properties", "-version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        err = proc.stderr or ""
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    for line in err.splitlines():
+        line = line.strip()
+        if not line.startswith("java.specification.version"):
+            continue
+        parts = line.split("=", 1)
+        if len(parts) != 2:
+            continue
+        raw = parts[1].strip()
+        try:
+            if raw.startswith("1."):
+                return int(raw.split(".", 1)[1])
+            return int(re.match(r"(\d+)", raw).group(1))
+        except (ValueError, AttributeError):
+            return None
+    return None
+
+
+def _ensure_pyspark_jdk24_jvm_opts() -> None:
+    """Let local Spark start on JDK 24+ (Hadoop UGI / Subject.getSubject).
+
+    See JEP 486. Notebook kernels inherit this process env. No-op on JDK < 24.
+    """
+    flag = "-Djava.security.manager=allow"
+    if flag in os.environ.get("JAVA_TOOL_OPTIONS", ""):
+        return
+    major = _java_specification_major()
+    if major is None or major < 24:
+        return
+    prev = os.environ.get("JAVA_TOOL_OPTIONS", "").strip()
+    os.environ["JAVA_TOOL_OPTIONS"] = (
+        f"{prev} {flag}".strip() if prev else flag
+    )
+
+
+_ensure_pyspark_jdk24_jvm_opts()
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/dataframe_schemas.md
+++ b/docs/source/dataframe_schemas.md
@@ -320,7 +320,9 @@ schema.validate(dataframe).head()
 
 By default, columns that aren’t specified in the schema aren’t checked.
 If you want to check that the DataFrame *only* contains columns in the
-schema, specify `strict=True`:
+schema, specify `strict=True`. Unexpected columns are reported as
+{class}`~pandera.errors.SchemaErrors` (see {attr}`~pandera.errors.SchemaErrors.schema_errors`),
+which may list more than one column when several are not in the schema.
 
 ```{code-cell} python
 import pandas as pd
@@ -335,8 +337,10 @@ df = pd.DataFrame({"column2": [1, 2, 3]})
 
 try:
     schema.validate(df)
-except pa.errors.SchemaError as exc:
-    print(exc)
+except pa.errors.SchemaErrors as exc:
+    # Strict column checks are reported as SchemaErrors (one or more entries)
+    for err in exc.schema_errors:
+        print(err)
 ```
 
 Alternatively, if your DataFrame contains columns that are not in the schema,
@@ -367,7 +371,9 @@ For some applications the order of the columns is important. For example:
 - Machine learning: Many ML libraries will cast a Dataframe to numpy arrays,
   for which order becomes crucial.
 
-To validate the order of the Dataframe columns, specify `ordered=True`:
+To validate the order of the Dataframe columns, specify `ordered=True`.
+Out-of-order columns are reported as {class}`~pandera.errors.SchemaErrors`
+(one entry per schema column that is not in the expected position).
 
 ```{code-cell} python
 import pandas as pd
@@ -380,9 +386,65 @@ df = pd.DataFrame({"b": [1], "a": [1]})
 
 try:
     schema.validate(df)
-except pa.errors.SchemaError as exc:
-    print(exc)
+except pa.errors.SchemaErrors as exc:
+    for err in exc.schema_errors:
+        print(err)
 ```
+
+(strict-and-ordered)=
+
+### Using `strict=True` and `ordered=True` together
+
+When both flags are set, pandera checks **every** column in the dataframe for:
+
+- **Extra columns** (`strict`): columns not defined in the schema.
+- **Column order** (`ordered`): schema columns must appear left-to-right in the
+  same order as in the schema.
+
+If the data has more than one problem (for example, columns out of order *and*
+an unexpected column), validation raises a single {class}`~pandera.errors.SchemaErrors`
+whose {attr}`~pandera.errors.SchemaErrors.schema_errors` list contains all
+relevant issues. Each entry is a {class}`~pandera.errors.SchemaError` with a
+{attr}`~pandera.errors.SchemaError.reason_code` of either
+`SchemaErrorReason.COLUMN_NOT_ORDERED` or
+`SchemaErrorReason.COLUMN_NOT_IN_SCHEMA`.
+
+```{code-cell} python
+import pandas as pd
+import pandera.pandas as pa
+from pandera.errors import SchemaErrorReason
+
+schema = pa.DataFrameSchema(
+    columns={
+        "id": pa.Column(pa.Int64, nullable=False),
+        "name": pa.Column(pa.String, nullable=True),
+    },
+    strict=True,
+    ordered=True,
+)
+
+# Wrong order (name before id) and an extra column
+df = pd.DataFrame(
+    {
+        "name": ["Alice", "Bob"],
+        "id": [1, 2],
+        "extra": ["x", "y"],
+    }
+)
+
+try:
+    schema.validate(df)
+except pa.errors.SchemaErrors as exc:
+    reasons = {e.reason_code for e in exc.schema_errors}
+    assert SchemaErrorReason.COLUMN_NOT_ORDERED in reasons
+    assert SchemaErrorReason.COLUMN_NOT_IN_SCHEMA in reasons
+```
+
+With `lazy=True`, these column checks are still collected into
+{class}`~pandera.errors.SchemaErrors` together with later validation errors
+(checks, dtypes, etc.) when applicable. With the default `lazy=False`, any
+`SchemaErrors` raised during this phase is raised immediately so you see every
+strict/ordered issue at once.
 
 (index)=
 

--- a/docs/source/dataframe_schemas.md
+++ b/docs/source/dataframe_schemas.md
@@ -147,7 +147,7 @@ schema = pa.DataFrameSchema({
 
 try:
     schema.validate(df)
-except pa.errors.SchemaError as exc:
+except (pa.errors.SchemaError, pa.errors.SchemaErrors) as exc:
     print(exc)
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - typing_inspect >= 0.6.0
   - frictionless <= 4.40.8  # v5.* introduces breaking changes
   - pyarrow >= 13 # https://github.com/apache/arrow/pull/35113
+  - pyarrow-hotfix
   - pydantic
 
   # hypotheses extra

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -548,8 +548,8 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 try:
                     next_ordered_col = next(sorted_column_names)
                 except StopIteration:
-                    pass
-                if next_ordered_col != column:
+                    next_ordered_col = None
+                if next_ordered_col is not None and next_ordered_col != column:
                     column_errors.append(
                         SchemaError(
                             schema=schema,

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -521,19 +521,23 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
 
         filter_out_columns = []
         sorted_column_names = iter(column_info.sorted_column_names)
+        column_errors = []
+
         for column in column_info.destuttered_column_names:
             is_schema_col = column in column_info.expanded_column_names
             if schema.strict is True and not is_schema_col:
-                raise SchemaError(
-                    schema=schema,
-                    data=check_obj,
-                    message=(
-                        f"column '{column}' not in {schema.__class__.__name__}"
-                        f" {schema.columns}"
-                    ),
-                    failure_cases=column,
-                    check="column_in_schema",
-                    reason_code=SchemaErrorReason.COLUMN_NOT_IN_SCHEMA,
+                column_errors.append(
+                    SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=(
+                            f"column '{column}' not in {schema.__class__.__name__}"
+                            f" {schema.columns}"
+                        ),
+                        failure_cases=column,
+                        check="column_in_schema",
+                        reason_code=SchemaErrorReason.COLUMN_NOT_IN_SCHEMA,
+                    )
                 )
             if schema.strict == "filter" and not is_schema_col:
                 filter_out_columns.append(column)
@@ -543,14 +547,23 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 except StopIteration:
                     pass
                 if next_ordered_col != column:
-                    raise SchemaError(
-                        schema=schema,
-                        data=check_obj,
-                        message=f"column '{column}' out-of-order",
-                        failure_cases=column,
-                        check="column_ordered",
-                        reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
+                    column_errors.append(
+                        SchemaError(
+                            schema=schema,
+                            data=check_obj,
+                            message=f"column '{column}' out-of-order",
+                            failure_cases=column,
+                            check="column_ordered",
+                            reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
+                        )
                     )
+
+        if column_errors:
+            raise SchemaErrors(
+                schema=schema,
+                schema_errors=column_errors,
+                data=check_obj,
+            )
 
         if schema.strict == "filter":
             if type(check_obj).__module__.startswith("pyspark.pandas"):

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -92,7 +92,10 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                     get_error_category(exc.reason_code), exc.reason_code, exc
                 )
             except SchemaErrors as exc:
-                error_handler.collect_errors(exc.schema_errors)
+                if lazy:
+                    error_handler.collect_errors(exc.schema_errors)
+                else:
+                    raise
 
         # We may have modified columns, for example by
         # add_missing_columns, so regenerate column info

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -554,8 +554,8 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 try:
                     next_ordered_col = next(sorted_column_names)
                 except StopIteration:
-                    pass
-                if next_ordered_col != column:
+                    # Schema column appears again after the ordered run of
+                    # expected columns (e.g. ... a, b, c, a with schema a, b).
                     column_errors.append(
                         SchemaError(
                             schema=schema,
@@ -566,6 +566,18 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                             reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
                         )
                     )
+                else:
+                    if next_ordered_col != column:
+                        column_errors.append(
+                            SchemaError(
+                                schema=schema,
+                                data=check_obj,
+                                message=f"column '{column}' out-of-order",
+                                failure_cases=column,
+                                check="column_ordered",
+                                reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
+                            )
+                        )
 
         if column_errors:
             raise SchemaErrors(

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -102,6 +102,7 @@ def __patched_generic_alias_call(self, *args, **kwargs):
     except (
         TypeError,
         errors.SchemaError,
+        errors.SchemaErrors,
         errors.SchemaInitError,
         errors.SchemaDefinitionError,
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,10 @@ dask = [
     "dask[dataframe]",
     "distributed",
 ]
-ibis = ["ibis-framework >= 9.0.0"]
+ibis = [
+    "ibis-framework >= 9.0.0",
+    "pyarrow-hotfix",
+]
 polars = ["polars >= 0.20.0"]
 all = [
     "hypothesis >= 6.92.7",
@@ -108,6 +111,7 @@ all = [
     "geopandas < 1.1.0",
     "shapely",
     "ibis-framework >= 9.0.0",
+    "pyarrow-hotfix",
     "polars >= 0.20.0",
 ]
 
@@ -142,6 +146,7 @@ testing = [
 ]
 docs = [
     "setuptools",
+    "pyarrow-hotfix",
     "sphinx<9",
     "sphinx-design",
     "sphinx-autodoc-typehints <= 1.14.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyyaml >= 5.1
 typing_inspect >= 0.6.0
 frictionless <= 4.40.8
 pyarrow >= 13
+pyarrow-hotfix
 pydantic
 scipy
 pandas-stubs

--- a/tests/geopandas/test_geopandas.py
+++ b/tests/geopandas/test_geopandas.py
@@ -285,7 +285,9 @@ def test_schema_from_dataframe(data, invalid: bool):
 
     # create a geodataframe that's validated on object initialization
     if invalid:
-        with pytest.raises(pa.errors.SchemaError):
+        with pytest.raises(
+            (pa.errors.SchemaError, pa.errors.SchemaErrors)
+        ):
             GeoDataFrame[Schema](data)
         return
 

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1262,7 +1262,7 @@ def test_from_yaml_load_required_fields():
 @pytest.mark.parametrize(
     "is_ordered,test_data,expected",
     [
-        (True, {"b": [1], "a": [1]}, pandera.errors.SchemaError),
+        (True, {"b": [1], "a": [1]}, pandera.errors.SchemaErrors),
         (True, {"a": [1], "b": [1]}, pd.DataFrame(data={"a": [1], "b": [1]})),
         (False, {"b": [1], "a": [1]}, pd.DataFrame(data={"b": [1], "a": [1]})),
         (False, {"a": [1], "b": [1]}, pd.DataFrame(data={"a": [1], "b": [1]})),
@@ -1563,7 +1563,7 @@ def test_to_yaml_bugfix_warn_unregistered_global_checks():
 @pytest.mark.parametrize(
     "is_ordered,test_data,expected",
     [
-        (True, {"b": [1], "a": [1]}, pandera.errors.SchemaError),
+        (True, {"b": [1], "a": [1]}, pandera.errors.SchemaErrors),
         (True, {"a": [1], "b": [1]}, pd.DataFrame(data={"a": [1], "b": [1]})),
         (False, {"b": [1], "a": [1]}, pd.DataFrame(data={"b": [1], "a": [1]})),
         (False, {"a": [1], "b": [1]}, pd.DataFrame(data={"a": [1], "b": [1]})),

--- a/tests/modin/test_schemas_on_modin.py
+++ b/tests/modin/test_schemas_on_modin.py
@@ -255,8 +255,13 @@ def test_dtype_coercion(from_dtype, to_dtype, data):
         try:
             result = to_schema(sample)
             assert result["field"].dtype == to_dtype
-        except pa.errors.SchemaError as err:
-            for x in err.failure_cases.failure_case:
+        except (pa.errors.SchemaError, pa.errors.SchemaErrors) as err:
+            if isinstance(err, pa.errors.SchemaErrors):
+                failure_series = err.failure_cases["failure_case"]
+            else:
+                failure_series = err.failure_cases.failure_case
+            for x in failure_series:
+                x = getattr(x, "item", lambda: x)()
                 with pytest.raises(ValueError):
                     to_dtype(x)
         return
@@ -276,7 +281,8 @@ def test_strict_schema():
     non_strict_schema(strict_df)
 
     with pytest.raises(
-        pa.errors.SchemaError, match="column 'foo' not in DataFrameSchema"
+        (pa.errors.SchemaError, pa.errors.SchemaErrors),
+        match="column 'foo' not in DataFrameSchema",
     ):
         strict_schema(non_strict_df)
 

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -927,11 +927,11 @@ def test_check_types_method_args() -> None:
         out, instance.regular_method(df1=in1, df2=in2)
     )
 
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.regular_method(in2, in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.regular_method(in2, df2=in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.regular_method(df1=in2, df2=in1)  # type: ignore
 
     pd.testing.assert_frame_equal(out, SomeClass.class_method(in1, in2))
@@ -940,11 +940,11 @@ def test_check_types_method_args() -> None:
         out, SomeClass.class_method(df1=in1, df2=in2)
     )
 
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.class_method(in2, in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.class_method(in2, df2=in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.class_method(df1=in2, df2=in1)  # type: ignore
 
     pd.testing.assert_frame_equal(out, instance.static_method(in1, in2))
@@ -955,11 +955,11 @@ def test_check_types_method_args() -> None:
         out, instance.static_method(df1=in1, df2=in2)
     )
 
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.static_method(in2, in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.static_method(in2, df2=in1)  # type: ignore
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         instance.static_method(df1=in2, df2=in1)  # type: ignore
 
 
@@ -1801,7 +1801,7 @@ def test_coroutines() -> None:
             res = await coro(good_df)
             pd.testing.assert_frame_equal(good_df, res)
 
-            with pytest.raises(errors.SchemaError):
+            with pytest.raises(errors.SchemaErrors):
                 await coro(bad_df)
 
     asyncio.get_event_loop().run_until_complete(check_coros())

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -656,8 +656,14 @@ class TestArrowStringSerializationRoundTrip:
         from pandera.pandas import DataFrameModel, DataFrameSchema
         from pandera.typing import Series as TypedSeries
 
+        # pandas >= 2.3 adds na_value; older versions only accept storage.
+        if len(inspect.signature(pd.StringDtype).parameters) >= 2:
+            str_dtype_ann = Annotated[pd.StringDtype, "pyarrow", pd.NA]
+        else:
+            str_dtype_ann = Annotated[pd.StringDtype, "pyarrow"]
+
         class PandasArrowModel(DataFrameModel):
-            col: TypedSeries[Annotated[pd.StringDtype, "pyarrow", pd.NA]]
+            col: TypedSeries[str_dtype_ann]
 
         original = PandasArrowModel.to_schema()
         assert isinstance(original.columns["col"].dtype, pandas_engine.STRING)

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -372,7 +372,9 @@ def test_dt_time_zone_agnostic(examples, tz, coerce, expected_output, raises):
     data = pd.DataFrame({"datetime_column": examples})
 
     if raises:
-        with pytest.raises((SchemaError, errors.ParserError)):
+        with pytest.raises(
+            (SchemaError, errors.SchemaErrors, errors.ParserError)
+        ):
             SimpleSchema.validate(data)
     else:
         validated_df = SimpleSchema.validate(data)

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -312,8 +312,8 @@ def test_pydantic_model_empty_dataframe():
         PydanticSchema.validate(empty_df)
 
     invalid_column_names = pd.DataFrame(columns=columns[:1])
-    with pytest.raises(
-        pa.errors.SchemaError,
-        match=".+Missing columns in .+data_container.+ ['y', 'z'].+",
-    ):
+    with pytest.raises(pa.errors.SchemaErrors) as exc_info:
         PydanticSchema.validate(invalid_column_names)
+    err_msg = exc_info.value.schema_errors[0].args[0]
+    assert "Missing columns" in err_msg
+    assert "y" in err_msg and "z" in err_msg

--- a/tests/pandas/test_pydantic_dtype.py
+++ b/tests/pandas/test_pydantic_dtype.py
@@ -66,9 +66,9 @@ def test_pydantic_model():
 
     try:
         func(invalid_df)
-    except pa.errors.SchemaError as exc:
+    except pa.errors.SchemaErrors as exc:
         pd.testing.assert_frame_equal(
-            exc.failure_cases, expected_failure_cases
+            exc.schema_errors[0].failure_cases, expected_failure_cases
         )
 
 

--- a/tests/pandas/test_schema_components.py
+++ b/tests/pandas/test_schema_components.py
@@ -709,7 +709,7 @@ def test_column_regex_strict() -> None:
 
     # adding an extra column in the dataframe should cause error
     data = data.assign(bar=[1, 2, 3])
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         schema.validate(data)
 
     # adding an extra regex column to the schema should pass the strictness

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -120,11 +120,12 @@ def test_dataframe_single_element_coerce() -> None:
     """Test that coercing a single element dataframe works correctly."""
     schema = DataFrameSchema({"x": Column(int, coerce=True)})
     assert isinstance(schema(pd.DataFrame({"x": [1]})), pd.DataFrame)
-    with pytest.raises(
-        errors.SchemaError,
-        match="Error while coercing 'x' to type int64",
-    ):
+    with pytest.raises(errors.SchemaErrors) as exc_info:
         schema(pd.DataFrame({"x": [None]}))
+    assert any(
+        "Error while coercing 'x' to type int64" in str(e.args[0])
+        for e in exc_info.value.schema_errors
+    )
 
 
 def test_dataframe_empty_coerce() -> None:
@@ -158,7 +159,7 @@ def test_dataframe_schema_strict() -> None:
     df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
 
     assert isinstance(schema.validate(df.loc[:, ["a", "b"]]), pd.DataFrame)
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         schema.validate(df)
 
     schema.strict = "filter"
@@ -180,6 +181,30 @@ def test_dataframe_schema_strict() -> None:
         schema.validate(df.loc[:, ["a", "c"]])
 
 
+def test_dataframe_schema_strict_and_ordered_raises_both_errors() -> None:
+    """Regression test for #2213: strict=True and ordered=True raise both
+    COLUMN_NOT_ORDERED and COLUMN_NOT_IN_SCHEMA when dataframe has both."""
+    schema = DataFrameSchema(
+        columns={
+            "id": Column(int, nullable=False),
+            "name": Column(str, nullable=True),
+        },
+        strict=True,
+        ordered=True,
+    )
+    # Wrong order (name before id) and extra column
+    df = pd.DataFrame({
+        "name": ["Alice", "Bob", "Charlie"],
+        "id": [1, 2, 3],
+        "extra_column": ["extra1", "extra2", "extra3"],
+    })
+    with pytest.raises(errors.SchemaErrors) as exc_info:
+        schema.validate(df)
+    reason_codes = {e.reason_code for e in exc_info.value.schema_errors}
+    assert errors.SchemaErrorReason.COLUMN_NOT_ORDERED in reason_codes
+    assert errors.SchemaErrorReason.COLUMN_NOT_IN_SCHEMA in reason_codes
+
+
 def test_dataframe_schema_strict_regex() -> None:
     """Test that strict dataframe schema checks for regex matches."""
     schema = DataFrameSchema(
@@ -190,9 +215,9 @@ def test_dataframe_schema_strict_regex() -> None:
 
     assert isinstance(schema.validate(df), pd.DataFrame)
 
-    # Raise a SchemaError if schema is strict and a regex pattern yields
+    # Raise SchemaErrors if schema is strict and a regex pattern yields
     # no matches
-    with pytest.raises(errors.SchemaError):
+    with pytest.raises(errors.SchemaErrors):
         schema.validate(
             pd.DataFrame({f"bar_{i}": range(10) for i in range(5)})
         )
@@ -448,7 +473,7 @@ def test_add_missing_columns_order():
         data=[[1, 2, 3]], columns=["a", "missing", "c"]
     )
     with pytest.raises(
-        errors.SchemaError,
+        errors.SchemaErrors,
         match="column 'missing' not in DataFrameSchema",
     ):
         schema.validate(frame_unknown_col)
@@ -786,12 +811,11 @@ def test_coerce_dtype_in_dataframe():
     # make sure that correct error is raised when null values are present
     # in a float column that's coerced to an int
     schema = DataFrameSchema({"column4": Column(int, coerce=True)})
-    with pytest.raises(
-        errors.SchemaError,
-        match=r"^Error while coercing .+ to type u{0,1}int[0-9]{1,2}: "
-        r"Could not coerce .+ data_container into type",
-    ):
+    with pytest.raises(errors.SchemaErrors) as exc_info:
         schema.validate(df)
+    assert len(exc_info.value.schema_errors) == 1
+    assert "Error while coercing" in str(exc_info.value.schema_errors[0].args[0])
+    assert "Could not coerce" in str(exc_info.value.schema_errors[0].args[0])
 
 
 def test_no_dtype_dataframe():
@@ -2063,7 +2087,7 @@ def test_series_schema_dtype(dtype):
             pd.DataFrame(
                 [[1, 2, 3], list("xyz"), [7, 8, 9]], columns=["a", "a", "b"]
             ),
-            errors.SchemaError,
+            (errors.SchemaError, errors.SchemaErrors),
         ],
     ],
 )

--- a/tests/pyspark/test_schemas_on_pyspark_pandas.py
+++ b/tests/pyspark/test_schemas_on_pyspark_pandas.py
@@ -458,10 +458,10 @@ def test_dtype_coercion(from_dtype, to_dtype, data):
 
     # strings that can't be interpreted as numbers are converted to NA
     if from_dtype is str and to_dtype in {int, float}:
-        # first check if sample contains NAs
+        # first check if sample contains NAs after pandas-style astype
         if sample.astype(to_dtype).isna().any().item():
             with pytest.raises(
-                pa.errors.SchemaError, match="non-nullable series"
+                (pa.errors.SchemaError, pa.errors.SchemaErrors)
             ):
                 to_schema(sample)
         return
@@ -511,7 +511,8 @@ def test_strict_schema():
     non_strict_schema(strict_df)
 
     with pytest.raises(
-        pa.errors.SchemaError, match="column 'foo' not in DataFrameSchema"
+        (pa.errors.SchemaError, pa.errors.SchemaErrors),
+        match="column 'foo' not in DataFrameSchema",
     ):
         strict_schema(non_strict_df)
 
@@ -710,7 +711,7 @@ def test_init_pyspark_pandas_dataframe():
 )
 def test_init_pyspark_dataframe_errors(invalid_data):
     """Test errors from initializing a pandas.typing.DataFrame with Schema."""
-    with pytest.raises(pa.errors.SchemaError):
+    with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
         DataFrame[InitSchema](invalid_data)
 
 


### PR DESCRIPTION
Fix #2213

This pull request primarily improves how column validation errors are reported in strict and ordered DataFrame schemas. Now, when multiple column-related issues occur (such as unexpected columns or columns out of order), they are collected and raised together as a `SchemaErrors` exception, making it easier to see all issues at once. The documentation and tests have been updated to reflect this improved error reporting. Additionally, the environment configuration is updated to include a `pyarrow-hotfix` dependency.

**Key changes:**

### Error handling and reporting improvements

* Column validation errors (strict/ordered) are now collected and raised as `SchemaErrors` (a collection of `SchemaError`), rather than failing fast on the first error. This allows users to see all column-related issues in one go. [[1]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0R101-R104) [[2]](diffhunk://#diff-69c91daba129d5a72275fe6bc1bed9f60b69bb4a46e61fc5e4ab67c8c027bbd0L554-R569)
* Updated all code, tests, and documentation to expect and handle `SchemaErrors` where appropriate, replacing previous usage of `SchemaError` for multi-column issues. [[1]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L150-R150) [[2]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L338-R343) [[3]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L370-R376) [[4]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L383-R448) [[5]](diffhunk://#diff-bc1641da1461c0d334ff9f81bab40ebeb1816e80e6ddf28202cf27c0bdcc60feL288-R290) [[6]](diffhunk://#diff-e0ea449fcc3840bf5f7746c0f6c351fe29d04060e41198ccdaac0d1d73bc403fL1265-R1265) [[7]](diffhunk://#diff-e0ea449fcc3840bf5f7746c0f6c351fe29d04060e41198ccdaac0d1d73bc403fL1566-R1566) [[8]](diffhunk://#diff-57ac62d9271759bdcbbb0e13d5a37b6f15b6f09f9fb46540db2d77d075eba640L258-R264) [[9]](diffhunk://#diff-57ac62d9271759bdcbbb0e13d5a37b6f15b6f09f9fb46540db2d77d075eba640L279-R285) [[10]](diffhunk://#diff-8f788700ba59e9fa57912f0c84a1bf8ea117260b1c4a9b2fff0eb839ae9dd518L930-R934) [[11]](diffhunk://#diff-8f788700ba59e9fa57912f0c84a1bf8ea117260b1c4a9b2fff0eb839ae9dd518L943-R947) [[12]](diffhunk://#diff-8f788700ba59e9fa57912f0c84a1bf8ea117260b1c4a9b2fff0eb839ae9dd518L958-R962) [[13]](diffhunk://#diff-8f788700ba59e9fa57912f0c84a1bf8ea117260b1c4a9b2fff0eb839ae9dd518L1804-R1804) [[14]](diffhunk://#diff-4a349f28ef78429bb1129800461d9d4b54aff201eb6de3eda873646cd2fd1e30L375-R377) [[15]](diffhunk://#diff-b690f7c55b658dc8529fb96e383af600fc1746addf4c516b7dc5366b27c4daddL315-R319) [[16]](diffhunk://#diff-f16041aa9633d0fe3648104f8e220cdc4a3ee7e305fd6c608fd179c45d8e9701L69-R71) [[17]](diffhunk://#diff-522bd082ab6ee4e7b9c917ac886fb7f875c4d6dee242b6ad0f5dba1401a5f8e6L712-R712) [[18]](diffhunk://#diff-64734cfe27e63226a05676638b2c878233a6e8d0ebe5c36b2f95f26b05060743R105)

### Documentation updates

* Expanded documentation for strict and ordered column checks, including how multiple issues are reported via `SchemaErrors`, and added examples for combined `strict=True` and `ordered=True` validation. [[1]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L323-R325) [[2]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L370-R376) [[3]](diffhunk://#diff-48045b75647dcc929832664c8b4b8213d864e1f0073a8a73e7f50aa848e741b1L383-R448)

### Dependency and environment updates

* Added `pyarrow-hotfix` to `environment.yml`, `pyproject.toml` (for `ibis`, `all`, `docs` extras), to address compatibility issues. [[1]](diffhunk://#diff-9efd195f4e9bfb79ccd456a1d8370fafcc4bcb0b00ea3799222667d2ae818533R17) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L92-R95) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R114) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R149)

### Miscellaneous

* Improved compatibility with pandas 2.3+ in tests by dynamically handling `pd.StringDtype` signature.
* Added a small helper in Sphinx config to ensure Spark can start on JDK 24+ by setting the appropriate JVM option. [[1]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R19) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R32-R80)

These changes collectively improve the user experience by providing clearer, more comprehensive error messages during DataFrame schema validation, and ensure compatibility with recent dependencies.