### PR TITLE
Included pyspark str_matches builtin check

### DIFF
--- a/pandera/backends/pyspark/builtin_checks.py
+++ b/pandera/backends/pyspark/builtin_checks.py
@@ -1,7 +1,8 @@
 """Built-in checks for PySpark."""
 
+import re
 from collections.abc import Iterable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 import pyspark.sql.types as pst
 from pyspark.sql.functions import col
@@ -266,6 +267,33 @@ def notin(
         data.dataframe.filter(
             col(data.column_name).isin(list(forbidden_values))
         )
+        .limit(1)
+        .count()
+        == 0
+    )
+
+
+@register_builtin_check(
+    error="str_matches('{pattern}')",
+)
+@register_input_datatypes(acceptable_datatypes=convert_to_list(STRING_TYPE))
+def str_matches(
+    data: PysparkDataframeColumnObject,
+    pattern: Union[str, re.Pattern],
+) -> bool:
+    """Ensure that all values start with a match of a regular expression pattern.
+
+    Remember it can be a compute intensive check on large dataset. So, use it with caution.
+
+    :param data: NamedTuple PysparkDataframeColumnObject contains the dataframe and column name for the check. The key
+        to access the dataframe is "dataframe", and the key to access the column name is "column_name".
+    :param pattern: Regular expression pattern to use for matching.
+    """
+    pattern = pattern.pattern if isinstance(pattern, re.Pattern) else pattern
+    if not pattern.startswith("^"):
+        pattern = f"^{pattern}"
+    return (
+        data.dataframe.filter(~col(data.column_name).rlike(pattern))
         .limit(1)
         .count()
         == 0

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -1435,6 +1435,98 @@ class TestStringType(BaseClass):
             spark, check_func, pass_data, fail_data, StringType(), check_value
         )
 
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_str_matches_check(self, spark_session, request) -> None:
+        """Test the Check to see if values match a regex pattern from the start"""
+        spark = request.getfixturevalue(spark_session)
+        check_func = pa.Check.str_matches
+        # Pattern to match strings starting with uppercase letter followed by lowercase letters
+        check_value = r"^[A-Z][a-z]+"
+
+        pass_data = [("Bal", "Bread"), ("Bal", "Butter")]
+        fail_data = [("Bal", "bread"), ("Bal", "Butter")]  # "bread" doesn't start with uppercase
+        BaseClass.check_function(
+            spark, check_func, pass_data, fail_data, StringType(), check_value
+        )
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_str_matches_check_without_caret(self, spark_session, request) -> None:
+        """Test str_matches automatically prepends ^ if not present"""
+        spark = request.getfixturevalue(spark_session)
+        check_func = pa.Check.str_matches
+        # Pattern without ^ - should be automatically added
+        check_value = r"[0-9]{3}"  # Match 3 digits at the start
+
+        pass_data = [("Bal", "123abc"), ("Bal", "456def")]
+        fail_data = [("Bal", "abc123"), ("Bal", "456def")]  # "abc123" doesn't start with digits
+        BaseClass.check_function(
+            spark, check_func, pass_data, fail_data, StringType(), check_value
+        )
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_str_matches_check_with_caret(self, spark_session, request) -> None:
+        """Test str_matches works correctly when ^ is already present"""
+        spark = request.getfixturevalue(spark_session)
+        check_func = pa.Check.str_matches
+        # Pattern with ^ already present
+        check_value = r"^test_"
+
+        pass_data = [("Bal", "test_123"), ("Bal", "test_abc")]
+        fail_data = [("Bal", "Test_123"), ("Bal", "test_abc")]  # "Test_123" has uppercase T
+        BaseClass.check_function(
+            spark, check_func, pass_data, fail_data, StringType(), check_value
+        )
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_str_matches_email_pattern(self, spark_session, request) -> None:
+        """Test str_matches with an email-like regex pattern"""
+        spark = request.getfixturevalue(spark_session)
+        check_func = pa.Check.str_matches
+        # Email pattern
+        check_value = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+
+        pass_data = [("Bal", "test@example.com"), ("Bal", "user.name@domain.org")]
+        fail_data = [("Bal", "invalid-email"), ("Bal", "test@example.com")]  # "invalid-email" is not an email
+        BaseClass.check_function(
+            spark, check_func, pass_data, fail_data, StringType(), check_value
+        )
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_str_matches_with_compiled_pattern(self, spark_session, request) -> None:
+        """Test str_matches with a pre-compiled regex pattern"""
+        import re
+
+        spark = request.getfixturevalue(spark_session)
+        # Using compiled pattern
+        check_value = re.compile(r"^[A-Z]{2,3}[0-9]+")
+
+        schema = DataFrameSchema(
+            {
+                "product": Column(StringType()),
+                "code": Column(StringType(), pa.Check.str_matches(check_value)),
+            }
+        )
+        spark_schema = StructType(
+            [
+                StructField("product", StringType(), False),
+                StructField("code", StringType(), False),
+            ],
+        )
+
+        # Pass case: strings starting with 2-3 uppercase letters followed by digits
+        pass_data = [("foo", "AB123"), ("bar", "XYZ99")]
+        df = spark.createDataFrame(data=pass_data, schema=spark_schema)
+        df_out = schema.validate(df)
+        assert not df_out.pandera.errors
+
+        # Fail case: "ab123" starts with lowercase
+        fail_data = [("foo", "ab123"), ("bar", "XYZ99")]
+        with pytest.raises(PysparkSchemaError):
+            df_fail = spark.createDataFrame(data=fail_data, schema=spark_schema)
+            df_out = schema.validate(df_fail)
+            if df_out.pandera.errors:
+                raise PysparkSchemaError
+
 
 class TestInRangeCheck(BaseClass):
     """This class is used to test the value in range check"""


### PR DESCRIPTION
I have included the built in check for pyspark which will resolve the issue "KeyError(\"<class 'pandera.api.pyspark.types.PysparkDataframeColumnObject'>\")" as faced by users when trying to validate column using regex match. Included test cases for the above changes.

Fixes: #2181 