### PR TITLE
Fix pandas typing empty-list constructor inference (#2247)

### DIFF
--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -125,6 +125,9 @@ class DataFrameBase(Generic[T]):
 
     default_dtype: type | None = None
 
+    def _before_schema_validate(self, schema):
+        return self
+
     def __setattr__(self, name: str, value: Any) -> None:
         object.__setattr__(self, name, value)
         if name == "__orig_class__":
@@ -148,7 +151,8 @@ class DataFrameBase(Generic[T]):
                 or pandera_accessor.schema is None
                 or pandera_accessor.schema != schema
             ):
-                self.__dict__.update(schema.validate(self).__dict__)
+                check_obj = self._before_schema_validate(schema)
+                self.__dict__.update(schema.validate(check_obj).__dict__)
                 if pandera_accessor is None:
                     pandera_accessor = getattr(self, "pandera")
                 pandera_accessor.add_schema(schema)

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -160,6 +160,20 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         _type_check(item, "Parameters to generic types must be types.")
         return _GenericAlias(cls, item)
 
+    def _before_schema_validate(self, schema):
+        if self.empty:
+            dtype_map = {}
+            for column_name, dtype in schema.dtypes.items():
+                if (
+                    dtype is not None
+                    and column_name in self.columns
+                    and self[column_name].dtype == np.dtype("float64")
+                ):
+                    dtype_map[column_name] = dtype.type
+            if dtype_map:
+                return self.astype(dtype_map)
+        return self
+
     @classmethod
     def from_format(cls, obj: Any, config) -> pd.DataFrame:
         """

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -482,12 +482,23 @@ class InitSchema(pa.DataFrameModel):
     index: Index[int]
 
 
+class EmptyBoolSchema(pa.DataFrameModel):
+    blah_not_foo: Series[bool]
+
+
 def test_init_pandas_dataframe():
     """Test initialization of pandas.typing.DataFrame with Schema."""
     assert isinstance(
         DataFrame[InitSchema]({"col1": [1], "col2": [1.0], "col3": ["1"]}),
         DataFrame,
     )
+
+
+def test_init_pandas_dataframe_empty_dict_data():
+    """Ensure empty list inputs don't fail due to pandas float64 inference."""
+    data = DataFrame[EmptyBoolSchema]({"blah_not_foo": []})
+
+    assert isinstance(data, DataFrame)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description:
- fix(python): Corrects DataFrame typing constructor handling of empty-list dict inputs.
- I noticed that pandas infers float64 for empty-list columns, which caused schema validation to fail for typed columns.
- This PR addresses it by adding a minimal pre-validation hook and a pandas-specific dtype alignment step for empty inferred float64 columns before schema validation.
- Closes #2247.

### Checklist:
- [x] I have reviewed all changes in this PR myself.
- [x] I have added a relevant test case for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --all-files.