### PR TITLE
test pandas model optional union with typing alias (resolves issue: #2211)

### DIFF
--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -18,6 +18,7 @@ import pandera.pandas as pa
 from pandera.api.base.model import MetaModel
 from pandera.errors import SchemaError, SchemaInitError
 from pandera.typing import DataFrame, Index, Series, String
+from pandera.typing import pandas as pandas_typing
 
 
 def test_idempotent_magics() -> None:
@@ -200,6 +201,18 @@ def test_optional_column() -> None:
     assert not schema.columns["b"].required
     assert not schema.columns["c"].required
     assert not schema.columns["d"].required
+
+
+def test_optional_column_with_typing_module_alias() -> None:
+    """Test optional column annotations with pandera.typing.pandas alias."""
+
+    class Schema(pa.DataFrameModel):
+        size: pandas_typing.Series[int]
+        label: pandas_typing.Series[str]
+        note: pandas_typing.Series[str] | None
+
+    schema = Schema.to_schema()
+    assert not schema.columns["note"].required
 
 
 def test_optional_index() -> None:


### PR DESCRIPTION
### Description:
- test(python): Adds regression coverage for DataFrameModel optional column annotations using the pandera.typing.pandas module alias.
- I noticed that issue #2211 requests support for PEP 604 union annotations to avoid Optional[...] style and UP007 lint conflicts.
- This PR addresses it by adding an exact regression test for the issue pattern so the behavior is explicitly verified and protected.
- Closes #2211.

### Checklist:
- [x] I have reviewed all changes in this PR myself.
- [x] I have added a relevant test case for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files tests/pandas/test_model.py.