### PR TITLE
fix io serialization for custom check errors (#2143)

### DIFF
--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -158,6 +158,24 @@ def get_series_schema_statistics(series_schema):
 
 def parse_checks(checks) -> Union[list[dict[str, Any]], None]:
     """Convert Check object to check statistics including options."""
+
+    def _has_custom_error(check: Check) -> bool:
+        """Determine whether a check has a user-defined error message."""
+        if check.error is None:
+            return False
+
+        if check.name is None or not Check.is_builtin_check(check.name):
+            return True
+
+        try:
+            default_check = getattr(Check, check.name)(
+                **(check.statistics or {})
+            )
+        except (AttributeError, TypeError, ValueError):
+            return True
+
+        return check.error != default_check.error
+
     check_statistics = []
 
     for check in checks:
@@ -179,6 +197,8 @@ def parse_checks(checks) -> Union[list[dict[str, Any]], None]:
             "n_failure_cases": check.n_failure_cases,
             "ignore_na": check.ignore_na,
         }
+        if _has_custom_error(check):
+            check_options["error"] = check.error
 
         # Filter out None values from options
         check_options = {

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1401,6 +1401,88 @@ def test_io_json(index):
         assert schema_from_json == schema
 
 
+def test_check_custom_error_json_serialization_roundtrip():
+    """Test that custom check errors are serialized and deserialized via JSON."""
+    import json
+
+    schema = pandera.DataFrameSchema(
+        {
+            "default_error": pandera.Column(
+                pandera.Int,
+                checks=[pandera.Check.greater_than(10)],
+            ),
+            "custom_error": pandera.Column(
+                pandera.Int,
+                checks=[
+                    pandera.Check.greater_than(
+                        10,
+                        error="column must be greater than 10",
+                    )
+                ],
+            ),
+        }
+    )
+
+    schema_dict = json.loads(schema.to_json())
+    default_options = schema_dict["columns"]["default_error"]["checks"][0][
+        "options"
+    ]
+    custom_options = schema_dict["columns"]["custom_error"]["checks"][0][
+        "options"
+    ]
+
+    assert "error" not in default_options
+    assert custom_options["error"] == "column must be greater than 10"
+
+    restored = io.from_json(json.dumps(schema_dict))
+    restored_checks = restored.columns["custom_error"].checks
+    assert restored_checks is not None
+    assert restored_checks[0].error == "column must be greater than 10"
+
+
+@pytest.mark.skipif(
+    SKIP_YAML_TESTS,
+    reason="pyyaml >= 5.1.0 required",
+)
+def test_check_custom_error_yaml_serialization_roundtrip():
+    """Test that custom check errors are serialized and deserialized via YAML."""
+    schema = pandera.DataFrameSchema(
+        {
+            "default_error": pandera.Column(
+                pandera.Int,
+                checks=[pandera.Check.greater_than(10)],
+            ),
+            "custom_error": pandera.Column(
+                pandera.Int,
+                checks=[
+                    pandera.Check.greater_than(
+                        10,
+                        error="column must be greater than 10",
+                    )
+                ],
+            ),
+        }
+    )
+
+    yaml_str = schema.to_yaml()
+    schema_dict = yaml.safe_load(yaml_str)
+
+    default_options = schema_dict["columns"]["default_error"]["checks"][0][
+        "options"
+    ]
+    custom_options = schema_dict["columns"]["custom_error"]["checks"][0][
+        "options"
+    ]
+
+    assert "error" not in default_options
+    assert custom_options["error"] == "column must be greater than 10"
+
+    restored = io.from_yaml(yaml_str)
+    restored_checks = restored.columns["custom_error"].checks
+    assert restored_checks is not None
+    assert restored_checks[0].error == "column must be greater than 10"
+
+
 @pytest.mark.skipif(
     platform.system() == "Windows",
     reason="skipping due to issues with opening file names for temp files.",

--- a/tests/pandas/test_schema_statistics.py
+++ b/tests/pandas/test_schema_statistics.py
@@ -815,3 +815,42 @@ def test_parse_checks_and_statistics_no_param(extra_registered_checks):
             sorted(check_list, key=lambda x: x.name),
         )
     )
+
+
+def test_parse_checks_custom_error_for_registered_custom_check(
+    extra_registered_checks,
+):
+    """Ensure custom check errors are serialized for registered checks."""
+    checks = [pa.Check.no_param_check(error="custom check error")]
+    expectation = [
+        {
+            "options": {
+                "check_name": "no_param_check",
+                "ignore_na": True,
+                "raise_warning": False,
+                "error": "custom check error",
+            }
+        }
+    ]
+
+    assert schema_statistics.parse_checks(checks) == expectation
+
+
+def test_parse_checks_invalid_builtin_stats_keeps_custom_error():
+    """Ensure invalid built-in stats do not drop custom error messages."""
+    check = pa.Check.greater_than(1, error="custom gt error")
+    check.statistics = {"bad_key": 1}
+
+    expectation = [
+        {
+            "bad_key": 1,
+            "options": {
+                "check_name": "greater_than",
+                "ignore_na": True,
+                "raise_warning": False,
+                "error": "custom gt error",
+            },
+        }
+    ]
+
+    assert schema_statistics.parse_checks([check]) == expectation


### PR DESCRIPTION
## Summary:
- include custom check error messages in serialized check options for JSON/YAML
- keep default built-in check errors omitted to avoid noisy schema output
- add regression tests covering JSON and YAML round-trip behavior

## Testing:
- pytest tests/io/test_pandas_io.py::test_check_custom_error_json_serialization_roundtrip -q
- pytest tests/io/test_pandas_io.py::test_check_custom_error_yaml_serialization_roundtrip -q
- pytest tests/io/test_pandas_io.py::test_to_yaml -q
- pytest tests/io/test_pandas_io.py::test_io_json[single] -q

## Checklist:
- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL.

Applied a fix for: #2143 