### PR TITLE
Fix pyspark.pandas coerce+nullable failure case reporting

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -222,7 +222,55 @@ class ArraySchemaBackend(PandasSchemaBackend):
             return check_obj
 
         try:
-            return schema.dtype.try_coerce(check_obj)
+            coerced = schema.dtype.try_coerce(check_obj)
+
+            # pyspark.pandas can coerce invalid values to null without
+            # raising, which masks dtype errors when nullable=True.
+            if type(check_obj).__module__.startswith("pyspark.pandas"):
+                try:
+                    introduced_na = coerced.isna() & check_obj.notna()
+                    if introduced_na.any():
+                        failure_cases = reshape_failure_cases(
+                            check_obj[introduced_na], ignore_na=False
+                        )
+                        raise SchemaError(
+                            schema=schema,
+                            data=check_obj,
+                            message=(
+                                f"Error while coercing '{schema.name}' to type "
+                                f"{schema.dtype}: coercion introduced null values"
+                            ),
+                            failure_cases=failure_cases,
+                            check=f"coerce_dtype('{schema.dtype}')",
+                            reason_code=SchemaErrorReason.DATATYPE_COERCION,
+                        )
+                except SchemaError:
+                    raise
+                except Exception as exc:
+                    from pandera.engines import utils as engine_utils
+
+                    try:
+                        failure_cases = (
+                            engine_utils.numpy_pandas_coerce_failure_cases(
+                                check_obj, schema.dtype
+                            )
+                        )
+                    except Exception:
+                        failure_cases = None
+
+                    raise SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=(
+                            f"Error while coercing '{schema.name}' to type "
+                            f"{schema.dtype}: {exc}"
+                        ),
+                        failure_cases=failure_cases,
+                        check=f"coerce_dtype('{schema.dtype}')",
+                        reason_code=SchemaErrorReason.DATATYPE_COERCION,
+                    ) from exc
+
+            return coerced
         except ParserError as exc:
             raise SchemaError(
                 schema=schema,

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -6,16 +6,19 @@ import copy
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from functools import partial
+from types import SimpleNamespace
 from typing import Any, Union
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from pandera.backends.pandas.array import ArraySchemaBackend
 from pandera.api.pandas.array import ArraySchema
 from pandera.dtypes import UniqueSettings
 from pandera.engines.pandas_engine import Engine
 from pandera.engines.utils import pandas_version
+from pandera.errors import SchemaErrorReason
 from pandera.pandas import (
     Category,
     Check,
@@ -628,6 +631,138 @@ def test_series_schema() -> None:
         match="Error while coercing",
     ):
         SeriesSchema(float, coerce=True).validate(pd.Series(list("abcdefg")))
+
+
+class _FakePysparkSeries(pd.Series):
+    __module__ = "pyspark.pandas.series"
+
+    @property
+    def _constructor(self):
+        return _FakePysparkSeries
+
+
+class _DummyDtype:
+    def __init__(self, coerced):
+        self._coerced = coerced
+
+    def try_coerce(self, _check_obj):
+        return self._coerced
+
+    def __str__(self) -> str:
+        return "float64"
+
+
+class _BrokenMask:
+    def __and__(self, _other):
+        return self
+
+    def any(self):
+        raise RuntimeError("boom")
+
+
+class _CoercedWithBrokenMask:
+    def isna(self):
+        return _BrokenMask()
+
+
+def test_array_backend_coerce_detects_introduced_nulls() -> None:
+    """Raised error should include introduced-null failure cases."""
+
+    backend = ArraySchemaBackend()
+    check_obj = _FakePysparkSeries(["1.0", "bad"], name="distance")
+    coerced = _FakePysparkSeries([1.0, pd.NA], name="distance")
+    schema = SimpleNamespace(
+        dtype=_DummyDtype(coerced), coerce=True, name="distance"
+    )
+
+    with pytest.raises(errors.SchemaError) as exc_info:
+        backend.coerce_dtype(check_obj, schema=schema)
+
+    err = exc_info.value
+    assert err.reason_code == SchemaErrorReason.DATATYPE_COERCION
+    assert "coercion introduced null values" in str(err)
+    assert set(err.failure_cases["failure_case"].astype(str).tolist()) == {
+        "bad"
+    }
+
+
+def test_array_backend_coerce_returns_value_without_new_nulls() -> None:
+    """Successful coercion should return the coerced object."""
+
+    backend = ArraySchemaBackend()
+    check_obj = _FakePysparkSeries(["1.0", "2.0"], name="distance")
+    coerced = _FakePysparkSeries([1.0, 2.0], name="distance")
+    schema = SimpleNamespace(
+        dtype=_DummyDtype(coerced), coerce=True, name="distance"
+    )
+
+    result = backend.coerce_dtype(check_obj, schema=schema)
+
+    assert result is coerced
+
+
+def test_array_backend_coerce_wraps_inner_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected errors are wrapped in SchemaError with failure cases."""
+
+    backend = ArraySchemaBackend()
+    check_obj = _FakePysparkSeries(["a"], name="distance")
+    schema = SimpleNamespace(
+        dtype=_DummyDtype(_CoercedWithBrokenMask()),
+        coerce=True,
+        name="distance",
+    )
+    failure_cases = pd.DataFrame(
+        {
+            "index": [0],
+            "failure_case": ["a"],
+            "column": ["distance"],
+        }
+    )
+
+    monkeypatch.setattr(
+        "pandera.engines.utils.numpy_pandas_coerce_failure_cases",
+        lambda *_args, **_kwargs: failure_cases,
+    )
+
+    with pytest.raises(errors.SchemaError) as exc_info:
+        backend.coerce_dtype(check_obj, schema=schema)
+
+    err = exc_info.value
+    assert err.reason_code == SchemaErrorReason.DATATYPE_COERCION
+    assert "boom" in str(err)
+    assert err.failure_cases is failure_cases
+
+
+def test_array_backend_coerce_handles_failure_case_extraction_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure-case extraction errors should not mask SchemaError."""
+
+    backend = ArraySchemaBackend()
+    check_obj = _FakePysparkSeries(["a"], name="distance")
+    schema = SimpleNamespace(
+        dtype=_DummyDtype(_CoercedWithBrokenMask()),
+        coerce=True,
+        name="distance",
+    )
+
+    def _raise(*_args, **_kwargs):
+        raise ValueError("cannot extract")
+
+    monkeypatch.setattr(
+        "pandera.engines.utils.numpy_pandas_coerce_failure_cases",
+        _raise,
+    )
+
+    with pytest.raises(errors.SchemaError) as exc_info:
+        backend.coerce_dtype(check_obj, schema=schema)
+
+    err = exc_info.value
+    assert err.reason_code == SchemaErrorReason.DATATYPE_COERCION
+    assert "boom" in str(err)
+    assert err.failure_cases is None
 
 
 def test_series_schema_checks() -> None:

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -13,8 +13,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandera.backends.pandas.array import ArraySchemaBackend
 from pandera.api.pandas.array import ArraySchema
+from pandera.backends.pandas.array import ArraySchemaBackend
 from pandera.dtypes import UniqueSettings
 from pandera.engines.pandas_engine import Engine
 from pandera.engines.utils import pandas_version

--- a/tests/pyspark/test_schemas_on_pyspark_pandas.py
+++ b/tests/pyspark/test_schemas_on_pyspark_pandas.py
@@ -469,6 +469,24 @@ def test_dtype_coercion(from_dtype, to_dtype, data):
     assert isinstance(to_schema(sample), ps.DataFrame)
 
 
+def test_dtype_coercion_nullable_reports_invalid_values():
+    """Ensure coerce dtype errors are reported even when nullable=True."""
+
+    schema = pa.DataFrameSchema(
+        {"distance": pa.Column(float, nullable=True, coerce=True)}
+    )
+    sample = ps.DataFrame({"distance": ["15.2", "test", "13", "NY"]})
+
+    with pytest.raises(pa.errors.SchemaErrors) as exc_info:
+        schema.validate(sample, lazy=True)
+
+    failure_cases = exc_info.value.failure_cases
+    assert set(failure_cases["failure_case"].astype(str).tolist()) == {
+        "test",
+        "NY",
+    }
+
+
 @pytest.mark.parametrize("dtype", [float, int, str, bool])
 @hypothesis.given(st.data())
 def test_failure_cases(dtype, data):


### PR DESCRIPTION
This PR fixes issue #2150 for pandera.pandas used with pyspark.pandas.

When coerce=True and 
ullable=True, invalid values in numeric coercion paths were being converted to nulls and not reported as coercion failure cases.

## Changes:

- Detect coercion introduced nulls in pandas array backend for pyspark.pandas objects.
- Raise SchemaError with DATATYPE_COERCION and concrete ailure_cases for those values.
- Add regression test: 	est_dtype_coercion_nullable_reports_invalid_values.

## Reproduction:

- Confirmed the bug on clean main clone:
  - invalid values in distance (coerce=True, 
ullable=True) were not reported.
  - only unrelated dtype failures were reported.

## Validation:

- [x] pytest tests/pyspark/test_schemas_on_pyspark_pandas.py -q -p no:warnings 
  - result: 262 passed, 243 skipped (with Spark ANSI disabled in this environment for stable pyspark behavior)
- [x] pytest tests/pyspark/test_schemas_on_pyspark_pandas.py -k dtype_coercion_nullable_reports_invalid_values -q
  - result: passed

<img width="2287" height="1110" alt="Screenshot 2026-04-02 175232" src="https://github.com/user-attachments/assets/13e5d181-51f2-4c2b-a56f-731359a4c8a2" />


Note: Spark ANSI mode setting was environment specific for this run. With ANSI enabled, pyspark can raise NumberFormatException before pandera collects failure cases in some tests. Disabling ANSI aligns behavior with the expected pandas on Spark coercion semantics used by this test module.