### PR TITLE
fix(pandas): preserve tz-aware MultiIndex level metadata

### DIFF
--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -647,7 +647,7 @@ class MultiIndexBackend(PandasSchemaBackend):
         # Create a Series with unique values as data, similar to full materialization.
         # This ensures error reporting is consistent between optimized and full paths.
         unique_series = pd.Series(
-            unique_values.values,
+            unique_values,
             name=index_schema.name,
             dtype=multiindex.levels[level_pos].dtype,
         )
@@ -817,7 +817,7 @@ class MultiIndexBackend(PandasSchemaBackend):
 
         # Create a Series with level values as data, indexed by the full MultiIndex
         level_series = pd.Series(
-            full_values.values, index=multiindex, name=index_schema.name
+            full_values, index=multiindex, name=index_schema.name
         )
 
         # Validate as a column (Series), rather than as an index

--- a/tests/pandas/test_schema_components.py
+++ b/tests/pandas/test_schema_components.py
@@ -3,7 +3,6 @@
 import copy
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
-from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -11,7 +10,6 @@ import pytest
 
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.backends.pandas.components import MultiIndexBackend
-from pandera.engines import pandas_engine
 from pandera.engines.pandas_engine import Engine, pandas_version
 from pandera.pandas import (
     Check,
@@ -1398,7 +1396,7 @@ def test_multiindex_optimized_vs_full_validation(
 
 def test_multiindex_tz_aware_level_full_materialization_validation() -> None:
     """Validate tz-aware MultiIndex levels in the full materialization path."""
-    timezone = ZoneInfo("America/New_York")
+    timezone = "America/New_York"
     level_one = pd.DatetimeIndex(
         ["2024-01-01 00:00", "2024-01-01 01:00"],
         tz=timezone,
@@ -1415,7 +1413,7 @@ def test_multiindex_tz_aware_level_full_materialization_validation() -> None:
         index=MultiIndex(
             [
                 Index(
-                    pandas_engine.DateTime(tz=timezone),  # type: ignore[call-arg]
+                    level_one.dtype,
                     name="LEVEL_ONE",
                     checks=Check(
                         lambda s: s.notna(),
@@ -1436,7 +1434,7 @@ def test_multiindex_tz_aware_level_full_materialization_validation() -> None:
 
 def test_multiindex_tz_aware_level_optimized_validation() -> None:
     """Validate tz-aware MultiIndex levels in the optimized path."""
-    timezone = ZoneInfo("America/New_York")
+    timezone = "America/New_York"
     level_one = pd.DatetimeIndex(
         [
             "2024-01-01 00:00",
@@ -1458,7 +1456,7 @@ def test_multiindex_tz_aware_level_optimized_validation() -> None:
         index=MultiIndex(
             [
                 Index(
-                    pandas_engine.DateTime(tz=timezone),  # type: ignore[call-arg]
+                    level_one.dtype,
                     name="LEVEL_ONE",
                     checks=Check.isin(level_one.unique()),
                 ),

--- a/tests/pandas/test_schema_components.py
+++ b/tests/pandas/test_schema_components.py
@@ -3,6 +3,7 @@
 import copy
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -10,6 +11,7 @@ import pytest
 
 from pandera.api.base.error_handler import ErrorHandler
 from pandera.backends.pandas.components import MultiIndexBackend
+from pandera.engines import pandas_engine
 from pandera.engines.pandas_engine import Engine, pandas_version
 from pandera.pandas import (
     Check,
@@ -1391,6 +1393,84 @@ def test_multiindex_optimized_vs_full_validation(
         full_fc.sort_values(by="index").reset_index(drop=True),
         check_like=True,
         check_dtype=False,  # pandas 3.0 uses StringDtype for strings
+    )
+
+
+def test_multiindex_tz_aware_level_full_materialization_validation() -> None:
+    """Validate tz-aware MultiIndex levels in the full materialization path."""
+    timezone = ZoneInfo("America/New_York")
+    level_one = pd.DatetimeIndex(
+        ["2024-01-01 00:00", "2024-01-01 01:00"],
+        tz=timezone,
+        name="LEVEL_ONE",
+    )
+    level_two = pd.Index(["A", "B"], name="LEVEL_TWO")
+    data = pd.DataFrame(
+        {"value": [1, 2]},
+        index=pd.MultiIndex.from_arrays([level_one, level_two]),
+    )
+
+    schema = DataFrameSchema(
+        columns={"value": Column(int)},
+        index=MultiIndex(
+            [
+                Index(
+                    pandas_engine.DateTime(tz=timezone),  # type: ignore[call-arg]
+                    name="LEVEL_ONE",
+                    checks=Check(
+                        lambda s: s.notna(),
+                        determined_by_unique=False,
+                    ),
+                ),
+                Index(String, name="LEVEL_TWO"),
+            ]
+        ),
+    )
+
+    validated = schema.validate(data)
+    pd.testing.assert_index_equal(
+        validated.index.get_level_values("LEVEL_ONE"),
+        level_one,
+    )
+
+
+def test_multiindex_tz_aware_level_optimized_validation() -> None:
+    """Validate tz-aware MultiIndex levels in the optimized path."""
+    timezone = ZoneInfo("America/New_York")
+    level_one = pd.DatetimeIndex(
+        [
+            "2024-01-01 00:00",
+            "2024-01-01 01:00",
+            "2024-01-01 00:00",
+            "2024-01-01 01:00",
+        ],
+        tz=timezone,
+        name="LEVEL_ONE",
+    )
+    level_two = pd.Index(["A", "B", "C", "D"], name="LEVEL_TWO")
+    data = pd.DataFrame(
+        {"value": [1, 2, 3, 4]},
+        index=pd.MultiIndex.from_arrays([level_one, level_two]),
+    )
+
+    schema = DataFrameSchema(
+        columns={"value": Column(int)},
+        index=MultiIndex(
+            [
+                Index(
+                    pandas_engine.DateTime(tz=timezone),  # type: ignore[call-arg]
+                    name="LEVEL_ONE",
+                    checks=Check.isin(level_one.unique()),
+                ),
+                Index(String, name="LEVEL_TWO"),
+            ]
+        ),
+    )
+
+    validated = schema.validate(data)
+    pd.testing.assert_index_equal(
+        validated.index.get_level_values("LEVEL_ONE"),
+        level_one,
     )
 
 


### PR DESCRIPTION
Description:

Issue #2205 reported that timezone-aware MultiIndex levels could fail validation because level values were materialized with .values, which drops timezone metadata.

This PR updates the pandas MultiIndex backend to avoid .values materialization in both full-materialization and optimized paths, preserving index-level dtype information.

It also adds regression tests that cover timezone-aware MultiIndex validation in both paths.

Closes #2205.

Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/backends/pandas/components.py tests/pandas/test_schema_components.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_schema_components.py -k 'tz_aware_level'.