### PR TITLE
fix(pandas): preserve nulls for nullable typed model fields with coercion

### DIFF
--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -14,6 +14,7 @@ from pandera.api.pandas.components import Column, Index, MultiIndex
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.model_config import BaseConfig
 from pandera.api.parsers import Parser
+from pandera.engines import numpy_engine, pandas_engine
 from pandera.engines.pandas_engine import Engine
 from pandera.errors import SchemaInitError
 from pandera.typing import (
@@ -31,6 +32,40 @@ else:
     from typing import Self
 
 SchemaIndex = Union[Index, MultiIndex]
+
+
+def _get_nullable_coercion_dtype(
+    dtype: Any,
+    *,
+    nullable: bool,
+    coerce: bool,
+) -> Any:
+    """Use nullable pandas dtypes for nullable fields when coercing."""
+    if dtype is None or not nullable or not coerce:
+        return dtype
+
+    try:
+        pandera_dtype = Engine.dtype(dtype)
+    except (TypeError, ValueError):
+        return dtype
+
+    nullable_dtype_map = {
+        numpy_engine.Bool: pandas_engine.BOOL,
+        numpy_engine.Int8: pandas_engine.INT8,
+        numpy_engine.Int16: pandas_engine.INT16,
+        numpy_engine.Int32: pandas_engine.INT32,
+        numpy_engine.Int64: pandas_engine.INT64,
+        numpy_engine.UInt8: pandas_engine.UINT8,
+        numpy_engine.UInt16: pandas_engine.UINT16,
+        numpy_engine.UInt32: pandas_engine.UINT32,
+        numpy_engine.UInt64: pandas_engine.UINT64,
+    }
+
+    for numpy_dtype, nullable_dtype in nullable_dtype_map.items():
+        if isinstance(pandera_dtype, numpy_dtype):
+            return nullable_dtype
+
+    return dtype
 
 
 class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
@@ -124,6 +159,13 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                     raise SchemaInitError(
                         f"'check_name' is not supported for {field_name}."
                     )
+
+                dtype = _get_nullable_coercion_dtype(
+                    dtype,
+                    nullable=field.nullable,
+                    coerce=field.coerce
+                    or bool(getattr(cls.__config__, "coerce", False)),
+                )
 
                 column_kwargs = (
                     field.column_properties(

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 import pandera.pandas as pa
+from pandera.api.pandas.model import _get_nullable_coercion_dtype
 from pandera.dtypes import DataType
 from pandera.typing import DataFrame, Index, Series
 
@@ -563,3 +564,31 @@ def test_nullable_coerce_uses_nullable_pandas_dtypes(
 
     assert str(validated["col"].dtype) == expected_dtype
     assert validated["col"].isna().tolist() == [False, True, False]
+
+
+def test_nullable_coerce_dtype_passthrough_for_non_nullable_mapping() -> None:
+    """Unmapped dtypes should be returned unchanged."""
+    assert (
+        _get_nullable_coercion_dtype(
+            pa.String,
+            nullable=True,
+            coerce=True,
+        )
+        is pa.String
+    )
+
+
+def test_nullable_coerce_dtype_passthrough_for_unknown_dtype() -> None:
+    """Unknown dtypes should be returned unchanged on engine resolution error."""
+
+    class UnknownType:
+        """Dummy dtype used to exercise fallback behavior."""
+
+    assert (
+        _get_nullable_coercion_dtype(
+            UnknownType,
+            nullable=True,
+            coerce=True,
+        )
+        is UnknownType
+    )

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -486,6 +486,34 @@ class EmptyBoolSchema(pa.DataFrameModel):
     blah_not_foo: Series[bool]
 
 
+class NullableCoerceBoolSchema(pa.DataFrameModel):
+    col: Series[bool] = pa.Field(nullable=True)
+
+    class Config:
+        coerce = True
+
+
+class NullableCoerceBoolAliasSchema(pa.DataFrameModel):
+    col: Series[pa.typing.Bool] = pa.Field(nullable=True)
+
+    class Config:
+        coerce = True
+
+
+class NullableCoerceIntSchema(pa.DataFrameModel):
+    col: Series[int] = pa.Field(nullable=True)
+
+    class Config:
+        coerce = True
+
+
+class NullableCoerceIntAliasSchema(pa.DataFrameModel):
+    col: Series[pa.typing.Int64] = pa.Field(nullable=True)
+
+    class Config:
+        coerce = True
+
+
 def test_init_pandas_dataframe():
     """Test initialization of pandas.typing.DataFrame with Schema."""
     assert isinstance(
@@ -514,3 +542,24 @@ def test_init_pandas_dataframe_errors(invalid_data):
     """Test errors from initializing a pandas.typing.DataFrame with Schema."""
     with pytest.raises(pa.errors.SchemaError):
         DataFrame[InitSchema](invalid_data)
+
+
+@pytest.mark.parametrize(
+    "model,values,expected_dtype",
+    [
+        (NullableCoerceBoolSchema, [True, None, False], "boolean"),
+        (NullableCoerceBoolAliasSchema, [True, None, False], "boolean"),
+        (NullableCoerceIntSchema, [1, None, 0], "Int64"),
+        (NullableCoerceIntAliasSchema, [1, None, 0], "Int64"),
+    ],
+)
+def test_nullable_coerce_uses_nullable_pandas_dtypes(
+    model: type[pa.DataFrameModel],
+    values: list[Any],
+    expected_dtype: str,
+):
+    """Ensure nullable typed fields preserve nulls when coercion is enabled."""
+    validated = model.validate(pd.DataFrame({"col": values}))
+
+    assert str(validated["col"].dtype) == expected_dtype
+    assert validated["col"].isna().tolist() == [False, True, False]


### PR DESCRIPTION
Issue #2176 reported that the inconsistent behavior for nullable bool and int typed columns in DataFrameModel with coerce=True.

This PR updates the pandas DataFrameModel schema building path to normalize nullable bool/int typed fields to pandas nullable extension dtypes when coercion is enabled, preserving null values consistently.

It also adds regression tests that cover nullable coercion behavior for bool/Bool and int/Int64 typed fields.

Closes #2176.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/api/pandas/model.py tests/pandas/test_typing.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_typing.py -k 'nullable_coerce_uses_nullable_pandas_dtypes'.
- [x] I have run related tests in WSL using pytest -q tests/pandas/test_typing.py.