### PR TITLE
fix(pandas): handle all-NaT nullable Date defaults in added columns

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1148,7 +1148,8 @@ class Date(_BaseDateTime, dtypes.Date):
 
         def _to_datetime(col: PandasObject) -> PandasObject:
             col = to_datetime_fn(col, **self.to_datetime_kwargs)
-            return col.astype(pandas_dtype).dt.date
+            # Keep date semantics as object dtype even for all-NaT values.
+            return col.astype(pandas_dtype).dt.date.astype(object)
 
         if isinstance(data_container, pd.DataFrame):
             # pd.to_datetime transforms a df input into a series.

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -927,6 +927,28 @@ def test_multiindex_unique() -> None:
     assert expected == Base.to_schema()
 
 
+def test_add_missing_columns_nullable_date_with_nat_default() -> None:
+    """Ensure nullable Date fields with NaT defaults validate when auto-added."""
+
+    class Schema(pa.DataFrameModel):
+        index: Series[int] = pa.Field(ge=0)
+        confirmation_date: pa.Date = pa.Field(
+            nullable=True,
+            coerce=True,
+            default=pd.NaT,
+        )
+
+        class Config:
+            add_missing_columns = True
+            coerce = True
+            strict = "filter"
+
+    validated = Schema.validate(pd.DataFrame({"index": [1, 1]}))
+
+    assert validated["confirmation_date"].isna().all()
+    assert validated["confirmation_date"].dtype == object
+
+
 def test_multiindex_strict_valid_schema() -> None:
     """Test that multiindex_strict=True passes validation with correct levels."""
 


### PR DESCRIPTION
The issue #2183 reported that the nullable pa.Date fields could fail validation when add_missing_columns=True auto-added a missing column with default=pd.NaT.

This PR updates the pandas Date coercion path to preserve object/date semantics for all-NaT inputs, so nullable date columns added with NaT defaults pass dtype validation.

It also adds a regression test that covers DataFrameModel validation for add_missing_columns=True with a nullable pa.Date field and pd.NaT default.

Closes #2183.

## Checklist:

- [x] I have reviewed all changes in this PR, manually.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/engines/pandas_engine.py tests/pandas/test_model.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_model.py -k 'add_missing_columns_nullable_date_with_nat_default'.
- [x] I have also run related tests in WSL using pytest -q tests/pandas/test_model.py and pytest -q tests/pandas/test_logical_dtypes.py.