### PR TITLE
fix(strategies): support exact_value in str_length generation

### DIFF
--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -768,8 +768,9 @@ def str_length_strategy(
     pandera_dtype: Union[numpy_engine.DataType, pandas_engine.DataType],
     strategy: SearchStrategy | None = None,
     *,
-    min_value: int,
-    max_value: int,
+    min_value: int | None = None,
+    max_value: int | None = None,
+    exact_value: int | None = None,
 ) -> SearchStrategy:
     """Strategy to generate strings of a particular length
 
@@ -778,15 +779,28 @@ def str_length_strategy(
         pandas dtype strategy will be chained onto this strategy.
     :param min_value: minimum string length.
     :param max_value: maximum string length.
+    :param exact_value: exact string length.
     :returns: ``hypothesis`` strategy
     """
+    if exact_value is not None:
+        min_value = exact_value
+        max_value = exact_value
+
+    if min_value is None and max_value is None:
+        raise ValueError(
+            "At least one of min_value/max_value or exact_value must be set"
+        )
+
     if strategy is None:
         return st.text(min_size=min_value, max_size=max_value).map(
             to_numpy_dtype(pandera_dtype).type
         )
-    return strategy.filter(partial(min_len, min_value)).filter(
-        partial(max_len, max_value)
-    )
+
+    if min_value is not None:
+        strategy = strategy.filter(partial(min_len, min_value))
+    if max_value is not None:
+        strategy = strategy.filter(partial(max_len, max_value))
+    return strategy
 
 
 def _timestamp_to_datetime64_strategy(

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -397,6 +397,16 @@ def test_str_length_checks(chained, data, value_range):
     assert min_value <= len(example) <= max_value
 
 
+def test_str_length_exact_value_example() -> None:
+    """Ensure example generation supports Check.str_length(exact_value=...)."""
+    schema = pa.DataFrameSchema(
+        {"colA": pa.Column(str, checks=[Check.str_length(exact_value=3)])}
+    )
+
+    example = schema.example(size=5)
+    assert example["colA"].map(len).eq(3).all()
+
+
 @hypothesis.given(st.data())
 def test_register_check_strategy(data) -> None:
     """Test registering check strategy on a custom check."""

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -5,7 +5,7 @@ import datetime
 import operator
 import re
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from unittest.mock import MagicMock
 from warnings import catch_warnings
 
@@ -405,6 +405,15 @@ def test_str_length_exact_value_example() -> None:
 
     example = schema.example(size=5)
     assert example["colA"].map(len).eq(3).all()
+
+
+def test_str_length_requires_bounds_or_exact_value() -> None:
+    """Ensure strategy errors when no length constraints are provided."""
+    with pytest.raises(
+        ValueError,
+        match="At least one of min_value/max_value or exact_value",
+    ):
+        strategies.str_length_strategy(cast(Any, pa.String))
 
 
 @hypothesis.given(st.data())


### PR DESCRIPTION
## Description:

This PR fixes the issue #2219 by updating the pandas string length strategy so it supports exact_value, while keeping the existing min/max behavior unchanged.

It also adds a regression test that verifies DataFrameSchema.example() works with Check.str_length(exact_value=3) and produces strings of the expected fixed length.

Closes #2219.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added a regression test for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/strategies/pandas_strategies.py tests/strategies/test_strategies.py.
- [x] I have run focused tests in WSL using pytest -q tests/strategies/test_strategies.py -k 'str_length_exact_value_example or str_length_checks'.
- [x] I have run other related tests in WSL using pytest -q tests/strategies/test_strategies.py.