### PR TITLE
Fix JSON serialization for tuple-labeled schema columns

### DIFF
--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -161,6 +161,20 @@ def _serialize_component_stats(component_stats):
     }
 
 
+def _serialize_column_name(col_name):
+    """Serialize column names that are not valid JSON object keys."""
+    if isinstance(col_name, tuple):
+        return list(col_name)
+    return col_name
+
+
+def _deserialize_column_name(col_name):
+    """Deserialize column names from json-compatible representation."""
+    if isinstance(col_name, list):
+        return tuple(col_name)
+    return col_name
+
+
 def serialize_schema(dataframe_schema):
     """Serialize dataframe schema into into json/yaml-compatible format."""
     from pandera import __version__
@@ -169,10 +183,19 @@ def serialize_schema(dataframe_schema):
 
     columns, index, checks = None, None, None
     if statistics["columns"] is not None:
-        columns = {
-            col_name: _serialize_component_stats(column_stats)
-            for col_name, column_stats in statistics["columns"].items()
-        }
+        columns = statistics["columns"]
+        if all(isinstance(col_name, str) for col_name in columns):
+            columns = {
+                col_name: _serialize_component_stats(column_stats)
+                for col_name, column_stats in columns.items()
+            }
+        else:
+            serialized_columns = []
+            for col_name, column_stats in columns.items():
+                serialized_column = _serialize_component_stats(column_stats)
+                serialized_column["name"] = _serialize_column_name(col_name)
+                serialized_columns.append(serialized_column)
+            columns = serialized_columns
 
     if statistics["index"] is not None:
         index = [
@@ -320,10 +343,24 @@ def deserialize_schema(serialized_schema):
     checks = serialized_schema.get("checks")
 
     if columns is not None:
-        columns = {
-            col_name: Column(**_deserialize_component_stats(column_stats))
-            for col_name, column_stats in columns.items()
-        }
+        if isinstance(columns, list):
+            deserialized_columns = {}
+            for column_stats in columns:
+                col_name = _deserialize_column_name(column_stats.get("name"))
+                component_stats = {
+                    key: value
+                    for key, value in column_stats.items()
+                    if key != "name"
+                }
+                deserialized_columns[col_name] = Column(
+                    **_deserialize_component_stats(component_stats)
+                )
+            columns = deserialized_columns
+        else:
+            columns = {
+                col_name: Column(**_deserialize_component_stats(column_stats))
+                for col_name, column_stats in columns.items()
+            }
 
     if index is not None:
         index = [

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -2160,7 +2160,7 @@ def test_frictionless_schema_primary_key(frictionless_schema):
 def test_frictionless_schema_with_description_and_title(
     frictionless_schema: dict[str, str],
 ):
-    schema = pandera.io.from_frictionless_schema(frictionless_schema)
+    schema = io.from_frictionless_schema(frictionless_schema)
     assert schema.columns["street_id"].description == "Id of the street"
     assert schema.columns["street_id"].title == "street identifier"
 

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1401,6 +1401,35 @@ def test_io_json(index):
         assert schema_from_json == schema
 
 
+def test_io_json_with_multiindex_column_labels():
+    """Test JSON serialization for schemas with tuple column labels."""
+    import json
+
+    schema = pandera.DataFrameSchema(
+        {
+            ("level1", "col_a"): pandera.Column(float),
+            ("level1", "col_b"): pandera.Column(float),
+            ("level2", "col_c"): pandera.Column(int),
+        }
+    )
+    dataframe = pd.DataFrame(
+        {
+            ("level1", "col_a"): [1.0, 2.0, 3.0],
+            ("level1", "col_b"): [4.0, 5.0, 6.0],
+            ("level2", "col_c"): [7, 8, 9],
+        }
+    )
+
+    validated = schema.validate(dataframe)
+    serialized = schema.to_json()
+    restored = schema.from_json(serialized)
+
+    assert isinstance(serialized, str)
+    assert isinstance(json.loads(serialized)["columns"], list)
+    assert restored == schema
+    pd.testing.assert_frame_equal(restored.validate(validated), validated)
+
+
 def test_check_custom_error_json_serialization_roundtrip():
     """Test that custom check errors are serialized and deserialized via JSON."""
     import json

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1555,7 +1555,7 @@ def test_to_script_lambda_check():
     )
 
     with pytest.warns(UserWarning):
-        pandera.io.to_script(schema1)
+        io.to_script(schema1)
 
     schema2 = pandera.DataFrameSchema(
         {
@@ -1567,7 +1567,7 @@ def test_to_script_lambda_check():
     )
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
-        pandera.io.to_script(schema2)
+        io.to_script(schema2)
 
 
 def test_to_yaml_lambda_check():
@@ -1584,7 +1584,7 @@ def test_to_yaml_lambda_check():
     )
 
     with pytest.warns(UserWarning):
-        pandera.io.to_yaml(schema)
+        io.to_yaml(schema)
 
 
 def test_format_checks_warning():
@@ -1626,8 +1626,8 @@ def test_to_yaml_registered_dataframe_check(_):
         checks=[pandera.Check.ncols_gt(column_count=5)],
     )
 
-    serialized = pandera.io.to_yaml(schema)
-    loaded = pandera.io.from_yaml(serialized)
+    serialized = io.to_yaml(schema)
+    loaded = io.from_yaml(serialized)
 
     assert len(loaded.checks) == 1, "global check was stripped"
 
@@ -1650,7 +1650,7 @@ def test_to_yaml_custom_dataframe_check():
     )
 
     with pytest.warns(UserWarning, match=".*registered checks.*"):
-        pandera.io.to_yaml(schema)
+        io.to_yaml(schema)
 
     # the unregistered column check case is tested in
     # `test_to_yaml_lambda_check`
@@ -2029,7 +2029,7 @@ INVALID_FRICTIONLESS_DF = pd.DataFrame(
 )
 def test_frictionless_schema_parses_correctly(frictionless_schema):
     """Test parsing frictionless schema from yaml and json."""
-    schema = pandera.io.from_frictionless_schema(frictionless_schema)
+    schema = io.from_frictionless_schema(frictionless_schema)
 
     assert str(schema.to_yaml()).strip() == YAML_FROM_FRICTIONLESS.strip()
 
@@ -2114,7 +2114,7 @@ def test_frictionless_schema_primary_key(frictionless_schema):
     If the primary key is only one field, the unique field should be in the
     column level and not the dataframe level.
     """
-    schema = pandera.io.from_frictionless_schema(frictionless_schema)
+    schema = io.from_frictionless_schema(frictionless_schema)
     if len(frictionless_schema["primaryKey"]) == 1:
         assert schema.columns[frictionless_schema["primaryKey"][0]].unique
         assert schema.unique is None

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -10,8 +10,9 @@ import pandas as pd
 import pytest
 from packaging import version
 
-import pandera
+import pandera as pandera_base
 import pandera.api.extensions as pa_ext
+import pandera.pandas as pandera
 import pandera.typing as pat
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.engines import pandas_engine
@@ -37,6 +38,7 @@ SKIP_YAML_TESTS = PYYAML_VERSION is None or PYYAML_VERSION.release < (5, 1, 0)  
 
 PANDAS_3_0_0_PLUS = pandas_version().release >= (3, 0, 0)
 
+_PANDERA_VERSION = pandera_base.__version__
 _PANDERA_STR_DTYPE = str(pandas_engine.Engine.dtype(pandera.String))
 
 
@@ -124,7 +126,7 @@ def _create_schema(index="single"):
 
 YAML_SCHEMA = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     title: integer_col
@@ -309,7 +311,7 @@ description: null
 
 YAML_SCHEMA_DICT_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     title: integer_col
@@ -516,7 +518,7 @@ def _create_schema_null_index():
 
 YAML_SCHEMA_NULL_INDEX = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   float_column:
     dtype: float64
@@ -562,7 +564,7 @@ strict: false
 
 YAML_SCHEMA_NULL_INDEX_DICT_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   float_column:
     dtype: float64
@@ -612,7 +614,7 @@ def _create_schema_python_types():
 
 YAML_SCHEMA_PYTHON_TYPES = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     dtype: int64
@@ -631,7 +633,7 @@ strict: false
 
 YAML_SCHEMA_MISSING_GLOBAL_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     dtype: int64
@@ -653,7 +655,7 @@ strict: false
 
 YAML_SCHEMA_MISSING_GLOBAL_CHECK_DICT_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     dtype: int64
@@ -674,7 +676,7 @@ strict: false
 
 YAML_SCHEMA_MISSING_COLUMN_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     dtype: int64
@@ -696,7 +698,7 @@ strict: false
 
 YAML_SCHEMA_MISSING_COLUMN_CHECK_DICT_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     dtype: int64
@@ -718,7 +720,7 @@ strict: false
 
 YAML_SCHEMA_NO_DESCR_NO_TITLE = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     title: null
@@ -903,7 +905,7 @@ description: null
 
 YAML_SCHEMA_NO_DESCR_NO_TITLE_DICT_CHECK = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   int_column:
     title: null
@@ -1272,7 +1274,7 @@ def test_from_yaml_retains_ordered_keyword(is_ordered, test_data, expected):
     """Test that from_yaml() retains the 'ordered' keyword."""
     yaml_schema = f"""
     schema_type: dataframe
-    version: {pandera.__version__}
+    version: {_PANDERA_VERSION}
     columns:
         a:
             dtype: int64
@@ -1828,7 +1830,7 @@ INT_DTYPE_ALIAS = str(pandas_engine.Engine.dtype("int"))
 
 YAML_FROM_FRICTIONLESS = f"""
 schema_type: dataframe
-version: {pandera.__version__}
+version: {_PANDERA_VERSION}
 columns:
   integer_col:
     title: null


### PR DESCRIPTION
## Description:

Issue #2182 reported that schemas with tuple-labeled (MultiIndex-style) columns fail JSON serialization because tuple keys are not valid JSON object keys.

This PR updates pandas schema JSON IO to keep the existing dict format for string column names, and serialize non-string column names with a JSON-safe list representation that roundtrips back to the original labels.

It also adds a regression test for tuple-labeled column schema JSON roundtrip.

Closes #2182.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/io/pandas_io.py tests/io/test_pandas_io.py.
- [x] I have run focused tests in WSL using pytest -q tests/io/test_pandas_io.py -k 'io_json'.

#### The validation screenshot of the tests run (ran on WSL):

<img width="1356" height="287" alt="image" src="https://github.com/user-attachments/assets/88dcaa42-e5be-4ee0-842a-8cde5aea6add" />

<img width="1358" height="642" alt="image" src="https://github.com/user-attachments/assets/ef96b056-c31e-4921-97f4-a9e867fc941a" />

