### PR TITLE
fix(ibis): preserve failed_cases row index positions

### DIFF
--- a/pandera/backends/ibis/base.py
+++ b/pandera/backends/ibis/base.py
@@ -64,9 +64,30 @@ class IbisSchemaBackend(BaseSchemaBackend):
                 from pandera.api.pandas.types import is_table
 
                 check_failure_cases = check_result.failure_cases.to_pandas()
+
+                failed_index = None
+                check_output = check_result.check_output.to_pandas()
+                if isinstance(check_output, pd.Series):
+                    failed_index = check_output[~check_output].index
+                elif (
+                    is_table(check_output)
+                    and CHECK_OUTPUT_KEY in check_output.columns
+                ):
+                    failed_index = check_output.index[
+                        ~check_output[CHECK_OUTPUT_KEY]
+                    ]
+
+                if failed_index is not None:
+                    check_failure_cases = check_failure_cases.set_axis(
+                        failed_index[: len(check_failure_cases)]
+                    )
+
                 if is_table(check_failure_cases):
                     check_failure_cases = (
-                        pd.Series(check_failure_cases.to_dict("records"))
+                        pd.Series(
+                            check_failure_cases.to_dict("records"),
+                            index=check_failure_cases.index,
+                        )
                         .rename("failure_case")
                         .to_frame()
                     )

--- a/tests/ibis/test_ibis_container.py
+++ b/tests/ibis/test_ibis_container.py
@@ -1,5 +1,6 @@
 """Unit tests for Ibis container."""
 
+from types import SimpleNamespace
 from typing import Optional
 
 import ibis
@@ -12,6 +13,8 @@ from ibis import selectors as s
 
 import pandera as pa
 from pandera.api.ibis.types import IbisData
+from pandera.backends.ibis.base import IbisSchemaBackend
+from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.dtypes import UniqueSettings
 from pandera.ibis import Column, DataFrameSchema
 
@@ -315,6 +318,56 @@ def test_failed_cases_index_for_dataframe_check():
         schema.validate(t, lazy=True)
 
     assert err.value.failure_cases["index"].to_list() == [1, 3]
+
+
+@pytest.mark.parametrize(
+    "check_output",
+    [
+        pd.Series([True, False, True, False], name=CHECK_OUTPUT_KEY),
+        pd.DataFrame({CHECK_OUTPUT_KEY: [True, False, True, False]}),
+    ],
+)
+def test_run_check_preserves_failed_index_for_materialized_output(
+    check_output,
+):
+    """run_check should preserve failed row positions in failure_cases."""
+
+    class _FakeExpr:
+        def __init__(self, pandas_obj=None, execute_value=None):
+            self._pandas_obj = pandas_obj
+            self._execute_value = execute_value
+
+        def execute(self):
+            return self._execute_value
+
+        def to_pandas(self):
+            return self._pandas_obj
+
+    class _FakeCheck:
+        ignore_na = True
+        raise_warning = False
+
+        def __init__(self, result):
+            self._result = result
+
+        def __call__(self, *_args, **_kwargs):
+            return self._result
+
+    check_result = SimpleNamespace(
+        check_passed=_FakeExpr(execute_value=False),
+        failure_cases=_FakeExpr(pandas_obj=pd.DataFrame({"a": [0, 0]})),
+        check_output=_FakeExpr(pandas_obj=check_output),
+    )
+    schema = SimpleNamespace(name="schema")
+
+    result = IbisSchemaBackend().run_check(
+        check_obj=ibis.memtable({"a": [10, 0, 20, 0]}),
+        schema=schema,
+        check=_FakeCheck(check_result),
+        check_index=0,
+    )
+
+    assert result.failure_cases["index"].to_list() == [1, 3]
 
 
 @pytest.mark.parametrize(

--- a/tests/ibis/test_ibis_container.py
+++ b/tests/ibis/test_ibis_container.py
@@ -284,6 +284,39 @@ def test_dataframe_level_checks():
         assert err.failure_cases.shape[0] == 6
 
 
+def test_failed_cases_index_for_column_check():
+    """Failure cases should keep original row positions."""
+    schema = DataFrameSchema(
+        {
+            "a": Column(int, checks=pa.Check.gt(0)),
+        }
+    )
+    t = ibis.memtable({"a": [10, 0, 20, 0, 30]})
+
+    with pytest.raises(pa.errors.SchemaErrors) as err:
+        schema.validate(t, lazy=True)
+
+    assert err.value.failure_cases["index"].to_list() == [1, 3]
+
+
+def test_failed_cases_index_for_dataframe_check():
+    """Dataframe checks should keep original row positions."""
+
+    def custom_check(data: IbisData):
+        return data.table.select((data.table.a > 0).name("a"))
+
+    schema = DataFrameSchema(
+        columns={"a": Column(dt.Int64)},
+        checks=[pa.Check(custom_check)],
+    )
+    t = ibis.memtable({"a": [10, 0, 20, 0, 30]})
+
+    with pytest.raises(pa.errors.SchemaErrors) as err:
+        schema.validate(t, lazy=True)
+
+    assert err.value.failure_cases["index"].to_list() == [1, 3]
+
+
 @pytest.mark.parametrize(
     "column_mod,filter_expr",
     [


### PR DESCRIPTION
## Description:

Issue #2188 reported that Ibis table validation could produce failed_cases index values that did not match original row positions.

This PR updates Ibis error formatting to derive failure row positions from check_output and apply them to materialized failure cases, preserving original row index positions without changing CheckResult.failure_cases shape.

It also adds regression tests covering both column-level and dataframe-level checks.

Closes #2188 

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run focused tests in WSL using pytest -q tests/ibis/test_ibis_container.py -k "failed_cases_index or different_unique_settings".
- [x] I have run focused Ibis checks in WSL using pytest -q tests/ibis/test_ibis_check.py.

#### The validation screenshot of the tests run (ran on WSL):

<img width="1793" height="850" alt="image" src="https://github.com/user-attachments/assets/e4676e3c-24dc-4d16-9228-8aded69589a7" />
