### PR TITLE
fix(pandas): preserve DataFrameModel Index metadata in generated schema components

### DIFF
--- a/pandera/api/dataframe/model_components.py
+++ b/pandera/api/dataframe/model_components.py
@@ -91,6 +91,7 @@ class FieldInfo(BaseFieldInfo):
             title=self.title,
             description=self.description,
             default=self.default,
+            metadata=self.metadata,
         )
 
     @property

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -2042,6 +2042,19 @@ def test_pandas_fields_metadata():
     assert PanderaSchema.get_metadata() == expected
 
 
+def test_index_field_metadata_persistence() -> None:
+    test_metadata = {"test_key": "test_value"}
+
+    class MyModel(pa.DataFrameModel):
+        index_field: Index[float] = pa.Field(
+            title="Index Field", metadata=test_metadata
+        )
+
+    class_schema = MyModel.to_schema()
+
+    assert class_schema.index.metadata == test_metadata
+
+
 def test_parse_single_column():
     """Test that a single column can be parsed from a DataFrame"""
 


### PR DESCRIPTION
Issue #2215 reported that metadata on DataFrameModel index fields was not persisted when schema components were built.

This PR updates index field schema-property construction to pass through Field metadata, aligning Index behavior with Series/Column behavior.

It also adds a regression test that verifies metadata persistence for Index fields.

Closes #2215.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/api/dataframe/model_components.py tests/pandas/test_model.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_model.py -k "index_field_metadata_persistence".

#### The validation screenshots of the tests run (ran on WSL):

<img width="1776" height="544" alt="image" src="https://github.com/user-attachments/assets/76d3582a-95c2-4e88-affa-aa123c40dc73" />

<img width="1784" height="980" alt="image" src="https://github.com/user-attachments/assets/580fc40e-851b-477b-b383-1837ffac6c55" />
