### PR TITLE
docs: clarify @check_types behavior in mypy integration

### DIFF
--- a/docs/source/mypy_integration.md
+++ b/docs/source/mypy_integration.md
@@ -111,3 +111,5 @@ exception at runtime, depending on whether you're doing
 ```{literalinclude} ../../tests/mypy/pandas_modules/pandas_dataframe.py
 :lines: 83-87
 ```
+
+However, note that for functions decorated with {class}`~pandera.decorators.check_types`, the runtime validation is only triggered if you explicitly call `validate()` on the returned object or use a schema model like {class}`~pandera.api.pandas.DataFrameModel`. If your function performs in-place mutations that change the structure (e.g., adding/dropping columns) without re-validating, mypy might not detect these structural changes at runtime.


### PR DESCRIPTION
This PR clarifies that for functions decorated with @check_types, runtime validation is only triggered if you explicitly call validate() or use a schema model. This addresses issue #2117.