### PR TITLE
Fix DataFrame.from_records parser execution with coerce=True

### DIFF
--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -394,12 +394,13 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         See :doc:`pandas:reference/api/pandas.DataFrame.from_records` for
         more details.
         """
-        schema = schema.to_schema()  # type: ignore[attr-defined]
+        schema_model = schema
+        schema = schema_model.to_schema()  # type: ignore[attr-defined]
         schema_index = schema.index.names if schema.index is not None else None
         if "index" not in kwargs:
             kwargs["index"] = schema_index
         data_df = pd.DataFrame.from_records(data=data, **kwargs)
-        return DataFrame[schema](  # type: ignore
+        return DataFrame[schema_model](  # type: ignore
             # set the column order according to schema
             data_df[[c for c in schema.columns if c in data_df.columns]]
         )

--- a/pandera/typing/pandas.py
+++ b/pandera/typing/pandas.py
@@ -395,8 +395,12 @@ class DataFrame(DataFrameBase, pd.DataFrame, Generic[T]):
         more details.
         """
         schema_model = schema
-        schema = schema_model.to_schema()  # type: ignore[attr-defined]
-        schema_index = schema.index.names if schema.index is not None else None
+        dataframe_schema = schema_model.to_schema()  # type: ignore[attr-defined]
+        schema_index = (
+            dataframe_schema.index.names
+            if dataframe_schema.index is not None
+            else None
+        )
         if "index" not in kwargs:
             kwargs["index"] = schema_index
         data_df = pd.DataFrame.from_records(data=data, **kwargs)

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -1756,6 +1756,25 @@ def test_from_records_validates_the_schema():
         DataFrame[Schema](raw_data)
 
 
+def test_from_records_invokes_parser_when_coerce_true() -> None:
+    """Ensure from_records uses DataFrameModel validation hooks."""
+
+    class Schema(pa.DataFrameModel):
+        c: Series[float] = pa.Field(alias="B", coerce=True)
+
+        @pa.parser("B")
+        def my_parser(cls, series: pd.Series) -> Series[float]:
+            return series.astype(float) + 1
+
+    raw_data = [
+        {"B": "1"},
+        {"B": "2"},
+    ]
+
+    expected = pd.DataFrame({"B": [2.0, 3.0]})
+    assert_frame_equal(DataFrame.from_records(Schema, raw_data), expected)
+
+
 def test_from_records_sets_the_index_from_schema():
     """Test that DataFrame[Schema] validates the schema"""
 


### PR DESCRIPTION
## Description:

Issue #2129 reported that DataFrameModel parsers could be skipped in DataFrame.from_records when coerce=True was set on a field.

This PR updates DataFrame.from_records to preserve the DataFrameModel generic parameter during construction, so model parser hooks are executed in the constructor validation path.

It also adds a regression test that covers from_records with a parser and coerce=True, asserting parser side effects are applied.

Closes #2129.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/typing/pandas.py tests/pandas/test_model.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_model.py -k "from_records or invokes_parser_when_coerce_true" and pytest -q tests/pandas/test_parsers.py.

#### The validation screenshots of the tests run, locally on WSL:

<img width="1570" height="1129" alt="image" src="https://github.com/user-attachments/assets/fb046181-3ede-40cd-8807-7bf2703bc8bd" />

Note: The warnings are the Future Warning about DataFrame.applymap deprecation, but it's fix is not in the scope of the current issue fix.