### PR TITLE
fix: support Spark Connect DataFrame in cache_check_obj decorator

### DIFF
--- a/pandera/backends/pyspark/decorators.py
+++ b/pandera/backends/pyspark/decorators.py
@@ -7,6 +7,12 @@ from contextlib import contextmanager
 
 from pyspark.sql import DataFrame
 
+try:
+    from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
+    _dataframe_types = (DataFrame, ConnectDataFrame)
+except ImportError:
+    _dataframe_types = (DataFrame,)
+
 from pandera.api.pyspark.types import PysparkDefaultTypes
 from pandera.config import ValidationDepth, get_config_context
 from pandera.errors import SchemaError
@@ -128,7 +134,7 @@ def cache_check_obj():
 
             # Check if decorated function has a dataframe object as an positional arg
             for arg in args:
-                if isinstance(arg, DataFrame):
+                if isinstance(arg, _dataframe_types):
                     check_obj = arg
                     break
 
@@ -136,7 +142,7 @@ def cache_check_obj():
             if check_obj is None:
                 check_obj = kwargs.get("check_obj", None)
 
-            if not isinstance(check_obj, DataFrame):
+            if not isinstance(check_obj, _dataframe_types):
                 raise ValueError(
                     "Expected to find a DataFrame object in a arg or a `check_obj` "
                     "kwarg in the decorated function "


### PR DESCRIPTION
Fixes #2262

### Problem

The `cache_check_obj` decorator in `pandera/backends/pyspark/decorators.py` uses 
`isinstance(check_obj, DataFrame)` with `pyspark.sql.DataFrame`, which rejects 
Spark Connect DataFrames (`pyspark.sql.connect.dataframe.DataFrame`).

In PySpark <= 3.5.x, the Connect DataFrame does not inherit from the classic 
DataFrame class, causing the `isinstance` check to fail when 
`PANDERA_CACHE_DATAFRAME` is enabled.

### Root cause
PySpark 3.5.2
ConnectDataFrame MRO: DataFrame -> object  (no shared base with classic DataFrame)

PySpark 4.x
ConnectDataFrame MRO: DataFrame -> DataFrame -> object  (inherits from classic)

### Changes

- Added a `try/except` import for `pyspark.sql.connect.dataframe.DataFrame`
- Created `_dataframe_types` tuple to accept both classic and Connect DataFrames
- Replaced `isinstance(arg, DataFrame)` with `isinstance(arg, _dataframe_types)` 
  in both checks (lines 138 and 146)

### Testing

- PySpark test suite: 714 passed, 1 failed (pre-existing failure unrelated to this change)
- Tested on PySpark 3.5.2 (same version reported in issue), Python 3.13.5