### PR TITLE
docs: update xarray integration info for v0.31.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,9 +207,9 @@ html_theme = "furo"
 # documentation.
 
 announcement = """
-📢 Pandera 0.25.0 introduces the <i>🦩 pandera-ibis integration </i>!
-Validate all supported Ibis backends, including Snowflake, BigQuery, and more.
-Learn more details <a href='./ibis.html'>here</a>
+📢 Pandera 0.31.0 introduces the <i> pandera-xarray integration </i>!
+Validate all supported xarray data structures, including Dataset, DataArray, and DataTree.
+Learn more details <a href='./xarray.html'>here</a>
 """
 
 html_logo = "_static/pandera-banner.png"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,7 +209,7 @@ html_theme = "furo"
 announcement = """
 📢 Pandera 0.31.0 introduces the <i> pandera-xarray integration </i>!
 Validate all supported xarray data structures, including Dataset, DataArray, and DataTree.
-Learn more details <a href='./xarray.html'>here</a>
+Learn more details <a href='./xarray_guide/index.html'>here</a>
 """
 
 html_logo = "_static/pandera-banner.png"

--- a/docs/source/reference/xarray.rst
+++ b/docs/source/reference/xarray.rst
@@ -3,6 +3,8 @@
 Xarray
 ======
 
+*New in 0.31.0*
+
 Schemas and components for validating :class:`xarray.DataArray`,
 :class:`xarray.Dataset`, and :class:`xarray.DataTree`. Typical imports use
 :mod:`pandera.xarray`; implementations live under :mod:`pandera.api.xarray`.

--- a/docs/source/xarray_guide/index.md
+++ b/docs/source/xarray_guide/index.md
@@ -6,6 +6,8 @@ file_format: mystnb
 
 # Xarray Data Validation
 
+*New in 0.31.0*
+
 [xarray](https://docs.xarray.dev/) provides labelled multi-dimensional arrays
 {class}`~xarray.DataArray`, collections of aligned arrays
 {class}`~xarray.Dataset`, and collections of datasets with {class}`~xarray.DataTree`.


### PR DESCRIPTION
## Summary
- Added "*New in 0.31.0*" to the Xarray reference page and guide index.
- Updated top-level banner in `conf.py` to reflect version 0.31.0 and xarray data structure validation.