### PR TITLE
tests(mypy): add regression coverage for polars Column Decimal/Struct typing

### DIFF
--- a/tests/mypy/polars_modules/polars_dtypes.py
+++ b/tests/mypy/polars_modules/polars_dtypes.py
@@ -1,0 +1,6 @@
+import polars as pl
+
+import pandera.polars as pa
+
+pa.Column(pl.Decimal(precision=38, scale=6))
+pa.Column(pl.Struct({"a": pl.Int64()}))

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -1,0 +1,35 @@
+"""Unit tests for static type checking of polars schemas."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+test_module_dir = Path(os.path.dirname(__file__))
+
+
+def test_mypy_polars_column_parametrized_dtypes() -> None:
+    """Check that Column typing accepts parametrized polars dtypes."""
+    pytest.importorskip("polars")
+
+    cache_dir = str(test_module_dir / ".mypy_cache" / "test-polars-dtypes")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            str(test_module_dir / "polars_modules" / "polars_dtypes.py"),
+            "--cache-dir",
+            cache_dir,
+            "--config-file",
+            str(test_module_dir / "config" / "no_plugin.ini"),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Description:

Issue #2152 reported that pa.Column mypy typing should accept pl.Decimal, and that it also happens with pl.Struct.

This PR adds a focused mypy regression module and test that verify pa.Column accepts both parametrized polars dtypes:
- pl.Decimal(precision=38, scale=6)
- pl.Struct({...})

The regression test runs mypy with the repository config (	ests/mypy/config/no_plugin.ini) and asserts successful type checking.

Closes #2152.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files tests/mypy/polars_modules/polars_dtypes.py tests/mypy/test_polars_static_type_checking.py.
- [x] I have run focused tests in WSL using pytest -q tests/mypy/test_polars_static_type_checking.py.
- [x] I have verified both issue reproductions (pl.Decimal and pl.Struct) with mypy using 	ests/mypy/config/no_plugin.ini.

#### The validation screenshots of the tests ran, locally on WSL:

<img width="2352" height="1339" alt="image" src="https://github.com/user-attachments/assets/6395b3a0-a6b5-43da-92a9-b00895114920" />
