### PR TITLE
fix(pandas): export errors in pandera.pandas public API

### DIFF
--- a/pandera/geopandas.py
+++ b/pandera/geopandas.py
@@ -136,6 +136,7 @@ __all__ = [
     "SeriesSchema",
     "extensions",
     "typing",
+    "errors",
     "dtypes",
 ]
 

--- a/pandera/pandas.py
+++ b/pandera/pandas.py
@@ -167,6 +167,8 @@ __all__ = [
     "extensions",
     # typing
     "typing",
+    # errors
+    "errors",
     # dtypes
     "dtypes",
 ]

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -13,12 +13,19 @@ import pytest
 import pytz
 from hypothesis import given
 
+import pandera.pandas as pa
 from pandera.engines import pandas_engine
 from pandera.engines.pandas_engine import PANDAS_3_0_0_PLUS
 from pandera.errors import ParserError, SchemaError
 from pandera.pandas import DataFrameModel, Field, check, errors
 
 UNSUPPORTED_DTYPE_CLS: set[Any] = set()
+
+
+def test_errors_exported_in_pandas_public_api() -> None:
+    """Ensure ``errors`` is explicitly exported from ``pandera.pandas``."""
+    assert "errors" in pa.__all__
+    assert pa.errors is errors
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description:

Issue #2098 reported that Pylance could flag pa.errors as private because errors was imported in pandera.pandas but not included in its public export list.

This PR updates the pandas entrypoint to include errors in __all__, making pa.errors an explicitly exported public API symbol.

It also adds a regression test that verifies errors is in pa.__all__ and that pa.errors resolves to the same module object.

Closes #2098.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/pandas.py tests/pandas/test_pandas_engine.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_pandas_engine.py -k 'errors_exported_in_pandas_public_api'.
- [x] I have run broader verification in WSL using pytest -q tests/pandas/test_pandas_engine.py.

#### The validation screenshot of the tests run, locally on WSL:

<img width="1413" height="1127" alt="image" src="https://github.com/user-attachments/assets/93cbb77f-892f-4084-acf5-84311bb7af91" />

Note: The warning is due to the negative test checks if Pandera correctly raises a warning if schema validation error when non geometry shapely objects as DataFrames are converted to GeoDataFrames.