### PR TITLE
test(pyspark): add str_length regressions for issues #1311 and #1314

### DIFF
--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -1553,6 +1553,71 @@ class TestStringType(BaseClass):
                 raise PysparkSchemaError
 
 
+@validate_scope(scope=ValidationScope.DATA)
+def test_str_length_check_regression_issue_1314(
+    spark_session, request
+) -> None:
+    """Check.str_length should work for pyspark DataFrameSchema checks."""
+    spark = request.getfixturevalue(spark_session)
+    schema = DataFrameSchema(
+        {
+            "participant_id": Column(
+                StringType(),
+                checks=[pa.Check.str_length(32)],
+            )
+        }
+    )
+    spark_schema = StructType(
+        [StructField("participant_id", StringType(), False)],
+    )
+
+    df = spark.createDataFrame(
+        data=[("a" * 32,), ("b" * 32,)],
+        schema=spark_schema,
+    )
+    df_out = schema.validate(df)
+    assert not df_out.pandera.errors
+
+    df = spark.createDataFrame(
+        data=[("a" * 31,), ("b" * 32,)],
+        schema=spark_schema,
+    )
+    df_out = schema.validate(df)
+    assert (
+        dict(df_out.pandera.errors)["DATA"]["DATAFRAME_CHECK"][0]["check"]
+        == "str_length(32)"
+    )
+
+
+@validate_scope(scope=ValidationScope.DATA)
+def test_field_str_length_regression_issue_1311(
+    spark_session, request
+) -> None:
+    """Field(str_length=...) should work for pyspark DataFrameModel."""
+    spark = request.getfixturevalue(spark_session)
+
+    # pylint: disable=too-few-public-methods
+    class ProductSchema(DataFrameModel):
+        product_name: StringType() = Field(
+            str_length={"min_value": 1, "max_value": 2}
+        )
+
+    spark_schema = StructType(
+        [StructField("product_name", StringType(), False)],
+    )
+
+    df = spark.createDataFrame(data=[("a",), ("bb",)], schema=spark_schema)
+    df_out = ProductSchema.validate(df)
+    assert not df_out.pandera.errors
+
+    df = spark.createDataFrame(data=[("bbb",)], schema=spark_schema)
+    df_out = ProductSchema.validate(df)
+    assert (
+        dict(df_out.pandera.errors)["DATA"]["DATAFRAME_CHECK"][0]["check"]
+        == "str_length(1, 2)"
+    )
+
+
 class TestInRangeCheck(BaseClass):
     """This class is used to test the value in range check"""
 

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -1554,7 +1554,7 @@ class TestStringType(BaseClass):
 
 
 @validate_scope(scope=ValidationScope.DATA)
-def test_str_length_check_regression_issue_1314(
+def test_str_length_check_with_pyspark_schemas(
     spark_session, request
 ) -> None:
     """Check.str_length should work for pyspark DataFrameSchema checks."""
@@ -1590,7 +1590,7 @@ def test_str_length_check_regression_issue_1314(
 
 
 @validate_scope(scope=ValidationScope.DATA)
-def test_field_str_length_regression_issue_1311(
+def test_field_str_length_with_pyspark_schema_fields(
     spark_session, request
 ) -> None:
     """Field(str_length=...) should work for pyspark DataFrameModel."""


### PR DESCRIPTION
## Description:

Issue #1311 and #1314 reported that PySpark str_length checks could fail with NotImplementedError in two user paths: DataFrameSchema with Check.str_length(...) and DataFrameModel with Field(str_length=...).

This PR adds focused regression tests in the PySpark SQL suite for both paths and validates both passing and failing cases, including emitted check names.

This improves over #1709 by including dedicated regression tests, and passing lint/test validation in WSL.

Closes #1311.
Closes #1314.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files tests/pyspark/test_pyspark_check.py.
- [x] I have run focused tests in WSL using pytest -q tests/pyspark/test_pyspark_check.py -k "regression_issue_1311 or regression_issue_1314".
- [x] I have run broader tests in WSL using pytest -q tests/pyspark/test_pyspark_check.py.

#### The validation screenshots for the tests run, locally on WSL:

<img width="1736" height="1161" alt="image" src="https://github.com/user-attachments/assets/7fbca74a-3d85-4c39-a7b7-69f91711aff8" />

<img width="1609" height="453" alt="image" src="https://github.com/user-attachments/assets/ed9504c3-0ae9-47b1-ad6d-ef9573e8e158" />
