### PR TITLE
Fix pandera[polars] import without pandas

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,6 +76,30 @@ jobs:
         if: always()
         run: prek run mypy --all-files
 
+  # Test that polars can be imported without pandas
+  import-test-polars-no-pandas:
+    name: Import Test Polars (no pandas)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install polars only (no pandas)
+        run: python -m pip install polars
+
+      - name: Uninstall pandas if present
+        run: python -m pip uninstall pandas -y || true
+
+      - name: Install pandera
+        run: python -m pip install -e .
+
+      - name: Test import pandera.polars
+        run: python -c "import pandera.polars; print('SUCCESS: pandera.polars imported without pandas')"
+
   # test base functionality
   unit-tests-base:
     name: >

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,6 +6,7 @@ on:
       - dev
       - bugfix
       - "release/*"
+      - "fix/**"
   pull_request:
     branches:
       - main
@@ -98,7 +99,8 @@ jobs:
         run: python -m pip install -e .
 
       - name: Test import pandera.polars
-        run: python -c "import pandera.polars; print('SUCCESS: pandera.polars imported without pandas')"
+        run: |
+          python -c "import pandera.polars; print('SUCCESS: pandera.polars imported without pandas')"
 
   # test base functionality
   unit-tests-base:
@@ -129,7 +131,8 @@ jobs:
           pip list
           printenv | sort
       - name: Unit Tests Base
-        run: nox -v -db uv --non-interactive --session "tests-${{ matrix.python-version }}(extra=None, pandas=None, pydantic=None, polars=None)"
+        run: |
+          nox -v -db uv --non-interactive --session 'tests-${{ matrix.python-version }}(extra=None, pandas=None, pydantic=None, polars=None)'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -29,7 +29,7 @@ from pandera.io._minimal import (
     DF_SCHEMA_DEFAULTS,
     apply_minimal_dataframe_container,
 )
-from pandera.schema_statistics import get_dataframe_schema_statistics
+from pandera.schema_statistics.pandas import get_dataframe_schema_statistics
 
 if TYPE_CHECKING:
     from frictionless import Schema as FrictionlessSchema

--- a/pandera/schema_inference/polars.py
+++ b/pandera/schema_inference/polars.py
@@ -8,7 +8,7 @@ import polars as pl
 
 from pandera.api.polars.components import Column
 from pandera.api.polars.container import DataFrameSchema
-from pandera.schema_statistics.pandas import parse_check_statistics
+from pandera.schema_statistics.polars import parse_check_statistics
 from pandera.schema_statistics.polars import infer_polars_dataframe_statistics
 
 

--- a/pandera/schema_inference/polars.py
+++ b/pandera/schema_inference/polars.py
@@ -8,8 +8,10 @@ import polars as pl
 
 from pandera.api.polars.components import Column
 from pandera.api.polars.container import DataFrameSchema
-from pandera.schema_statistics.polars import parse_check_statistics
-from pandera.schema_statistics.polars import infer_polars_dataframe_statistics
+from pandera.schema_statistics.polars import (
+    infer_polars_dataframe_statistics,
+    parse_check_statistics,
+)
 
 
 def infer_dataframe_schema(df: pl.DataFrame) -> DataFrameSchema:

--- a/pandera/schema_statistics/__init__.py
+++ b/pandera/schema_statistics/__init__.py
@@ -1,12 +1,1 @@
 """Module to extract schema statsitics from schema objects."""
-
-from pandera.schema_statistics.pandas import (
-    get_dataframe_schema_statistics,
-    get_index_schema_statistics,
-    get_series_schema_statistics,
-    infer_dataframe_statistics,
-    infer_index_statistics,
-    infer_series_statistics,
-    parse_check_statistics,
-    parse_checks,
-)

--- a/pandera/schema_statistics/polars.py
+++ b/pandera/schema_statistics/polars.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+import warnings
+from typing import Any, Union
 
 from pandera import dtypes
+from pandera.api.checks import Check
 from pandera.engines import polars_engine
-from pandera.schema_statistics.pandas import parse_checks
 
 
 def _infer_polars_series_checks(
@@ -85,3 +86,82 @@ def get_dataframe_schema_statistics(dataframe_schema) -> dict[str, Any]:
         "coerce": dataframe_schema.coerce,
     }
     return statistics
+
+
+def parse_checks(checks) -> Union[list[dict[str, Any]], None]:
+    """Convert Check object to check statistics including options."""
+
+    def _has_custom_error(check: Check) -> bool:
+        """Determine whether a check has a user-defined error message."""
+        if check.error is None:
+            return False
+
+        if check.name is None or not Check.is_builtin_check(check.name):
+            return True
+
+        try:
+            default_check = getattr(Check, check.name)(
+                **(check.statistics or {})
+            )
+        except (AttributeError, TypeError, ValueError):
+            return True
+
+        return check.error != default_check.error
+
+    check_statistics = []
+
+    for check in checks:
+        if check not in Check:
+            warnings.warn(
+                "Only registered checks may be serialized to statistics. "
+                "Did you forget to register it with the extension API? "
+                f"Check `{check.name}` will be skipped."
+            )
+            continue
+
+        base_stats = {} if check.statistics is None else check.statistics
+
+        check_options = {
+            "check_name": check.name,
+            "raise_warning": check.raise_warning,
+            "n_failure_cases": check.n_failure_cases,
+            "ignore_na": check.ignore_na,
+        }
+        if _has_custom_error(check):
+            check_options["error"] = check.error
+
+        check_options = {
+            k: v for k, v in check_options.items() if v is not None
+        }
+
+        if check_options:
+            base_stats["options"] = check_options
+            check_statistics.append(base_stats)
+
+    return check_statistics if check_statistics else None
+
+
+def parse_check_statistics(check_stats: Union[dict[str, Any], None]):
+    """Convert check statistics to a list of Check objects, including their options."""
+    if check_stats is None:
+        return None
+    checks = []
+    for check_name, stats in check_stats.items():
+        check = getattr(Check, check_name)
+        try:
+            if isinstance(stats, dict):
+                options = (
+                    stats.pop("options", {}) if "options" in stats else {}
+                )
+                if stats:
+                    check_instance = check(**stats)
+                else:
+                    check_instance = check()
+                for option_name, option_value in options.items():
+                    setattr(check_instance, option_name, option_value)
+                checks.append(check_instance)
+            else:
+                checks.append(check(stats))
+        except TypeError:
+            checks.append(check(stats))
+    return checks if checks else None


### PR DESCRIPTION
## Summary

- Fix import chain that was causing pandas dependency when importing `pandera.polars` without pandas installed
- Changed `schema_statistics/__init__.py` to not import any submodules (all imports now explicit)
- Added `parse_checks` and `parse_check_statistics` to polars module to avoid importing from pandas module

## Root cause

The import chain was:
- `pandera.polars` → `schema_inference.polars` → `schema_statistics.pandas` → `import pandas`

This failed when pandas wasn't installed.

## Changes

1. `pandera/schema_statistics/__init__.py` - Empty (no submodule imports)
2. `pandera/schema_inference/polars.py` - Import from polars submodule
3. `pandera/schema_statistics/polars.py` - Added standalone parse utilities
4. `pandera/io/pandas_io.py` - Import from explicit pandas submodule

Closes #2289