### PR TITLE
fix: Ibis validation fails checks if column all nulls

### DIFF
--- a/pandera/backends/ibis/base.py
+++ b/pandera/backends/ibis/base.py
@@ -59,26 +59,29 @@ class IbisSchemaBackend(BaseSchemaBackend):
                     schema, check, check_index
                 )
             else:
+                import ibis
                 import pandas as pd
 
                 from pandera.api.pandas.types import is_table
-
-                import ibis
 
                 check_failure_cases = check_result.failure_cases.to_pandas()
 
                 failed_index = None
                 check_output = check_result.check_output.to_pandas()
-                
+
                 # Get ignore_na from the check parameter or default to True
-                check_ignore_na = getattr(check, 'ignore_na', True)
-                
+                check_ignore_na = getattr(check, "ignore_na", True)
+
                 if isinstance(check_output, pd.Series):
                     # Handle case where all values are None or NA - these should be filtered out if ignore_na=True
                     if check_ignore_na:
                         # Convert to boolean, treating NA as False for the purpose of ~ operation
-                        check_output_bool = check_output.fillna(False).astype(bool)
-                        failed_index = check_output_bool[~check_output_bool].index
+                        check_output_bool = check_output.fillna(False).astype(
+                            bool
+                        )
+                        failed_index = check_output_bool[
+                            ~check_output_bool
+                        ].index
                     else:
                         failed_index = check_output[~check_output].index
                 elif (
@@ -89,12 +92,12 @@ class IbisSchemaBackend(BaseSchemaBackend):
                     # Handle case where all values are None or NA - these should be filtered out if ignore_na=True
                     if check_ignore_na:
                         # Convert to boolean, treating NA as False for the purpose of ~ operation
-                        check_output_bool = check_output_col.fillna(False).astype(bool)
+                        check_output_bool = check_output_col.fillna(
+                            False
+                        ).astype(bool)
                         failed_index = check_output.index[~check_output_bool]
                     else:
-                        failed_index = check_output.index[
-                            ~check_output_col
-                        ]
+                        failed_index = check_output.index[~check_output_col]
 
                 if failed_index is not None:
                     check_failure_cases = check_failure_cases.set_axis(

--- a/pandera/backends/ibis/base.py
+++ b/pandera/backends/ibis/base.py
@@ -63,19 +63,38 @@ class IbisSchemaBackend(BaseSchemaBackend):
 
                 from pandera.api.pandas.types import is_table
 
+                import ibis
+
                 check_failure_cases = check_result.failure_cases.to_pandas()
 
                 failed_index = None
                 check_output = check_result.check_output.to_pandas()
+                
+                # Get ignore_na from the check parameter or default to True
+                check_ignore_na = getattr(check, 'ignore_na', True)
+                
                 if isinstance(check_output, pd.Series):
-                    failed_index = check_output[~check_output].index
+                    # Handle case where all values are None or NA - these should be filtered out if ignore_na=True
+                    if check_ignore_na:
+                        # Convert to boolean, treating NA as False for the purpose of ~ operation
+                        check_output_bool = check_output.fillna(False).astype(bool)
+                        failed_index = check_output_bool[~check_output_bool].index
+                    else:
+                        failed_index = check_output[~check_output].index
                 elif (
                     is_table(check_output)
                     and CHECK_OUTPUT_KEY in check_output.columns
                 ):
-                    failed_index = check_output.index[
-                        ~check_output[CHECK_OUTPUT_KEY]
-                    ]
+                    check_output_col = check_output[CHECK_OUTPUT_KEY]
+                    # Handle case where all values are None or NA - these should be filtered out if ignore_na=True
+                    if check_ignore_na:
+                        # Convert to boolean, treating NA as False for the purpose of ~ operation
+                        check_output_bool = check_output_col.fillna(False).astype(bool)
+                        failed_index = check_output.index[~check_output_bool]
+                    else:
+                        failed_index = check_output.index[
+                            ~check_output_col
+                        ]
 
                 if failed_index is not None:
                     check_failure_cases = check_failure_cases.set_axis(

--- a/pandera/backends/ibis/checks.py
+++ b/pandera/backends/ibis/checks.py
@@ -159,12 +159,12 @@ class IbisCheckBackend(BaseCheckBackend):
     ) -> CheckResult:
         """Postprocesses the result of applying the check function."""
         check_output = check_output.name(CHECK_OUTPUT_KEY)
-        
+
         # Handle null values according to ignore_na setting
         if self.check.ignore_na and check_obj.key:
             isna = check_obj.table[check_obj.key].isnull()
             check_output = check_output | isna
-        
+
         failure_cases = check_obj.table.filter(~check_output)
         if check_obj.key is not None:
             failure_cases = failure_cases.select(check_obj.key)
@@ -185,24 +185,26 @@ class IbisCheckBackend(BaseCheckBackend):
         check_output: ibis.Table,
     ) -> CheckResult:
         """Postprocesses the result of applying the check function."""
-        
+
         # Handle null values according to ignore_na setting
         if self.check.ignore_na and check_obj.key:
             # Get the original column from check_obj.table (not from check_output which has check columns)
             orig_col = check_obj.table[check_obj.key]
             isna = orig_col.isnull()
             # Mutate to update the check output column - OR with isna
-            check_output = check_output.mutate({
-                CHECK_OUTPUT_KEY: check_output[CHECK_OUTPUT_KEY] | isna
-            })
+            check_output = check_output.mutate(
+                {CHECK_OUTPUT_KEY: check_output[CHECK_OUTPUT_KEY] | isna}
+            )
         elif self.check.ignore_na:
             # For table-level checks, all columns in output might be affected
             # Apply isnull to each check column
             for col in check_output.columns:
                 if col.endswith(CHECK_OUTPUT_SUFFIX):
                     isna = check_output[col].isnull()
-                    check_output = check_output.mutate({col: check_output[col] | isna})
-        
+                    check_output = check_output.mutate(
+                        {col: check_output[col] | isna}
+                    )
+
         passed = check_output[CHECK_OUTPUT_KEY].all()
         failure_cases = check_output.filter(~_[CHECK_OUTPUT_KEY]).drop(
             s.endswith(CHECK_OUTPUT_SUFFIX) | select_column(CHECK_OUTPUT_KEY)

--- a/pandera/backends/ibis/checks.py
+++ b/pandera/backends/ibis/checks.py
@@ -159,6 +159,12 @@ class IbisCheckBackend(BaseCheckBackend):
     ) -> CheckResult:
         """Postprocesses the result of applying the check function."""
         check_output = check_output.name(CHECK_OUTPUT_KEY)
+        
+        # Handle null values according to ignore_na setting
+        if self.check.ignore_na and check_obj.key:
+            isna = check_obj.table[check_obj.key].isnull()
+            check_output = check_output | isna
+        
         failure_cases = check_obj.table.filter(~check_output)
         if check_obj.key is not None:
             failure_cases = failure_cases.select(check_obj.key)
@@ -179,6 +185,24 @@ class IbisCheckBackend(BaseCheckBackend):
         check_output: ibis.Table,
     ) -> CheckResult:
         """Postprocesses the result of applying the check function."""
+        
+        # Handle null values according to ignore_na setting
+        if self.check.ignore_na and check_obj.key:
+            # Get the original column from check_obj.table (not from check_output which has check columns)
+            orig_col = check_obj.table[check_obj.key]
+            isna = orig_col.isnull()
+            # Mutate to update the check output column - OR with isna
+            check_output = check_output.mutate({
+                CHECK_OUTPUT_KEY: check_output[CHECK_OUTPUT_KEY] | isna
+            })
+        elif self.check.ignore_na:
+            # For table-level checks, all columns in output might be affected
+            # Apply isnull to each check column
+            for col in check_output.columns:
+                if col.endswith(CHECK_OUTPUT_SUFFIX):
+                    isna = check_output[col].isnull()
+                    check_output = check_output.mutate({col: check_output[col] | isna})
+        
         passed = check_output[CHECK_OUTPUT_KEY].all()
         failure_cases = check_output.filter(~_[CHECK_OUTPUT_KEY]).drop(
             s.endswith(CHECK_OUTPUT_SUFFIX) | select_column(CHECK_OUTPUT_KEY)

--- a/tests/ibis/test_ibis_nullable_column_checks.py
+++ b/tests/ibis/test_ibis_nullable_column_checks.py
@@ -1,16 +1,16 @@
-"""Test for issue #2294: ibis validation fails checks if column all nulls."""
+"""Tests for ibis validation with nullable columns and check functions."""
 
+import ibis
 import pytest
 
 import pandera.ibis
-import ibis
 
 
-class TestIssue2294:
-    """Tests for the fix to issue #2294."""
+class TestIbisNullableColumnChecks:
+    """Tests for ibis validation when nullable columns contain only null values."""
 
     def test_ibis_column_with_all_nulls_passes_nullable_check(self):
-        """Ibis validation should pass when checking a nullable column with all nulls."""
+        """Validation should pass when checking a nullable column with all nulls."""
         data = {"my_value": [None, None]}
         df = ibis.memtable(data).cast({"my_value": "float64"})
 
@@ -26,12 +26,11 @@ class TestIssue2294:
             }
         )
 
-        # Should not raise - all nulls should be ignored
         result = schema.validate(df)
         assert isinstance(result, ibis.Table)
 
     def test_ibis_column_with_mixed_nulls_passes_nullable_check(self):
-        """Ibis validation should pass with some nulls and some valid values."""
+        """Validation should pass with some nulls and some valid values."""
         data = {"my_value": [42, None]}
         df = ibis.memtable(data).cast({"my_value": "float64"})
 
@@ -51,7 +50,7 @@ class TestIssue2294:
         assert isinstance(result, ibis.Table)
 
     def test_ibis_column_with_invalid_values_fails(self):
-        """Ibis validation should fail when non-null values don't pass checks."""
+        """Validation should fail when non-null values don't pass the check."""
         data = {"my_value": [-5, None]}
         df = ibis.memtable(data).cast({"my_value": "float64"})
 
@@ -71,7 +70,7 @@ class TestIssue2294:
             schema.validate(df)
 
     def test_ibis_column_with_all_valid_values_passes(self):
-        """Ibis validation should pass when all non-null values pass checks."""
+        """Validation should pass when all non-null values pass the check."""
         data = {"my_value": [10, 20]}
         df = ibis.memtable(data).cast({"my_value": "float64"})
 

--- a/tests/ibis/test_issue_2294.py
+++ b/tests/ibis/test_issue_2294.py
@@ -1,0 +1,91 @@
+"""Test for issue #2294: ibis validation fails checks if column all nulls."""
+
+import pytest
+
+import pandera.ibis
+import ibis
+
+
+class TestIssue2294:
+    """Tests for the fix to issue #2294."""
+
+    def test_ibis_column_with_all_nulls_passes_nullable_check(self):
+        """Ibis validation should pass when checking a nullable column with all nulls."""
+        data = {"my_value": [None, None]}
+        df = ibis.memtable(data).cast({"my_value": "float64"})
+
+        schema = pandera.ibis.DataFrameSchema(
+            {
+                "my_value": pandera.ibis.Column(
+                    float,
+                    nullable=True,
+                    checks=[
+                        pandera.ibis.Check.greater_than_or_equal_to(0),
+                    ],
+                ),
+            }
+        )
+
+        # Should not raise - all nulls should be ignored
+        result = schema.validate(df)
+        assert isinstance(result, ibis.Table)
+
+    def test_ibis_column_with_mixed_nulls_passes_nullable_check(self):
+        """Ibis validation should pass with some nulls and some valid values."""
+        data = {"my_value": [42, None]}
+        df = ibis.memtable(data).cast({"my_value": "float64"})
+
+        schema = pandera.ibis.DataFrameSchema(
+            {
+                "my_value": pandera.ibis.Column(
+                    float,
+                    nullable=True,
+                    checks=[
+                        pandera.ibis.Check.greater_than_or_equal_to(0),
+                    ],
+                ),
+            }
+        )
+
+        result = schema.validate(df)
+        assert isinstance(result, ibis.Table)
+
+    def test_ibis_column_with_invalid_values_fails(self):
+        """Ibis validation should fail when non-null values don't pass checks."""
+        data = {"my_value": [-5, None]}
+        df = ibis.memtable(data).cast({"my_value": "float64"})
+
+        schema = pandera.ibis.DataFrameSchema(
+            {
+                "my_value": pandera.ibis.Column(
+                    float,
+                    nullable=True,
+                    checks=[
+                        pandera.ibis.Check.greater_than_or_equal_to(0),
+                    ],
+                ),
+            }
+        )
+
+        with pytest.raises(pandera.ibis.errors.SchemaError):
+            schema.validate(df)
+
+    def test_ibis_column_with_all_valid_values_passes(self):
+        """Ibis validation should pass when all non-null values pass checks."""
+        data = {"my_value": [10, 20]}
+        df = ibis.memtable(data).cast({"my_value": "float64"})
+
+        schema = pandera.ibis.DataFrameSchema(
+            {
+                "my_value": pandera.ibis.Column(
+                    float,
+                    nullable=True,
+                    checks=[
+                        pandera.ibis.Check.greater_than_or_equal_to(0),
+                    ],
+                ),
+            }
+        )
+
+        result = schema.validate(df)
+        assert isinstance(result, ibis.Table)


### PR DESCRIPTION
#2294

Fixes ibis validation that was failing when checking nullable columns containing only null values with the error:
TypeError("bad operand type for unary ~: 'NoneType'")

## Changes
- Modified  and  to OR check outputs with isna() when ignore_na=True
- Modified  to handle None/NA values in failure cases by converting them to False before inversion

## Testing
- All existing ibis tests pass (541 passed, 22 xfailed)
- Added test file for issue #2294 covering all scenarios