### PR TITLE
Pyspark: Added unique_values_eq builtin check 

### DIFF
--- a/pandera/backends/pyspark/builtin_checks.py
+++ b/pandera/backends/pyspark/builtin_checks.py
@@ -390,3 +390,32 @@ def str_length(
         cond = (str_len >= min_value) & (str_len <= max_value)
 
     return data.dataframe.filter(~cond).limit(1).count() == 0
+
+@register_builtin_check(
+    error="unique_values_eq({values})",
+)
+@register_input_datatypes(
+    acceptable_datatypes=convert_to_list(
+        ALL_NUMERIC_TYPE, ALL_DATE_TYPE, STRING_TYPE, BINARY_TYPE
+    )
+)
+def unique_values_eq(
+        data: PysparkDataframeColumnObject, values: Iterable
+) -> bool:
+    """Ensure that unique values in the data object contain all values.
+
+    Remember it can be a compute intensive check on large dataset. So, use it with caution.
+
+    .. note::
+        In contrast with :func:`isin`, this check makes sure that all the items
+        in the ``values`` iterable are contained within the series.
+
+    :param data: NamedTuple PysparkDataframeColumnObject contains the dataframe and column name for the check. The key
+        to access the dataframe is "dataframe", and the key to access the column name is "column_name".
+    :param values: The set of values that must be present. May be any iterable.
+    """
+    unique_values = {
+        row[data.column_name]
+        for row in data.dataframe.select(data.column_name).distinct().collect()
+    }
+    return unique_values == set(values)

--- a/tests/pyspark/test_pyspark_check.py
+++ b/tests/pyspark/test_pyspark_check.py
@@ -1888,3 +1888,146 @@ class TestCustomCheck(BaseClass):
             self.sample_numeric_data["test_fail_data"],
             IntegerType(),
         )
+
+
+class TestUniqueValuesEqCheck(BaseClass):
+    """This class is used to test the unique_values_eq check"""
+
+    sample_numeric_data = {
+        "test_pass_data": [("foo", 31), ("bar", 32)],
+        "test_fail_data": [("foo", 31), ("bar", 31)],  # Missing 32, only has 31
+        "test_expression": [31, 32],
+    }
+
+    sample_timestamp_data = {
+        "test_pass_data": [
+            ("foo", datetime.datetime(2020, 10, 1, 10, 0)),
+            ("bar", datetime.datetime(2020, 10, 2, 10, 0)),
+        ],
+        "test_fail_data": [
+            ("foo", datetime.datetime(2020, 10, 1, 10, 0)),
+            ("bar", datetime.datetime(2020, 10, 1, 10, 0)),  # Missing second date
+        ],
+        "test_expression": [
+            datetime.datetime(2020, 10, 1, 10, 0),
+            datetime.datetime(2020, 10, 2, 10, 0),
+        ],
+    }
+
+    sample_date_data = {
+        "test_pass_data": [
+            ("foo", datetime.date(2020, 10, 1)),
+            ("bar", datetime.date(2020, 10, 2)),
+        ],
+        "test_fail_data": [
+            ("foo", datetime.date(2020, 10, 1)),
+            ("bar", datetime.date(2020, 10, 1)),  # Missing second date
+        ],
+        "test_expression": [
+            datetime.date(2020, 10, 1),
+            datetime.date(2020, 10, 2),
+        ],
+    }
+
+    sample_string_data = {
+        "test_pass_data": [("foo", "b"), ("bar", "c")],
+        "test_fail_data": [("foo", "b"), ("bar", "b")],  # Missing 'c'
+        "test_expression": ["b", "c"],
+    }
+
+    sample_bolean_data = {
+        "test_pass_data": [("foo", [True]), ("bar", [True])],
+        "test_expression": [True],
+    }
+
+    def pytest_generate_tests(self, metafunc):
+        """This function passes the parameter for each function based on parameter form get_data_param function"""
+        # called once per each test function
+        funcarglist = self.get_data_param()[metafunc.function.__name__]
+        argnames = sorted(funcarglist[0])
+        metafunc.parametrize(
+            argnames,
+            [
+                [funcargs[name] for name in argnames]
+                for funcargs in funcarglist
+            ],
+        )
+
+    def get_data_param(self):
+        """Generate the params which will be used to test this function. All the acceptable
+        data types would be tested"""
+        return {
+            "test_unique_values_eq_check": [
+                {"datatype": LongType(), "data": self.sample_numeric_data},
+                {"datatype": IntegerType(), "data": self.sample_numeric_data},
+                {"datatype": ByteType(), "data": self.sample_numeric_data},
+                {"datatype": ShortType(), "data": self.sample_numeric_data},
+                {
+                    "datatype": DoubleType(),
+                    "data": self.convert_numeric_data(
+                        self.sample_numeric_data, "double"
+                    ),
+                },
+                {
+                    "datatype": TimestampType(),
+                    "data": self.sample_timestamp_data,
+                },
+                {"datatype": DateType(), "data": self.sample_date_data},
+                {
+                    "datatype": DecimalType(),
+                    "data": self.convert_numeric_data(
+                        self.sample_numeric_data, "decimal"
+                    ),
+                },
+                {
+                    "datatype": FloatType(),
+                    "data": self.convert_numeric_data(
+                        self.sample_numeric_data, "float"
+                    ),
+                },
+                {"datatype": StringType(), "data": self.sample_string_data},
+            ],
+            "test_failed_unaccepted_datatypes": [
+                {"datatype": BooleanType(), "data": self.sample_bolean_data},
+                {
+                    "datatype": ArrayType(StringType()),
+                    "data": self.sample_array_data,
+                },
+                {
+                    "datatype": MapType(StringType(), StringType()),
+                    "data": self.sample_map_data,
+                },
+            ],
+        }
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_unique_values_eq_check(
+        self, spark_session, datatype, data, request
+    ) -> None:
+        """Test the Check to see if all unique values match the defined values exactly"""
+        spark = request.getfixturevalue(spark_session)
+        self.check_function(
+            spark,
+            pa.Check.unique_values_eq,
+            data["test_pass_data"],
+            data["test_fail_data"],
+            datatype,
+            data["test_expression"],
+        )
+
+    @validate_scope(scope=ValidationScope.DATA)
+    def test_failed_unaccepted_datatypes(
+        self, spark_session, datatype, data, request
+    ) -> None:
+        """Test the Check to see if error is raised for datatypes which are not accepted for this function"""
+        spark = request.getfixturevalue(spark_session)
+        with pytest.raises(TypeError):
+            self.check_function(
+                spark,
+                pa.Check.unique_values_eq,
+                data["test_pass_data"],
+                None,
+                datatype,
+                data["test_expression"],
+            )
+


### PR DESCRIPTION
This change ensures that validation for unique values in the Pyspark data object is checked without any errors. "unique_values_eq" builtin check has been added which was missing.

Fixes : #2299 

Now it is able to validate the values.

```
{
    "DATA": {
        "DATAFRAME_CHECK": [
            {
                "schema": "PanderaSchema",
                "column": "blah_not_foo",
                "check": "unique_values_eq([1, 3])",
                "error": "<Schema Column(name=blah_not_foo, type=DataType(IntegerType()))> failed validation unique_values_eq([1, 3])"
            }
        ]
    }
}
```

For valid scenario - 

```
class PanderaSchema(DataFrameModel):
    id: T.IntegerType() = pa.Field(gt=5)
    price: T.DecimalType(20, 5) = pa.Field()
    blah_not_foo: T.IntegerType() = pa.Field(unique_values_eq=[1, 3])

data = [
    (5333333,  Decimal(44.4), 1),
    (151111,  Decimal(99.0), 3),
]

spark_schema = T.StructType(
    [
        T.StructField("id", T.IntegerType(), False),
        T.StructField("price", T.DecimalType(20, 5), False),
        T.StructField("blah_not_foo", T.IntegerType(), False)
    ]
)
df = spark.createDataFrame(data, spark_schema)
df.show()

df_out = PanderaSchema.validate(check_obj=df)
df_out

import json

df_out_errors = df_out.pandera.errors
print(df_out)
print(json.dumps(dict(df_out_errors), indent=4))


Output - 

+-------+--------+------------+
|     id|   price|blah_not_foo|
+-------+--------+------------+
|5333333|44.40000|           1|
| 151111|99.00000|           3|
+-------+--------+------------+

DataFrame[id: int, price: decimal(20,5), blah_not_foo: int]
{}
```