### PR TITLE
fix(dataframe-model): preserve Annotated Field metadata in DataFrameModel

### DIFF
--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -65,14 +65,36 @@ GENERIC_SCHEMA_CACHE: dict[
 
 
 def get_dtype_kwargs(annotation: AnnotationInfo) -> dict[str, Any]:
-    sig = inspect.signature(annotation.arg)  # type: ignore
+    metadata = tuple(
+        item
+        for item in (annotation.metadata or ())
+        if not isinstance(item, FieldInfo)
+    )
+    try:
+        sig = inspect.signature(annotation.arg)  # type: ignore
+    except (TypeError, ValueError):
+        return {}
     dtype_arg_names = list(sig.parameters.keys())
-    if len(annotation.metadata) != len(dtype_arg_names):  # type: ignore
+    if len(metadata) != len(dtype_arg_names):
         raise TypeError(
             f"Annotation '{annotation.arg.__name__}' requires "  # type: ignore
             + f"all positional arguments {dtype_arg_names}."
         )
-    return dict(zip(dtype_arg_names, annotation.metadata))  # type: ignore
+    return dict(zip(dtype_arg_names, metadata))
+
+
+def _get_field_from_annotation(annotation: Any) -> FieldInfo | None:
+    metadata = getattr(annotation, "__metadata__", ())
+    field_infos = [item for item in metadata if isinstance(item, FieldInfo)]
+    if field_infos:
+        return copy.deepcopy(field_infos[0])
+
+    for arg in typing.get_args(annotation):
+        field_info = _get_field_from_annotation(arg)
+        if field_info is not None:
+            return field_info
+
+    return None
 
 
 def _is_field(name: str) -> bool:
@@ -259,10 +281,9 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
         super().__init_subclass__(**kwargs)
         subclass_annotations = inspect.get_annotations(cls)
 
-        for field_name in subclass_annotations.keys():
+        for field_name, annotation in subclass_annotations.items():
             if _is_field(field_name) and field_name not in cls.__dict__:
-                # Field omitted
-                field = Field()
+                field = _get_field_from_annotation(annotation) or Field()
                 field.__set_name__(cls, field_name)
                 setattr(cls, field_name, field)
 

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -6,7 +6,7 @@ import runpy
 from collections.abc import Iterable
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Generic, Optional, TypeVar
+from typing import Annotated, Any, Generic, Optional, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -116,6 +116,42 @@ def test_schema_with_bare_types():
     )
 
     assert expected == Model.to_schema()
+
+
+def test_annotated_field_metadata_with_omitted_field() -> None:
+    class Model(pa.DataFrameModel):
+        a: Annotated[
+            int,
+            pa.Field(
+                title="A",
+                description="annotated description",
+                unique=True,
+            ),
+        ]
+
+    schema = Model.to_schema()
+
+    assert schema.columns["a"].title == "A"
+    assert schema.columns["a"].description == "annotated description"
+    assert schema.columns["a"].unique
+
+
+def test_annotated_dtype_with_annotated_field_metadata() -> None:
+    class Model(pa.DataFrameModel):
+        a: Series[
+            Annotated[
+                pd.DatetimeTZDtype,
+                "ns",
+                "UTC",
+                pa.Field(description="annotated dtype description"),
+            ]
+        ]
+
+    schema = Model.to_schema()
+
+    expected_dtype = pa.Column(pd.DatetimeTZDtype("ns", "UTC")).dtype
+    assert schema.columns["a"].dtype == expected_dtype
+    assert schema.columns["a"].description == "annotated dtype description"
 
 
 def test_empty_schema() -> None:

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -6,7 +6,7 @@ import runpy
 from collections.abc import Iterable
 from copy import deepcopy
 from enum import Enum
-from typing import Annotated, Any, Generic, Optional, TypeVar
+from typing import Annotated, Any, Generic, Optional, TypeVar, cast
 
 import numpy as np
 import pandas as pd
@@ -16,9 +16,11 @@ from pandas._testing import assert_frame_equal
 import pandera.api.extensions as pax
 import pandera.pandas as pa
 from pandera.api.base.model import MetaModel
+from pandera.api.dataframe.model import get_dtype_kwargs
 from pandera.errors import SchemaError, SchemaInitError
 from pandera.typing import DataFrame, Index, Series, String
 from pandera.typing import pandas as pandas_typing
+from pandera.typing.common import AnnotationInfo
 
 
 def test_idempotent_magics() -> None:
@@ -152,6 +154,13 @@ def test_annotated_dtype_with_annotated_field_metadata() -> None:
     expected_dtype = pa.Column(pd.DatetimeTZDtype("ns", "UTC")).dtype
     assert schema.columns["a"].dtype == expected_dtype
     assert schema.columns["a"].description == "annotated dtype description"
+
+
+def test_get_dtype_kwargs_signature_failure_returns_empty_kwargs() -> None:
+    raw_annotation = cast(type, Annotated[type(None), "ignored"])
+    annotation = AnnotationInfo(raw_annotation)
+
+    assert get_dtype_kwargs(annotation) == {}
 
 
 def test_empty_schema() -> None:

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -6,6 +6,7 @@ import runpy
 from collections.abc import Iterable
 from copy import deepcopy
 from enum import Enum
+from types import SimpleNamespace
 from typing import Annotated, Any, Generic, Optional, TypeVar, cast
 
 import numpy as np
@@ -156,9 +157,21 @@ def test_annotated_dtype_with_annotated_field_metadata() -> None:
     assert schema.columns["a"].description == "annotated dtype description"
 
 
-def test_get_dtype_kwargs_signature_failure_returns_empty_kwargs() -> None:
-    raw_annotation = cast(type, Annotated[type(None), "ignored"])
-    annotation = AnnotationInfo(raw_annotation)
+def test_get_dtype_kwargs_signature_failure_returns_empty_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    annotation = cast(
+        AnnotationInfo,
+        SimpleNamespace(arg=int, metadata=("ignored",)),
+    )
+
+    def fake_signature(_arg):
+        raise TypeError
+
+    monkeypatch.setattr(
+        "pandera.api.dataframe.model.inspect.signature",
+        fake_signature,
+    )
 
     assert get_dtype_kwargs(annotation) == {}
 


### PR DESCRIPTION
## Description:

Issue #2110 reported that metadata provided through typing.Annotated[..., pa.Field(...)] could be dropped when a DataFrameModel field omitted explicit assignment, because __init_subclass__ created a default empty Field() instead of reusing annotation metadata.

This PR updates shared DataFrameModel annotation handling to preserve FieldInfo from Annotated metadata when initializing omitted fields. It also updates dtype-kwargs extraction to ignore FieldInfo metadata entries, so mixed Annotated[pd.DatetimeTZDtype, ..., pa.Field(...)] annotations continue to parse dtype args correctly.

It adds regression tests that cover:
- metadata propagation from omitted Annotated[..., pa.Field(...)] fields
- mixed Annotated extension dtype parameters plus pa.Field(...) metadata

Closes #2110.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using prek run --files pandera/api/dataframe/model.py tests/pandas/test_model.py.
- [x] I have run focused tests in WSL using pytest -q tests/pandas/test_model.py -k 'annotated_field_metadata or annotated_dtype_with_annotated_field_metadata' and pytest -q tests/pandas/test_typing.py -k 'annotated_dtype or invalid_annotated_dtype or redundant_field'.

#### The validation screenshots of the tests run, locally on WSL:

<img width="2312" height="1173" alt="image" src="https://github.com/user-attachments/assets/a235553a-887d-412f-bbd3-26e3a3bf68ad" />