### PR TITLE
Fix mypy type hinting for Polars DataFrameModel field annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ warn_unused_configs = True
 show_error_codes = True
 exclude=(?x)(
     ^tests/mypy/pandas_modules
+  | ^tests/mypy/polars_modules
     | ^pandera/engines/pyspark_engine
     | ^pandera/api/pyspark
     | ^pandera/backends/pyspark

--- a/pandera/mypy.py
+++ b/pandera/mypy.py
@@ -23,15 +23,18 @@ from mypy.types import CallableType, Instance, UnionType
 DATAFRAMEMODEL_FULLNAMES = {
     "pandera.api.dataframe.model.DataFrameModel",
     "pandera.api.pandas.model.DataFrameModel",
+    "pandera.api.polars.model.DataFrameModel",
     "pandera.api.geopandas.GeoDataFrameModel",
     "pandera.api.geopandas.model.GeoDataFrameModel",
     "pandera.pandas.DataFrameModel",
+    "pandera.polars.DataFrameModel",
     "pandera.geopandas.GeoDataFrameModel",
     "pandera._pandas_deprecated.DataFrameModel",
 }
 PANDERA_PANDAS_DATAFRAME_FULLNAME = "pandera.typing.pandas.DataFrame"
 PANDERA_PANDAS_SERIES_FULLNAME = "pandera.typing.pandas.Series"
 PANDERA_PANDAS_INDEX_FULLNAME = "pandera.typing.pandas.Index"
+PANDERA_POLARS_SERIES_FULLNAME = "pandera.typing.polars.Series"
 PANDERA_MODIN_SERIES_FULLNAME = "pandera.typing.modin.Series"
 PANDERA_MODIN_INDEX_FULLNAME = "pandera.typing.modin.Index"
 PANDERA_DASK_SERIES_FULLNAME = "pandera.typing.dask.Series"
@@ -44,6 +47,7 @@ PANDAS_CONCAT = "pandas.core.reshape.concat.concat"
 FIELD_GENERICS_FULLNAMES = {
     PANDERA_PANDAS_SERIES_FULLNAME,
     PANDERA_PANDAS_INDEX_FULLNAME,
+    PANDERA_POLARS_SERIES_FULLNAME,
     PANDERA_MODIN_SERIES_FULLNAME,
     PANDERA_MODIN_INDEX_FULLNAME,
     PANDERA_DASK_SERIES_FULLNAME,

--- a/tests/mypy/polars_modules/__init__.py
+++ b/tests/mypy/polars_modules/__init__.py
@@ -1,0 +1,1 @@
+"""Polars mypy test modules."""

--- a/tests/mypy/polars_modules/polars_model_column_attrs.py
+++ b/tests/mypy/polars_modules/polars_model_column_attrs.py
@@ -1,0 +1,31 @@
+# pylint: skip-file
+"""Regression coverage for Polars DataFrameModel class attribute column names."""
+
+import pandera.polars as pa
+from pandera.typing.polars import Series
+
+
+class SchemaWithSeries(pa.DataFrameModel):
+    a: Series[int]
+    b: Series[float]
+
+
+class SchemaWithBareTypes(pa.DataFrameModel):
+    x: int
+    y: float
+
+
+def print_string(string: str):
+    """Function that expects a string argument."""
+    print(f"type: {type(string)}, value: {string}")
+
+
+# These should all work without mypy errors when the plugin is enabled
+series_columns: list[str] = [SchemaWithSeries.a, SchemaWithSeries.b]
+bare_columns: list[str] = [SchemaWithBareTypes.x, SchemaWithBareTypes.y]
+
+# These should work with the plugin enabled
+print_string(SchemaWithBareTypes.x)
+print_string(SchemaWithBareTypes.y)
+print_string(SchemaWithSeries.a)
+print_string(SchemaWithSeries.b)

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -45,6 +45,8 @@ POLARS_MODEL_COLUMN_ATTRS_ERRORS = [
 )
 def test_polars_mypy_typing(capfd, module, config, expected_errors) -> None:
     """Test that mypy plugin correctly handles Polars DataFrameModel field types."""
+    pytest.importorskip("polars")
+    
     cache_dir = str(
         test_module_dir
         / ".mypy_cache"

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -27,6 +27,8 @@ def _get_mypy_errors(
 
 
 POLARS_MODEL_COLUMN_ATTRS_ERRORS = [
+    'List item 0 has incompatible type "int"; expected "str"',
+    'List item 1 has incompatible type "float"; expected "str"',
     'Argument 1 to "print_string" has incompatible type "int"; expected "str"',
     'Argument 1 to "print_string" has incompatible type "float"; expected "str"',
 ]
@@ -40,7 +42,7 @@ POLARS_MODEL_COLUMN_ATTRS_ERRORS = [
             "no_plugin.ini",
             POLARS_MODEL_COLUMN_ATTRS_ERRORS,
         ],
-        ["polars_model_column_attrs.py", "plugin_mypy.ini", []],
+        ["polars_model_column_attrs.py", "plugin_mypy_silent.ini", []],
     ],
 )
 def test_polars_mypy_typing(module, config, expected_errors) -> None:

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -16,11 +16,11 @@ test_module_dir = Path(os.path.dirname(__file__))
 
 def _get_mypy_errors(
     module_name: str,
-    stdout,
+    output,
 ):
     """Parse mypy output and return list of errors."""
     errors = []
-    for line in stdout.split("\n"):
+    for line in output.split("\n"):
         if module_name in line and "error:" in line:
             errors.append(line)
     return errors
@@ -43,7 +43,7 @@ POLARS_MODEL_COLUMN_ATTRS_ERRORS = [
         ["polars_model_column_attrs.py", "plugin_mypy.ini", []],
     ],
 )
-def test_polars_mypy_typing(capfd, module, config, expected_errors) -> None:
+def test_polars_mypy_typing(module, config, expected_errors) -> None:
     """Test that mypy plugin correctly handles Polars DataFrameModel field types."""
     pytest.importorskip("polars")
     
@@ -64,11 +64,11 @@ def test_polars_mypy_typing(capfd, module, config, expected_errors) -> None:
         "--show-error-codes",
     ]
     # pylint: disable=subprocess-run-check
-    result = subprocess.run(commands, text=True)
+    result = subprocess.run(commands, text=True, capture_output=True)
     # NOTE: mypy return code is 0 if no errors were found, 1 if errors were found
     # or 2 if there was a failure in checking
     assert result.returncode in (0, 1)
-    resulting_errors = _get_mypy_errors(module, capfd.readouterr().out)
+    resulting_errors = _get_mypy_errors(module, result.stderr)
 
     assert len(expected_errors) == len(resulting_errors), (
         f"Expected {len(expected_errors)} errors but got {len(resulting_errors)}. "

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -1,4 +1,8 @@
-"""Unit tests for static type checking of polars schemas."""
+"""Test mypy static type checking for Polars DataFrameModel.
+
+This module uses subprocess and pytest to capture the output
+of calling mypy on the python modules in the tests/mypy/polars_modules folder.
+"""
 
 import os
 import subprocess
@@ -8,6 +12,68 @@ from pathlib import Path
 import pytest
 
 test_module_dir = Path(os.path.dirname(__file__))
+
+
+def _get_mypy_errors(
+    module_name: str,
+    stdout,
+):
+    """Parse mypy output and return list of errors."""
+    errors = []
+    for line in stdout.split("\n"):
+        if module_name in line and "error:" in line:
+            errors.append(line)
+    return errors
+
+
+POLARS_MODEL_COLUMN_ATTRS_ERRORS = [
+    'Argument 1 to "print_string" has incompatible type "int"; expected "str"',
+    'Argument 1 to "print_string" has incompatible type "float"; expected "str"',
+]
+
+
+@pytest.mark.parametrize(
+    ["module", "config", "expected_errors"],
+    [
+        [
+            "polars_model_column_attrs.py",
+            "no_plugin.ini",
+            POLARS_MODEL_COLUMN_ATTRS_ERRORS,
+        ],
+        ["polars_model_column_attrs.py", "plugin_mypy.ini", []],
+    ],
+)
+def test_polars_mypy_typing(capfd, module, config, expected_errors) -> None:
+    """Test that mypy plugin correctly handles Polars DataFrameModel field types."""
+    cache_dir = str(
+        test_module_dir
+        / ".mypy_cache"
+        / f"{module.replace('.', '_')}-{config.replace('.', '_')}"
+    )
+    commands = [
+        sys.executable,
+        "-m",
+        "mypy",
+        "--config-file",
+        str(test_module_dir / "config" / config),
+        str(test_module_dir / "polars_modules" / module),
+        "--cache-dir",
+        cache_dir,
+        "--show-error-codes",
+    ]
+    # pylint: disable=subprocess-run-check
+    result = subprocess.run(commands, text=True)
+    # NOTE: mypy return code is 0 if no errors were found, 1 if errors were found
+    # or 2 if there was a failure in checking
+    assert result.returncode in (0, 1)
+    resulting_errors = _get_mypy_errors(module, capfd.readouterr().out)
+
+    assert len(expected_errors) == len(resulting_errors), (
+        f"Expected {len(expected_errors)} errors but got {len(resulting_errors)}. "
+        f"Errors: {resulting_errors}"
+    )
+    for expected, error in zip(expected_errors, resulting_errors):
+        assert expected in error, f"Expected '{expected}' in error '{error}'"
 
 
 def test_mypy_polars_column_parametrized_dtypes() -> None:

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -68,7 +68,7 @@ def test_polars_mypy_typing(module, config, expected_errors) -> None:
     # NOTE: mypy return code is 0 if no errors were found, 1 if errors were found
     # or 2 if there was a failure in checking
     assert result.returncode in (0, 1)
-    resulting_errors = _get_mypy_errors(module, result.stderr)
+    resulting_errors = _get_mypy_errors(module, result.stdout)
 
     assert len(expected_errors) == len(resulting_errors), (
         f"Expected {len(expected_errors)} errors but got {len(resulting_errors)}. "

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -294,3 +294,31 @@ def test_dataframe_schema_with_tz_agnostic_dates(time_zone, data):
         if time_zone:
             with pytest.raises(SchemaError):
                 tz_sensitive_model.validate(lf)
+
+
+def test_model_field_access_returns_string():
+    """Test that accessing DataFrameModel fields returns column names as strings.
+    
+    Regression test for issue #2297.
+    """
+    from pandera.typing.polars import Series
+
+    class ModelWithSeries(DataFrameModel):
+        a: Series[int]
+        b: Series[float]
+
+    class ModelWithBareTypes(DataFrameModel):
+        x: int
+        y: float
+
+    # Both Series and bare type annotations should return strings
+    assert isinstance(ModelWithSeries.a, str)
+    assert isinstance(ModelWithSeries.b, str)
+    assert isinstance(ModelWithBareTypes.x, str)
+    assert isinstance(ModelWithBareTypes.y, str)
+
+    # Verify the actual column names
+    assert ModelWithSeries.a == "a"
+    assert ModelWithSeries.b == "b"
+    assert ModelWithBareTypes.x == "x"
+    assert ModelWithBareTypes.y == "y"


### PR DESCRIPTION
## Description:

Issue #2297 reported that mypy throws type hinting errors when using Polars DataFrameModel field names as strings with direct column type annotations. The runtime behavior was correct (field access returned strings), but mypy incorrectly inferred the type as the annotation type (like `float`) instead of `str`.

This issue was similar to #1681 and #2144, which were fixed for Pandas models in #2255. Though, the fix was not applied to Polars models.

This PR extends the mypy plugin to recognize Polars DataFrameModel and Series types, enabling the plugin to correctly treat field attributes as strings for type checking purposes.

## Changes Done:

- Updated `pandera/mypy.py` to add Polars specific type fullnames:
  - Added `pandera.api.polars.model.DataFrameModel` to `DATAFRAMEMODEL_FULLNAMES`
  - Added `pandera.polars.DataFrameModel` to `DATAFRAMEMODEL_FULLNAMES`
  - Added `pandera.typing.polars.Series` to `FIELD_GENERICS_FULLNAMES`

### Test Coverage:
- Added runtime regression test in `tests/polars/test_polars_model.py::test_model_field_access_returns_string`
- Added mypy static type checking test module `tests/mypy/polars_modules/polars_model_column_attrs.py`
- Added mypy test runner `tests/mypy/test_polars_static_type_checking.py`

Closes #2297.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have verified the mypy plugin correctly handles Polars DataFrameModel types.
- [x] I have added static type checking tests to prevent regression.
- [x] All changes follow the existing code style and conventions.

#### The validation screenshot of the tests run, locally on WSL:

<img width="2147" height="1355" alt="image" src="https://github.com/user-attachments/assets/c08303c7-c0d4-411a-9295-8053aac2a6d6" />


