### PR TITLE
docs: clarify required extra for data synthesis strategies

### DIFF
--- a/docs/source/data_synthesis_strategies.md
+++ b/docs/source/data_synthesis_strategies.md
@@ -19,6 +19,16 @@ is collected to create a data-generating strategy using
 [hypothesis](https://hypothesis.readthedocs.io/en/latest/), which is a
 property-based testing library.
 
+:::{note}
+The data synthesis feature requires a pandera installation with the
+`strategies` dependency set:
+
+`pip install 'pandera[strategies]'`
+
+The `hypotheses` dependency set is for pandera hypothesis checks and does
+not install the `hypothesis` library.
+:::
+
 ## Basic Usage
 
 Once you've defined a schema, it's easy to generate examples:


### PR DESCRIPTION
Issue #1649 reports the confusion between `hypotheses` and `strategies` extras when using data synthesis.

This PR updates the data synthesis documentation to explicitly state that data synthesis requires `pandera[strategies]`, and clarifies that `pandera[hypotheses]` is for pandera hypothesis checks and does not install the `hypothesis` library.

Closes #1649.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have kept the change minimal and docs only.
- [x] I have verified style consistency with existing docs note/extras patterns.
- [x] I reproduced the issue behavior in WSL.
- [x] I ran lint checks in WSL using `prek run --files docs/source/data_synthesis_strategies.md`.
- [x] I ran focused tests in WSL using `pytest -q tests/strategies/test_strategies.py -k "strategy" --maxfail=1`.

#### The validation screenshot of the test run, locally on WSL:

<img width="1555" height="1140" alt="image" src="https://github.com/user-attachments/assets/038c5e8a-7410-46b3-8906-9ca69d807493" />


**Note:** There were no test failures in that run. The four xfailed tests are expected failures that are already marked in the test suite, so they do not indicate a regression. The warnings are mostly pre existing Hypothesis, and pandas noise from the strategies tests, and a known truthiness warning around if strategy, that is separate from this docs only fix.