### PR TITLE
fix(strategies): use `is not None` for base-strategy guards (#2307)

### DIFF
--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -829,7 +829,7 @@ def field_element_strategy(
         the values of the data in the column/index.
     :returns: ``hypothesis`` strategy
     """
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The series strategy is a base strategy. You cannot specify the "
             "strategy argument to chain it to a parent strategy."
@@ -1052,7 +1052,7 @@ def dataframe_strategy(
             "`n_regex_columns` must be a positive integer, found: "
             f"{n_regex_columns}"
         )
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The dataframe strategy is a base strategy. You cannot specify "
             "the strategy argument to chain it to a parent strategy."
@@ -1263,7 +1263,7 @@ def multiindex_strategy(
     :returns: ``hypothesis`` strategy.
     """
 
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The dataframe strategy is a base strategy. You cannot specify "
             "the strategy argument to chain it to a parent strategy."

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -4,6 +4,7 @@
 import datetime
 import operator
 import re
+import warnings
 from collections.abc import Callable
 from typing import Any, Optional, cast
 from unittest.mock import MagicMock
@@ -712,6 +713,31 @@ def test_multiindex_example() -> None:
     for _ in range(10):
         example = multiindex.example()
         multiindex(pd.DataFrame(index=example))
+
+
+def test_base_strategy_guards_do_not_emit_hypothesis_warning():
+    """Regression test for #2307: the base-strategy guards in
+    series_strategy, dataframe_strategy, and multiindex_strategy must use
+    ``is not None`` rather than truthiness, so Hypothesis does not emit
+    ``HypothesisWarning: bool(...) is always True``.
+    """
+    data_type = pa.Int()
+    chained = strategies.pandas_dtype_strategy(data_type)
+
+    cases = [
+        lambda: strategies.series_strategy(data_type, strategy=chained),
+        lambda: strategies.dataframe_strategy(data_type, strategy=chained),
+        lambda: strategies.multiindex_strategy(data_type, strategy=chained),
+    ]
+    for call in cases:
+        with catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            with pytest.raises(pa.errors.BaseStrategyOnlyError):
+                call()
+        assert not any(
+            issubclass(w.category, hypothesis.errors.HypothesisWarning)
+            for w in recorded
+        ), [str(w.message) for w in recorded]
 
 
 @pytest.mark.parametrize("data_type", NULLABLE_DTYPES)


### PR DESCRIPTION
## Summary
- Fixes #2307. `series_strategy`, `dataframe_strategy`, and `multiindex_strategy` guarded against chained strategies with `if strategy:`, which Hypothesis warns about via `HypothesisWarning: bool(...) is always True, did you mean to draw a value?`.
- Replaced the three truthiness checks with explicit `is not None` checks.
- Added a regression test that calls all three entry points with a chained strategy and asserts the `BaseStrategyOnlyError` still raises **and** no `HypothesisWarning` is emitted.

Note: the issue calls out two locations (lines 832, 1055); a third instance of the same pattern exists in `multiindex_strategy` (line 1266) and is fixed here as well.

## Test plan
- [x] New test `test_base_strategy_guards_do_not_emit_hypothesis_warning` passes with the fix and fails without it (surfaces the exact `HypothesisWarning` from the issue).
- [x] `pytest tests/strategies/test_strategies.py -k "strategy"` — 454 passed, 4 xfailed, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)