### PR TITLE
fix(tests): drop deprecated axis=None from DataFrame.sum call (#2309)

### DIFF
--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -775,7 +775,7 @@ def test_check_nullable_dataframe_strategy(data_type, nullable, data):
     )
     example = data.draw(strat)
     if nullable:
-        assert example.isna().sum(axis=None).item() >= 0
+        assert example.isna().sum().item() >= 0
     else:
         assert example.notna().all(axis=None)
 


### PR DESCRIPTION
## Summary

Closes #2309.

`tests/strategies/test_strategies.py::test_check_nullable_dataframe_strategy` calls `example.isna().sum(axis=None).item()`, which emits a `FutureWarning` under pandas >= 2.1:

> The behavior of DataFrame.sum with axis=None is deprecated, in a future version this will reduce over both axes and return a scalar. To retain the old behavior, pass axis=0 (or do not pass axis).

The strategy under test only generates a single-column DataFrame (`columns={"col": pa.Column(...)}`), so dropping `axis=None` and relying on `.sum()`'s default (`axis=0`) returns the same scalar as before via `.item()`. No behavior change; warning eliminated.

The nearby `example.notna().all(axis=None)` on the next line was left alone — the deprecation is specific to `.sum` (NumPy-reduction ops), and `.all(axis=None)` does not emit a warning.

## Test plan

- [x] Reproduced the `FutureWarning` at `tests/strategies/test_strategies.py:778` under pandas 2.3.3 by running the single parameterized case with `-W error::FutureWarning` (fails before the change).
- [x] After the change, ran the full `test_check_nullable_dataframe_strategy` (56 parameterized cases) with `-W error::FutureWarning` under pandas 2.3.3 — all pass.