### PR TITLE
refactor(narwhals): make backend opt-in via config

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -234,10 +234,10 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
-  # The dataframe-extras jobs below install ONLY the library-native extras —
-  # narwhals is NOT installed here. This exercises the native pandera.polars and
-  # pandera.ibis backends. The `unit-tests-narwhals-backend` jobs below run the
-  # same test suites with narwhals co-installed so the narwhals backend is active.
+  # The dataframe-extras jobs below exercise the native pandera.polars and
+  # pandera.ibis backends (PANDERA_USE_NARWHALS_BACKEND is unset / False).
+  # The `unit-tests-narwhals-backend` jobs below run the same test suites with
+  # PANDERA_USE_NARWHALS_BACKEND=True so the narwhals backend is active.
 
   # test extras for popular dataframe libraries
   unit-tests-dataframe-extras:
@@ -327,9 +327,9 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
-  # Run tests/polars/ and tests/ibis/ with narwhals co-installed so the narwhals
-  # backend is active for those frame types. Tests that expose gaps in the narwhals
-  # backend should be marked xfail(condition=narwhals_installed) in the test files.
+  # Run tests/polars/ and tests/ibis/ with narwhals co-installed and
+  # PANDERA_USE_NARWHALS_BACKEND=True so the narwhals backend is active for those
+  # frame types. Tests that expose narwhals backend gaps should be marked xfail.
   unit-tests-narwhals-backend:
     name: >
       Unit Tests Narwhals Backend: python-${{ matrix.python-version }} (extra-${{ matrix.extra }})

--- a/noxfile.py
+++ b/noxfile.py
@@ -371,7 +371,8 @@ def tests_narwhals_backend(session: Session, extra: str) -> None:
     if not CI_RUN:
         args.append("--cov-report=html")
     args.append(path)
-    session.run("pytest", *args, env={"PANDERA_USE_NARWHALS_BACKEND": "True"})
+    env = {"PANDERA_USE_NARWHALS_BACKEND": "True"}
+    session.run("pytest", *args, env=env)
 
 
 @nox.session(venv_backend="uv", python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -283,6 +283,7 @@ def tests(
     if extra == "narwhals":
         # TEST-03: narwhals backend tests live under tests/backends/narwhals/
         test_dir = "backends/narwhals"
+        env["PANDERA_USE_NARWHALS_BACKEND"] = "True"
 
     if extra and extra.startswith("modin"):
         modin_split = extra.split("-")
@@ -326,14 +327,14 @@ def tests(
 @nox.session(venv_backend="uv", python=PYTHON_VERSIONS)
 @nox.parametrize("extra", ["polars", "ibis"])
 def tests_narwhals_backend(session: Session, extra: str) -> None:
-    """Run existing backend tests with narwhals co-installed.
+    """Run existing backend tests with narwhals co-installed and opt-in enabled.
 
-    Installs <extra> + narwhals so that register_polars_backends() /
-    register_ibis_backends() auto-detects narwhals and activates the narwhals
-    backend for that library's frame types. The existing tests/polars/ or
-    tests/ibis/ suite then exercises the narwhals backend rather than the
+    Installs <extra> + narwhals and sets PANDERA_USE_NARWHALS_BACKEND=True so
+    that register_polars_backends() / register_ibis_backends() activate the
+    narwhals backend for that library's frame types. The existing tests/polars/
+    or tests/ibis/ suite then exercises the narwhals backend rather than the
     native one. Tests that expose narwhals backend gaps should be marked
-    xfail(condition=narwhals_installed, ...) in the test files.
+    xfail in the test files.
     """
     deps = PYPROJECT["project"]["optional-dependencies"]
     requirements = [
@@ -370,7 +371,7 @@ def tests_narwhals_backend(session: Session, extra: str) -> None:
     if not CI_RUN:
         args.append("--cov-report=html")
     args.append(path)
-    session.run("pytest", *args)
+    session.run("pytest", *args, env={"PANDERA_USE_NARWHALS_BACKEND": "True"})
 
 
 @nox.session(venv_backend="uv", python=PYTHON_VERSIONS)

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -246,4 +246,4 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
         schema = copy.deepcopy(cls.to_schema())
         schema.coerce = True
         empty_df = schema.coerce_dtype(pl.DataFrame(schema=[*schema.columns]))
-        return DataFrame[Self](empty_df)
+        return DataFrame[Self](cast(pl.DataFrame, empty_df))

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -38,9 +38,7 @@ def register_ibis_backends(
                 "pip install 'pandera[narwhals]'"
             ) from exc
 
-        from pandera.backends.narwhals import (
-            builtin_checks,  # noqa — triggers Dispatcher registration
-        )
+        import pandera.backends.narwhals.builtin_checks  # noqa: F401
         from pandera.backends.narwhals.checks import NarwhalsCheckBackend
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
@@ -51,7 +49,7 @@ def register_ibis_backends(
         Check.register_backend(ibis.Column, NarwhalsCheckBackend)
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
     else:
-        from pandera.backends.ibis import builtin_checks  # noqa
+        import pandera.backends.ibis.builtin_checks  # noqa: F401
         from pandera.backends.ibis.checks import IbisCheckBackend
         from pandera.backends.ibis.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.ibis.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -16,7 +16,9 @@ def register_ibis_backends(
     registers the native Ibis backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
-    validate() calls.
+    validate() calls. The backend choice is fixed at first call — programmatic
+    changes to ``CONFIG.use_narwhals_backend`` after registration require
+    ``register_ibis_backends.cache_clear()`` to take effect.
 
     This function is called at schema initialization in the _register_*_backends
     method.
@@ -27,7 +29,14 @@ def register_ibis_backends(
     from pandera.config import CONFIG
 
     if CONFIG.use_narwhals_backend:
-        import narwhals.stable.v1 as nw
+        try:
+            import narwhals.stable.v1 as nw
+        except ImportError as exc:
+            raise ImportError(
+                "PANDERA_USE_NARWHALS_BACKEND is enabled but the 'narwhals' "
+                "package is not installed. Install it with: "
+                "pip install 'pandera[narwhals]'"
+            ) from exc
 
         from pandera.backends.narwhals import (
             builtin_checks,  # noqa — triggers Dispatcher registration

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -1,6 +1,5 @@
 """Register Ibis backends."""
 
-import warnings
 from functools import lru_cache
 
 import ibis
@@ -12,10 +11,9 @@ def register_ibis_backends(
 ):
     """Register backends for Ibis Table types.
 
-    Auto-detects Narwhals: if Narwhals is installed, registers Narwhals backends
-    (NarwhalsCheckBackend, Narwhals ColumnBackend, Narwhals DataFrameSchemaBackend)
-    and emits a UserWarning. If Narwhals is not installed, registers the native
-    Ibis backends.
+    Uses the Narwhals backends when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
+    ``pandera.config.CONFIG.use_narwhals_backend`` is ``True``); otherwise
+    registers the native Ibis backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
     validate() calls.
@@ -26,9 +24,10 @@ def register_ibis_backends(
     from pandera.api.checks import Check
     from pandera.api.ibis.components import Column
     from pandera.api.ibis.container import DataFrameSchema
+    from pandera.config import CONFIG
 
-    try:
-        import narwhals.stable.v1 as nw  # noqa: F401
+    if CONFIG.use_narwhals_backend:
+        import narwhals.stable.v1 as nw
 
         from pandera.backends.narwhals import (
             builtin_checks,  # noqa — triggers Dispatcher registration
@@ -37,20 +36,13 @@ def register_ibis_backends(
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
 
-        warnings.warn(
-            "Narwhals is installed. Pandera is using the experimental Narwhals backends "
-            "for Ibis Tables. These backends may change in future versions.",
-            UserWarning,
-            stacklevel=2,
-        )
-
         DataFrameSchema.register_backend(ibis.Table, DataFrameSchemaBackend)
         Column.register_backend(ibis.Table, ColumnBackend)
         Check.register_backend(ibis.Table, NarwhalsCheckBackend)
         Check.register_backend(ibis.Column, NarwhalsCheckBackend)
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
-    except ImportError:
-        from pandera.backends.ibis import builtin_checks  # type: ignore[no-redef]  # noqa
+    else:
+        from pandera.backends.ibis import builtin_checks  # noqa
         from pandera.backends.ibis.checks import IbisCheckBackend
         from pandera.backends.ibis.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.ibis.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -49,7 +49,7 @@ def register_ibis_backends(
         Check.register_backend(ibis.Column, NarwhalsCheckBackend)
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
     else:
-        import pandera.backends.ibis.builtin_checks  # noqa: F401
+        import pandera.backends.ibis.builtin_checks  # noqa: F401, I001
         from pandera.backends.ibis.checks import IbisCheckBackend
         from pandera.backends.ibis.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.ibis.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -33,7 +33,7 @@ def register_ibis_backends(
             import narwhals.stable.v1 as nw
         except ImportError as exc:
             raise ImportError(
-                "PANDERA_USE_NARWHALS_BACKEND is enabled but the 'narwhals' "
+                "The Narwhals backend is enabled but the 'narwhals' "
                 "package is not installed. Install it with: "
                 "pip install 'pandera[narwhals]'"
             ) from exc

--- a/pandera/backends/narwhals/register.py
+++ b/pandera/backends/narwhals/register.py
@@ -1,6 +1,8 @@
 """Narwhals backend registration.
 
-Registration of Narwhals backends for Polars frame types is handled by
-pandera.backends.polars.register.register_polars_backends(), which
-auto-detects Narwhals at registration time.
+Registration of Narwhals backends for Polars and Ibis frame types is handled by
+pandera.backends.polars.register.register_polars_backends() and
+pandera.backends.ibis.register.register_ibis_backends() when
+PANDERA_USE_NARWHALS_BACKEND=True (or pandera.config.CONFIG.use_narwhals_backend
+is True).
 """

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -47,7 +47,7 @@ def register_polars_backends(
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
         Check.register_backend(nw.DataFrame, NarwhalsCheckBackend)
     else:
-        import pandera.backends.polars.builtin_checks  # noqa: F401
+        import pandera.backends.polars.builtin_checks  # noqa: F401, I001
         from pandera.backends.polars.checks import PolarsCheckBackend
         from pandera.backends.polars.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.polars.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -35,9 +35,7 @@ def register_polars_backends(
                 "pip install 'pandera[narwhals]'"
             ) from exc
 
-        from pandera.backends.narwhals import (
-            builtin_checks,  # noqa — triggers Dispatcher registration for NarwhalsData
-        )
+        import pandera.backends.narwhals.builtin_checks  # noqa: F401
         from pandera.backends.narwhals.checks import NarwhalsCheckBackend
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
@@ -49,7 +47,7 @@ def register_polars_backends(
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
         Check.register_backend(nw.DataFrame, NarwhalsCheckBackend)
     else:
-        from pandera.backends.polars import builtin_checks  # noqa
+        import pandera.backends.polars.builtin_checks  # noqa: F401
         from pandera.backends.polars.checks import PolarsCheckBackend
         from pandera.backends.polars.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.polars.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -16,7 +16,9 @@ def register_polars_backends(
     registers the native Polars backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
-    validate() calls.
+    validate() calls. The backend choice is fixed at first call — programmatic
+    changes to ``CONFIG.use_narwhals_backend`` after registration require
+    ``register_polars_backends.cache_clear()`` to take effect.
     """
     from pandera.api.checks import Check
     from pandera.api.polars.components import Column
@@ -24,7 +26,14 @@ def register_polars_backends(
     from pandera.config import CONFIG
 
     if CONFIG.use_narwhals_backend:
-        import narwhals.stable.v1 as nw
+        try:
+            import narwhals.stable.v1 as nw
+        except ImportError as exc:
+            raise ImportError(
+                "PANDERA_USE_NARWHALS_BACKEND is enabled but the 'narwhals' "
+                "package is not installed. Install it with: "
+                "pip install 'pandera[narwhals]'"
+            ) from exc
 
         from pandera.backends.narwhals import (
             builtin_checks,  # noqa — triggers Dispatcher registration for NarwhalsData

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -30,7 +30,7 @@ def register_polars_backends(
             import narwhals.stable.v1 as nw
         except ImportError as exc:
             raise ImportError(
-                "PANDERA_USE_NARWHALS_BACKEND is enabled but the 'narwhals' "
+                "The Narwhals backend is enabled but the 'narwhals' "
                 "package is not installed. Install it with: "
                 "pip install 'pandera[narwhals]'"
             ) from exc

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -1,6 +1,5 @@
 """Register polars backends."""
 
-import warnings
 from functools import lru_cache
 
 import polars as pl
@@ -12,10 +11,9 @@ def register_polars_backends(
 ):
     """Register backends for Polars frame types.
 
-    Auto-detects Narwhals: if Narwhals is installed, registers Narwhals backends
-    (NarwhalsCheckBackend, Narwhals ColumnBackend, Narwhals DataFrameSchemaBackend)
-    and emits a UserWarning. If Narwhals is not installed, registers the native
-    Polars backends.
+    Uses the Narwhals backends when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
+    ``pandera.config.CONFIG.use_narwhals_backend`` is ``True``); otherwise
+    registers the native Polars backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
     validate() calls.
@@ -23,8 +21,9 @@ def register_polars_backends(
     from pandera.api.checks import Check
     from pandera.api.polars.components import Column
     from pandera.api.polars.container import DataFrameSchema
+    from pandera.config import CONFIG
 
-    try:
+    if CONFIG.use_narwhals_backend:
         import narwhals.stable.v1 as nw
 
         from pandera.backends.narwhals import (
@@ -34,21 +33,14 @@ def register_polars_backends(
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
 
-        warnings.warn(
-            "Narwhals is installed. Pandera is using the experimental Narwhals backends "
-            "for Polars DataFrames. These backends may change in future versions.",
-            UserWarning,
-            stacklevel=2,
-        )
-
         DataFrameSchema.register_backend(pl.LazyFrame, DataFrameSchemaBackend)
         DataFrameSchema.register_backend(pl.DataFrame, DataFrameSchemaBackend)
         Column.register_backend(pl.LazyFrame, ColumnBackend)
         Check.register_backend(pl.LazyFrame, NarwhalsCheckBackend)
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
         Check.register_backend(nw.DataFrame, NarwhalsCheckBackend)
-    except ImportError:
-        from pandera.backends.polars import builtin_checks  # type: ignore[no-redef]  # noqa
+    else:
+        from pandera.backends.polars import builtin_checks  # noqa
         from pandera.backends.polars.checks import PolarsCheckBackend
         from pandera.backends.polars.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.polars.container import DataFrameSchemaBackend  # type: ignore[assignment]

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -35,6 +35,7 @@ class PanderaConfig:
     export PANDERA_VALIDATION_DEPTH=DATA_ONLY
     export PANDERA_CACHE_DATAFRAME=True
     export PANDERA_KEEP_CACHED_DATAFRAME=True
+    export PANDERA_USE_NARWHALS_BACKEND=True
     export SILENCE_WARNING_PYDANTIC_MODEL=true
     """
 
@@ -46,6 +47,7 @@ class PanderaConfig:
     validation_depth: ValidationDepth | None = None
     cache_dataframe: bool = False
     keep_cached_dataframe: bool = False
+    use_narwhals_backend: bool = False
     silenced_warnings: list[str] = field(default_factory=list)
 
     def is_warning_silenced(self, warning_name: str) -> bool:
@@ -83,12 +85,16 @@ def _config_from_env_vars():
     keep_cached_dataframe = (
         os.environ.get("PANDERA_KEEP_CACHED_DATAFRAME", "False") in _TRUTHY
     )
+    use_narwhals_backend = (
+        os.environ.get("PANDERA_USE_NARWHALS_BACKEND", "False") in _TRUTHY
+    )
 
     return PanderaConfig(
         validation_enabled=validation_enabled,
         validation_depth=validation_depth,
         cache_dataframe=cache_dataframe,
         keep_cached_dataframe=keep_cached_dataframe,
+        use_narwhals_backend=use_narwhals_backend,
         silenced_warnings=_silenced_warnings_from_env(),
     )
 

--- a/tests/backends/narwhals/conftest.py
+++ b/tests/backends/narwhals/conftest.py
@@ -2,22 +2,19 @@
 
 CI Matrix (TEST-01, TEST-02, TEST-03):
 
-- tests/polars/ runs WITHOUT narwhals installed (CI job: unit-tests-dataframe-extras,
-  extra=polars). Guarded by tests/polars/conftest.py which re-registers the native
-  polars backend at session start (see TEST-01 in that file).
-- tests/ibis/ runs WITHOUT narwhals installed (CI job: unit-tests-dataframe-extras,
-  extra=ibis). Guarded by tests/ibis/conftest.py.
+- tests/polars/ and tests/ibis/ run with PANDERA_USE_NARWHALS_BACKEND unset
+  (defaults to False), so the native polars/ibis backends are used regardless
+  of whether narwhals is installed.
 - tests/backends/narwhals/ (this directory) runs WITH narwhals + polars + ibis all
-  installed together (CI job: unit-tests-narwhals, extra=narwhals). The
-  `make_narwhals_frame` fixture below parametrizes every test across the three
-  supported native frame types (pl.DataFrame, pl.LazyFrame, ibis.Table) so each
-  test runs 3 times and no frame type is silently skipped (TEST-02).
+  installed together and PANDERA_USE_NARWHALS_BACKEND=True
+  (CI job: unit-tests-narwhals, extra=narwhals). The `make_narwhals_frame` fixture
+  below parametrizes every test across the three supported native frame types
+  (pl.DataFrame, pl.LazyFrame, ibis.Table) so each test runs 3 times and no frame
+  type is silently skipped (TEST-02).
 
 See .github/workflows/ci-tests.yml for the full matrix and .planning/REQUIREMENTS.md
 for TEST-01, TEST-02, and TEST-03 definitions.
 """
-
-import warnings
 
 import narwhals.stable.v1 as nw
 import polars as pl
@@ -25,27 +22,25 @@ import pytest
 
 
 @pytest.fixture(autouse=True, scope="module")
-def _suppress_narwhals_warning():
-    """Initialise narwhals backends and suppress the auto-activation UserWarning.
+def _ensure_narwhals_backends_registered():
+    """Initialise narwhals backends before each test module in this directory.
 
-    Calls register_polars_backends() once per module so that:
+    Clears the lru_cache on the register functions and re-registers so that:
     - builtin_checks side-effect runs (populates Dispatcher._function_registry)
     - NarwhalsCheckBackend, ColumnBackend, DataFrameSchemaBackend are registered
     - Tests that call NarwhalsCheckBackend directly do not need to trigger
       schema.validate() first.
 
-    UserWarning is suppressed to keep test output clean.
+    Requires PANDERA_USE_NARWHALS_BACKEND=True (set by the nox session).
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        from pandera.backends.ibis.register import register_ibis_backends
-        from pandera.backends.polars.register import register_polars_backends
+    from pandera.backends.ibis.register import register_ibis_backends
+    from pandera.backends.polars.register import register_polars_backends
 
-        register_polars_backends.cache_clear()
-        register_ibis_backends.cache_clear()
-        register_polars_backends()
-        register_ibis_backends()
-        yield
+    register_polars_backends.cache_clear()
+    register_ibis_backends.cache_clear()
+    register_polars_backends()
+    register_ibis_backends()
+    yield
 
 
 @pytest.fixture(

--- a/tests/backends/narwhals/test_container.py
+++ b/tests/backends/narwhals/test_container.py
@@ -154,7 +154,7 @@ def test_polars_backends_registered():
 # ---------------------------------------------------------------------------
 
 
-def test_narwhals_activated_when_opted_in(monkeypatch):
+def test_polars_narwhals_activated_when_opted_in(monkeypatch, request):
     """register_polars_backends() registers narwhals backends when opt-in is enabled."""
     from pandera.backends.narwhals.container import (
         DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
@@ -163,7 +163,7 @@ def test_narwhals_activated_when_opted_in(monkeypatch):
     from pandera.config import CONFIG
 
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
-    monkeypatch.addfinalizer(register_polars_backends.cache_clear)
+    request.addfinalizer(register_polars_backends.cache_clear)
     register_polars_backends.cache_clear()
     register_polars_backends()
     backend = DataFrameSchema.get_backend(pl.DataFrame({}))
@@ -199,7 +199,7 @@ def test_failure_cases_is_native():
 # ---------------------------------------------------------------------------
 
 
-def test_ibis_narwhals_activated_when_opted_in(monkeypatch):
+def test_ibis_narwhals_activated_when_opted_in(monkeypatch, request):
     """register_ibis_backends() registers narwhals backends when opt-in is enabled."""
     import ibis
 
@@ -213,7 +213,7 @@ def test_ibis_narwhals_activated_when_opted_in(monkeypatch):
     from pandera.config import CONFIG
 
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
-    monkeypatch.addfinalizer(register_ibis_backends.cache_clear)
+    request.addfinalizer(register_ibis_backends.cache_clear)
     register_ibis_backends.cache_clear()
     register_ibis_backends()
     t = ibis.memtable({"a": [1, 2, 3]})

--- a/tests/backends/narwhals/test_container.py
+++ b/tests/backends/narwhals/test_container.py
@@ -195,7 +195,7 @@ def test_failure_cases_is_native():
 
 
 # ---------------------------------------------------------------------------
-# REGISTER-03: ibis.Table uses narwhals DataFrameSchemaBackend after registration
+# REGISTER-04 (ibis): narwhals backend activated when PANDERA_USE_NARWHALS_BACKEND=True
 # ---------------------------------------------------------------------------
 
 
@@ -219,6 +219,11 @@ def test_ibis_narwhals_activated_when_opted_in(monkeypatch, request):
     t = ibis.memtable({"a": [1, 2, 3]})
     backend = IbisDataFrameSchema.get_backend(t)
     assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
+
+
+# ---------------------------------------------------------------------------
+# REGISTER-03 (ibis): ibis.Table uses narwhals DataFrameSchemaBackend after registration
+# ---------------------------------------------------------------------------
 
 
 def test_ibis_backend_is_narwhals():

--- a/tests/backends/narwhals/test_container.py
+++ b/tests/backends/narwhals/test_container.py
@@ -160,12 +160,18 @@ def test_narwhals_activated_when_opted_in():
         DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
     )
     from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG
 
-    register_polars_backends.cache_clear()
-    register_polars_backends()
-    backend = DataFrameSchema.get_backend(pl.DataFrame({}))
-    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
-    register_polars_backends.cache_clear()  # restore clean state
+    original = CONFIG.use_narwhals_backend
+    try:
+        CONFIG.use_narwhals_backend = True
+        register_polars_backends.cache_clear()
+        register_polars_backends()
+        backend = DataFrameSchema.get_backend(pl.DataFrame({}))
+        assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
+    finally:
+        CONFIG.use_narwhals_backend = original
+        register_polars_backends.cache_clear()  # restore clean state
 
 
 # ---------------------------------------------------------------------------
@@ -208,13 +214,19 @@ def test_ibis_narwhals_activated_when_opted_in():
     from pandera.backends.narwhals.container import (
         DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
     )
+    from pandera.config import CONFIG
 
-    register_ibis_backends.cache_clear()
-    register_ibis_backends()
-    t = ibis.memtable({"a": [1, 2, 3]})
-    backend = IbisDataFrameSchema.get_backend(t)
-    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
-    register_ibis_backends.cache_clear()  # restore clean state
+    original = CONFIG.use_narwhals_backend
+    try:
+        CONFIG.use_narwhals_backend = True
+        register_ibis_backends.cache_clear()
+        register_ibis_backends()
+        t = ibis.memtable({"a": [1, 2, 3]})
+        backend = IbisDataFrameSchema.get_backend(t)
+        assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
+    finally:
+        CONFIG.use_narwhals_backend = original
+        register_ibis_backends.cache_clear()  # restore clean state
 
 
 def test_ibis_backend_is_narwhals():

--- a/tests/backends/narwhals/test_container.py
+++ b/tests/backends/narwhals/test_container.py
@@ -7,7 +7,7 @@ Tests cover:
   CONTAINER-04: lazy=True collects all errors before raising SchemaErrors
   REGISTER-01: register_polars_backends() is idempotent via lru_cache
   REGISTER-02: DataFrameSchema backend for pl.DataFrame/pl.LazyFrame is narwhals after registration
-  REGISTER-04: narwhals backend auto-activated when narwhals is installed
+  REGISTER-04: narwhals backend activated when PANDERA_USE_NARWHALS_BACKEND=True (opt-in)
   TEST-03: SchemaError.failure_cases is a native pl.DataFrame, not nw.DataFrame
 """
 
@@ -150,22 +150,21 @@ def test_polars_backends_registered():
 
 
 # ---------------------------------------------------------------------------
-# REGISTER-04: narwhals backend auto-activated when narwhals is installed
+# REGISTER-04: narwhals backend activated when PANDERA_USE_NARWHALS_BACKEND=True
 # ---------------------------------------------------------------------------
 
 
-def test_narwhals_auto_activated_when_installed():
-    """register_polars_backends() emits UserWarning when narwhals is installed."""
-    import warnings
-
+def test_narwhals_activated_when_opted_in():
+    """register_polars_backends() registers narwhals backends when opt-in is enabled."""
+    from pandera.backends.narwhals.container import (
+        DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
+    )
     from pandera.backends.polars.register import register_polars_backends
 
     register_polars_backends.cache_clear()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        register_polars_backends()
-        narwhals_warnings = [x for x in w if "Narwhals" in str(x.message)]
-        assert len(narwhals_warnings) == 1
+    register_polars_backends()
+    backend = DataFrameSchema.get_backend(pl.DataFrame({}))
+    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
     register_polars_backends.cache_clear()  # restore clean state
 
 
@@ -198,18 +197,23 @@ def test_failure_cases_is_native():
 # ---------------------------------------------------------------------------
 
 
-def test_ibis_narwhals_auto_activated():
-    """register_ibis_backends() emits UserWarning when narwhals is installed."""
-    import warnings
+def test_ibis_narwhals_activated_when_opted_in():
+    """register_ibis_backends() registers narwhals backends when opt-in is enabled."""
+    import ibis
 
+    from pandera.api.ibis.container import (
+        DataFrameSchema as IbisDataFrameSchema,
+    )
     from pandera.backends.ibis.register import register_ibis_backends
+    from pandera.backends.narwhals.container import (
+        DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
+    )
 
     register_ibis_backends.cache_clear()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        register_ibis_backends()
-        narwhals_warnings = [x for x in w if "Narwhals" in str(x.message)]
-        assert len(narwhals_warnings) == 1
+    register_ibis_backends()
+    t = ibis.memtable({"a": [1, 2, 3]})
+    backend = IbisDataFrameSchema.get_backend(t)
+    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
     register_ibis_backends.cache_clear()  # restore clean state
 
 

--- a/tests/backends/narwhals/test_container.py
+++ b/tests/backends/narwhals/test_container.py
@@ -154,7 +154,7 @@ def test_polars_backends_registered():
 # ---------------------------------------------------------------------------
 
 
-def test_narwhals_activated_when_opted_in():
+def test_narwhals_activated_when_opted_in(monkeypatch):
     """register_polars_backends() registers narwhals backends when opt-in is enabled."""
     from pandera.backends.narwhals.container import (
         DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
@@ -162,16 +162,12 @@ def test_narwhals_activated_when_opted_in():
     from pandera.backends.polars.register import register_polars_backends
     from pandera.config import CONFIG
 
-    original = CONFIG.use_narwhals_backend
-    try:
-        CONFIG.use_narwhals_backend = True
-        register_polars_backends.cache_clear()
-        register_polars_backends()
-        backend = DataFrameSchema.get_backend(pl.DataFrame({}))
-        assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
-    finally:
-        CONFIG.use_narwhals_backend = original
-        register_polars_backends.cache_clear()  # restore clean state
+    monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
+    monkeypatch.addfinalizer(register_polars_backends.cache_clear)
+    register_polars_backends.cache_clear()
+    register_polars_backends()
+    backend = DataFrameSchema.get_backend(pl.DataFrame({}))
+    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +199,7 @@ def test_failure_cases_is_native():
 # ---------------------------------------------------------------------------
 
 
-def test_ibis_narwhals_activated_when_opted_in():
+def test_ibis_narwhals_activated_when_opted_in(monkeypatch):
     """register_ibis_backends() registers narwhals backends when opt-in is enabled."""
     import ibis
 
@@ -216,17 +212,13 @@ def test_ibis_narwhals_activated_when_opted_in():
     )
     from pandera.config import CONFIG
 
-    original = CONFIG.use_narwhals_backend
-    try:
-        CONFIG.use_narwhals_backend = True
-        register_ibis_backends.cache_clear()
-        register_ibis_backends()
-        t = ibis.memtable({"a": [1, 2, 3]})
-        backend = IbisDataFrameSchema.get_backend(t)
-        assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
-    finally:
-        CONFIG.use_narwhals_backend = original
-        register_ibis_backends.cache_clear()  # restore clean state
+    monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
+    monkeypatch.addfinalizer(register_ibis_backends.cache_clear)
+    register_ibis_backends.cache_clear()
+    register_ibis_backends()
+    t = ibis.memtable({"a": [1, 2, 3]})
+    backend = IbisDataFrameSchema.get_backend(t)
+    assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
 
 
 def test_ibis_backend_is_narwhals():

--- a/tests/backends/narwhals/test_e2e.py
+++ b/tests/backends/narwhals/test_e2e.py
@@ -27,8 +27,6 @@ Key behavioural notes
   The simplest portable pattern is to return a ``bool``.
 """
 
-import warnings
-
 import polars as pl
 import pytest
 
@@ -37,10 +35,6 @@ import pandera.polars as pa_pl
 from pandera.backends.narwhals.checks import NarwhalsCheckBackend
 from pandera.config import ValidationDepth, config_context
 from pandera.errors import SchemaError, SchemaErrors
-
-# Suppress the "experimental Narwhals backend" UserWarning globally for this
-# module — we assert the backend is in use via the registry, not via the warning.
-pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 # ---------------------------------------------------------------------------
 # ibis is an optional dependency — skip all ibis tests if it is not installed.

--- a/tests/backends/narwhals/test_lazy_regressions.py
+++ b/tests/backends/narwhals/test_lazy_regressions.py
@@ -1,7 +1,5 @@
 """Regression tests for critical lazy=True bugs (Phase 8)."""
 
-import warnings
-
 import polars as pl
 import pytest
 
@@ -9,21 +7,6 @@ from pandera.api.checks import Check
 from pandera.api.polars.components import Column
 from pandera.api.polars.container import DataFrameSchema
 from pandera.errors import SchemaErrors
-
-
-@pytest.fixture(autouse=True, scope="module")
-def _suppress_narwhals_warning():
-    """Initialise narwhals backends and suppress the auto-activation UserWarning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        from pandera.backends.ibis.register import register_ibis_backends
-        from pandera.backends.polars.register import register_polars_backends
-
-        register_polars_backends.cache_clear()
-        register_ibis_backends.cache_clear()
-        register_polars_backends()
-        register_ibis_backends()
-        yield
 
 
 def test_lazy_failure_cases_per_row_polars():

--- a/tests/pandas/test_pandas_config.py
+++ b/tests/pandas/test_pandas_config.py
@@ -48,6 +48,7 @@ class TestPandasDataFrameConfig:
             "keep_cached_dataframe": False,
             "validation_enabled": False,
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
 
@@ -69,6 +70,7 @@ class TestPandasSeriesConfig:
             "keep_cached_dataframe": False,
             "validation_enabled": False,
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
         pandera_schema = SeriesSchema(

--- a/tests/pyspark/test_pyspark_config.py
+++ b/tests/pyspark/test_pyspark_config.py
@@ -49,6 +49,7 @@ class TestPanderaConfig:
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
 
@@ -72,6 +73,7 @@ class TestPanderaConfig:
             "validation_depth": ValidationDepth.SCHEMA_ONLY,
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
         input_df = spark_df(spark, self.sample_data, sample_spark_schema)
@@ -159,6 +161,7 @@ class TestPanderaConfig:
             "validation_depth": ValidationDepth.DATA_ONLY,
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
 
@@ -243,6 +246,7 @@ class TestPanderaConfig:
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
             "cache_dataframe": False,
             "keep_cached_dataframe": False,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
 
@@ -353,6 +357,7 @@ class TestPanderaConfig:
             "validation_depth": ValidationDepth.SCHEMA_AND_DATA,
             "cache_dataframe": cache_dataframe,
             "keep_cached_dataframe": keep_cached_dataframe,
+            "use_narwhals_backend": False,
             "silenced_warnings": [],
         }
         with config_context(


### PR DESCRIPTION
Narwhals is a transitive dependency of many popular packages (e.g. Altair), so auto-activating the experimental Narwhals backend whenever it is installed silently breaks existing users. The backend is now opt-in: native polars/ibis backends are always used unless PANDERA_USE_NARWHALS_BACKEND=True is set (or pandera.config.CONFIG.use_narwhals_backend is True programmatically).

- Add use_narwhals_backend: bool = False to PanderaConfig
- Parse PANDERA_USE_NARWHALS_BACKEND env var in _config_from_env_vars()
- Replace try/except auto-detect in register_polars_backends() and register_ibis_backends() with if CONFIG.use_narwhals_backend branch
- Remove UserWarning emitted on auto-activation (opt-in users chose this)
- Nox sessions tests(extra=narwhals) and tests_narwhals_backend now pass PANDERA_USE_NARWHALS_BACKEND=True to pytest
- Drop _suppress_narwhals_warning fixtures and pytestmark filterwarnings from narwhals test files; update conftest fixture name and docstring