### PR TITLE
refactor(polars): preserve input frame kind in `coerce_dtype`

### DIFF
--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -246,10 +246,8 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
         schema = copy.deepcopy(cls.to_schema())
         if schema.columns:
             schema.coerce = True
-            empty_df = (
-                schema.coerce_dtype(pl.DataFrame(schema=[*schema.columns]))
-                .lazy()
-                .collect()
+            empty_df = schema.coerce_dtype(
+                pl.DataFrame(schema=[*schema.columns])
             )
         elif isinstance(schema.dtype, pe.PydanticModel):
             empty_df = pl.DataFrame(schema=schema.dtype._get_polars_schema())

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -432,19 +432,26 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
 
         return check_obj
 
-    def coerce_dtype(self, check_obj: pl.LazyFrame, schema=None):
-        """Coerce dataframe columns to the correct dtype."""
+    def coerce_dtype(self, check_obj: PolarsFrame, schema=None) -> PolarsFrame:
+        """Coerce dataframe columns to the correct dtype.
+
+        Preserves the input frame kind: a ``pl.DataFrame`` in returns a
+        ``pl.DataFrame`` out; a ``pl.LazyFrame`` in returns a ``pl.LazyFrame``
+        out.
+        """
         assert schema is not None, "The `schema` argument must be provided."
 
-        error_handler = ErrorHandler(lazy=True)
+        return_type = type(check_obj)
+        check_lf = _to_lazy(check_obj)
 
         if not (
             schema.coerce or any(col.coerce for col in schema.columns.values())
         ):
-            return check_obj
+            return _to_frame_kind(check_lf, return_type)
 
+        error_handler = ErrorHandler(lazy=True)
         try:
-            check_obj = self._coerce_dtype_helper(check_obj, schema)
+            check_lf = self._coerce_dtype_helper(check_lf, schema)
         except SchemaErrors as err:
             for schema_error in err.schema_errors:
                 error_handler.collect_error(
@@ -467,10 +474,10 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             raise SchemaErrors(
                 schema=schema,
                 schema_errors=error_handler.schema_errors,
-                data=check_obj,
+                data=check_lf,
             )
 
-        return check_obj
+        return _to_frame_kind(check_lf, return_type)
 
     def _coerce_dtype_helper(
         self,

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -154,12 +154,28 @@ def test_coerce_dtype_preserves_lazyframe(ldf_basic, ldf_schema_basic):
 
 
 def test_coerce_dtype_with_dataframe(ldf_schema_basic):
-    """coerce_dtype is callable with a DataFrame input via the overload path."""
+    """coerce_dtype preserves a DataFrame input as a DataFrame at runtime."""
     ldf_schema_basic._coerce = True
     df = pl.DataFrame(schema=[*ldf_schema_basic.columns])
     result = ldf_schema_basic.coerce_dtype(df)
-    # Backend currently lazifies DataFrame inputs; assert it's still a frame-like.
-    assert isinstance(result, (pl.DataFrame, pl.LazyFrame))
+    assert isinstance(result, pl.DataFrame)
+
+
+@pytest.mark.xfail(
+    condition=narwhals_installed,
+    reason="Narwhals backend does not support dtype coercion",
+    strict=True,
+)
+def test_coerce_dtype_dataframe_actually_coerces():
+    """coerce_dtype with a DataFrame input both coerces and stays a DataFrame."""
+    schema = DataFrameSchema(
+        {"a": Column(int, coerce=True)},
+    )
+    df = pl.DataFrame({"a": ["1", "2", "3"]})
+    result = schema.coerce_dtype(df)
+    assert isinstance(result, pl.DataFrame)
+    assert result.schema == {"a": pl.Int64}
+    assert result["a"].to_list() == [1, 2, 3]
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
depends on: #2313 

## Summary

Aligns the polars backend's `DataFrameSchemaBackend.coerce_dtype` with the base class contract `TDataObject -> TDataObject` (`pandera/api/dataframe/container.py:299`). A `pl.DataFrame` in now returns a `pl.DataFrame` out; a `pl.LazyFrame` in returns a `pl.LazyFrame` out.

This makes the typed `@overload` declarations on `DataFrameSchema.coerce_dtype` (`pandera/api/polars/container.py`) truthful at runtime, so callers no longer need a `.lazy().collect()` shim or an `isinstance` narrow to recover their original frame kind.

## Motivation

`DataFrameModel.empty()` (`pandera/api/polars/model.py`) calls `schema.coerce_dtype(pl.DataFrame(...))` to materialise an empty frame with the schema's coerced dtypes. Until this PR, the backend always lazified the input internally and returned a `pl.LazyFrame`, so the caller had to suffix the call with `.lazy().collect()` to recover a `DataFrame`. The schema-level overloads added previously declared `DataFrame -> DataFrame`, but the runtime did not match.

The base class signature has always been `coerce_dtype(check_obj: TDataObject) -> TDataObject` — the polars backend was the one violating the contract.

## What changed

### `pandera/backends/polars/container.py`
Rewrote `DataFrameSchemaBackend.coerce_dtype` (lines 435–478) to use the same lazify/restore pattern that `validate()` already uses:

- `return_type = type(check_obj)` to capture the original frame kind.
- `_to_lazy(check_obj)` (line 29) for internal processing.
- `_to_frame_kind(check_lf, return_type)` (line 36) to restore the original kind on every return path (no-op for `LazyFrame` input).

Signature is now `coerce_dtype(check_obj: PolarsFrame, schema=None) -> PolarsFrame`.

`validate()` still passes a `LazyFrame`, so its behavior is unchanged: lazify is a no-op, restore returns the LazyFrame as-is.

### `pandera/api/polars/model.py`
Dropped the `.lazy().collect()` suffix in `empty()` since `coerce_dtype(pl.DataFrame(...))` now returns a `pl.DataFrame` directly.

### `tests/polars/test_polars_container.py`
- Tightened `test_coerce_dtype_with_dataframe` to assert exact `isinstance(result, pl.DataFrame)` (was `(pl.DataFrame, pl.LazyFrame)`).
- Added `test_coerce_dtype_dataframe_actually_coerces`: builds a schema with a real coerce, passes a `pl.DataFrame` of strings, asserts the return is a `pl.DataFrame` *and* the dtypes were coerced to `Int64`. Marked `xfail` under the narwhals backend (which does not implement column-level coercion).

## Behavior change

This is a **runtime behavior change**, not just a typing fix:

> Direct callers of `schema.coerce_dtype(some_df)` that previously received a `pl.LazyFrame` (despite passing a `pl.DataFrame`) will now receive a `pl.DataFrame`.

Anyone written to the documented base-class contract (`T -> T`) is unaffected. The bug has been around long enough that some downstream code may have grown to depend on the old quirk; the changelog note below calls it out explicitly.

## Out of scope

- **narwhals backend parity** — `pandera/backends/narwhals/container.py:359` still returns via `_to_lazy_nw(coerced)` on the active-coerce path. The narwhals backend's column-level coercion is handled separately by schema components, and tightening it requires deeper changes to the narwhals adapter. The schema-level overloads remain valid because narwhals's `validate()` flow performs its own frame-kind handling.
- The other backends (pandas / pyspark / xarray) — out of scope; they have their own contracts and may already conform.
- The `# type: ignore[override]` on the polars `coerce_dtype` overloads — the underlying issue is the base class's class-level `Generic[TDataObject]` binding, which is a separate refactor.

## Test plan

- [x] `pytest tests/polars/ -q` — 89 passed (without narwhals installed).
- [x] `PANDERA_USE_NARWHALS_BACKEND=True pytest tests/polars/ -q` — `test_coerce_dtype_dataframe_actually_coerces` correctly xfails on the narwhals backend; all other polars tests behave as before.
- [x] `mypy pandera/api/polars/ pandera/backends/polars/` — no new errors introduced.
- [x] End-to-end smoke:
  ```python
  import polars as pl, pandera.polars as pa
  schema = pa.DataFrameSchema({"a": pa.Column(int, coerce=True)})

  df = pl.DataFrame({"a": ["1", "2", "3"]})
  out = schema.coerce_dtype(df)
  assert isinstance(out, pl.DataFrame)
  assert out.schema == {"a": pl.Int64}

  lf = pl.LazyFrame({"a": ["1", "2"]})
  assert isinstance(schema.coerce_dtype(lf), pl.LazyFrame)
  ```

## Suggested changelog entry

> **polars** — `DataFrameSchema.coerce_dtype` now preserves the input frame kind, matching the base class contract `T -> T`. Previously a `pl.DataFrame` input was returned as a `pl.LazyFrame`. Callers that depended on the old behavior should add a `.lazy()` at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
