### PR TITLE
test(ibis): enable decimal datatype test after fix

### DIFF
--- a/tests/ibis/test_ibis_builtin_checks.py
+++ b/tests/ibis/test_ibis_builtin_checks.py
@@ -50,25 +50,10 @@ class BaseClass:
         data_dict = {}
         for key, value in sample_data.items():
             if key == "test_expression":
-                # Work around Ibis issue wherein comparison with decimal
-                # literals doesn't work. This is very fragile and should
-                # be undone once the open issue is fixed. For more info,
-                # see https://github.com/ibis-project/ibis/issues/11819
-                if conversion_datatype is decimal.Decimal:
-
-                    def patched_conversion_datatype(x):
-                        return ibis.literal(conversion_datatype(x)).cast(
-                            "decimal(28, 0)"
-                        )
-                else:
-                    patched_conversion_datatype = conversion_datatype
-
                 if not isinstance(value, list):
-                    data_dict[key] = patched_conversion_datatype(value)
+                    data_dict[key] = conversion_datatype(value)
                 else:
-                    data_dict[key] = [
-                        patched_conversion_datatype(i) for i in value
-                    ]
+                    data_dict[key] = [conversion_datatype(i) for i in value]
 
             else:
                 if not isinstance(value[0][1], list):

--- a/tests/ibis/test_ibis_builtin_checks.py
+++ b/tests/ibis/test_ibis_builtin_checks.py
@@ -1018,13 +1018,12 @@ class TestInRangeCheck(BaseClass):
                 "datatype": dt.Float64,
                 "data": self.convert_data(self.sample_numeric_data, "float64"),
             },
-            # TODO(deepyaman): Enable once the decimal issue is resolved
-            # {
-            #     "datatype": dt.Decimal(precision=38, scale=10),
-            #     "data": self.convert_data(
-            #         self.sample_numeric_data, "decimal"
-            #     ),
-            # },
+            {
+                "datatype": dt.Decimal(precision=38, scale=10),
+                "data": self.convert_data(
+                    self.sample_numeric_data, "decimal"
+                ),
+            },
             {
                 "datatype": dt.Date,
                 "data": self.convert_data(self.sample_datetime_data, "date"),

--- a/tests/ibis/test_ibis_builtin_checks.py
+++ b/tests/ibis/test_ibis_builtin_checks.py
@@ -1506,39 +1506,6 @@ class TestStringType(BaseClass):
 class TestUniqueValuesEqCheck(BaseClass):
     """This class is used to test the unique values eq check"""
 
-    # Use the original `convert_value` implementation. Once the upstream
-    # issue is fixed, we can remove this override; the "original" method
-    # will again be the `BaseClass` implementation.
-    @staticmethod
-    def convert_value(sample_data, conversion_datatype):
-        """
-        Convert the sample data to other formats excluding dates and does not
-        support complex datatypes such as array and map as of now
-        """
-
-        data_dict = {}
-        for key, value in sample_data.items():
-            if key == "test_expression":
-                if not isinstance(value, list):
-                    data_dict[key] = conversion_datatype(value)
-                else:
-                    data_dict[key] = [conversion_datatype(i) for i in value]
-
-            else:
-                if not isinstance(value[0][1], list):
-                    data_dict[key] = [
-                        (i[0], conversion_datatype(i[1])) for i in value
-                    ]
-                else:
-                    final_val = []
-                    for row in value:
-                        data_val = []
-                        for column in row[1]:
-                            data_val.append(conversion_datatype(column))
-                        final_val.append((row[0], data_val))
-                    data_dict[key] = final_val
-        return data_dict
-
     sample_numeric_data = {
         "test_pass_data": [("foo", 32), ("bar", 31)],
         "test_fail_data": [("foo", 31), ("bar", 31)],


### PR DESCRIPTION
The issue raised in #2194 was resolved by https://github.com/ibis-project/ibis/pull/11818.