### PR TITLE
chore: add `Time` as a cross-engine semantic dtype

### DIFF
--- a/pandera/dtypes.py
+++ b/pandera/dtypes.py
@@ -538,6 +538,14 @@ class Timedelta(DataType):
 
 
 @immutable
+class Time(DataType):
+    """Semantic representation of a time-of-day data type."""
+
+    def __str__(self) -> str:
+        return "time"
+
+
+@immutable
 class Binary(DataType):
     """Semantic representation of a delta time data type."""
 

--- a/pandera/engines/ibis_engine.py
+++ b/pandera/engines/ibis_engine.py
@@ -451,10 +451,12 @@ class DateTime(DataType, dtypes.DateTime):
         dt.Time,
         dt.time,
         dt.Time(nullable=False),
+        dtypes.Time,
+        dtypes.Time(),
     ]
 )
 @immutable
-class Time(DataType):
+class Time(DataType, dtypes.Time):
     """Semantic representation of a :class:`dt.Time`."""
 
     type = dt.time

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -538,10 +538,12 @@ class DateTime(DataType, dtypes.DateTime):
         "time",
         datetime.time,
         pl.Time,
+        dtypes.Time,
+        dtypes.Time(),
     ]
 )
 @immutable
-class Time(DataType):
+class Time(DataType, dtypes.Time):
     """Polars time data type."""
 
     type = pl.Time


### PR DESCRIPTION
Add dtypes.Time to represent time-of-day values, parallel to Date and Timedelta. Register it as an equivalent in both PolarsEngine.Time and IbisEngine.Time so dtypes.Time routes correctly through engine dispatch.