### PR TITLE
Bugfix/2319

### DIFF
--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -14,8 +14,9 @@ from pandera.api.pandas.components import Column, Index, MultiIndex
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.pandas.model_config import BaseConfig
 from pandera.api.parsers import Parser
+from pandera.dtypes import DataType
 from pandera.engines import numpy_engine, pandas_engine
-from pandera.engines.pandas_engine import Engine
+from pandera.engines.pandas_engine import Engine, PythonGenericType
 from pandera.errors import SchemaInitError
 from pandera.typing import (
     AnnotationInfo,
@@ -247,9 +248,17 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
             FastAPI integration.
         """
         schema = cls.to_schema()
-        empty = pd.DataFrame(columns=schema.columns.keys()).astype(
-            {k: v.type if v else None for k, v in schema.dtypes.items()}
-        )
+        dtypes = {
+            k: (
+                v.type
+                if not isinstance(v.type, PythonGenericType)
+                else "object"
+            )
+            if v
+            else None
+            for k, v in schema.dtypes.items()
+        }
+        empty = pd.DataFrame(columns=schema.columns.keys()).astype(dtypes)
         table_schema = pd.io.json.build_table_schema(empty)
 
         def _field_json_schema(field):
@@ -280,8 +289,13 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
 
         data = {}
         for col_name, col_schema in schema.columns.items():
+            dtype = (
+                col_schema.dtype.type
+                if not isinstance(col_schema.dtype, PythonGenericType)
+                else "object"
+            )
             if col_schema.dtype is not None:
-                data[col_name] = pd.array([], dtype=col_schema.dtype.type)
+                data[col_name] = pd.array([], dtype=dtype)
             else:
                 data[col_name] = pd.array([])
 

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -2215,6 +2215,9 @@ def test_empty() -> None:
         b: Series[pa.Int]
         c: Series[pa.String]
         d: Series[pa.DateTime]
+        e: Series[list]
+        f: Series[tuple]
+        g: Series[dict]
 
     df = Schema.empty()
     assert df.empty


### PR DESCRIPTION
Issue #2319 reports that the python types underlying `PythonGenericType` cause `pandas` to fail when assigning a dtype upon generating an empty `DataFrame` from a `DataFrameModel`. This same issue with dtypes appears to also be the cause behind Issue #2059 when using `to_json_schema`. 

This PR proposes that, if the intended behaviour is to allow PythonGenericType type annotations in `DataFrameModel` subclasses, the empty `pd.DataFrame` object generated should have `dtype="object"` in the associated columns. This then matches the `dtype` that would be automatically assigned to fields in a `pd.DataFrame` object that are populated by instances of e.g. `list`, `tuple`, `dict`, etc.

## Changes Done
- Updated the `DataFrameModel.empty()` and `DataFrameModel.to_json_schema()` methods in `pandera.api.pandas.model.py` to check for `PythonGenericType` annotations before assigning dtype to columns

## Test Coverage
- Updated the test for `DataFrameModel.empty()` to include additional dummy fields for series of `list`,`tuple`, and `dict`


This is my first ever PR and open-source contribution, so please don't hold back if I have got any of this procedure wrong! 