### PR TITLE
fix: handle SchemaErrors in check_types Union fallback (#2325)

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -728,6 +728,8 @@ def check_types(
                 )
             except errors.SchemaError as e:
                 schema_errors.append(e)
+            except errors.SchemaErrors as e:
+                schema_errors.extend(e.schema_errors)
         if schema_errors:
             raise errors.SchemaErrors(
                 schema=child.dataframe_model.to_schema()

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -1002,6 +1002,45 @@ def test_check_types_union_args() -> None:
         validate_union_wrong_outputs(pd.DataFrame({"a": [0, 0]}))  # type: ignore [arg-type]
 
 
+def test_check_types_union_with_strict_schema() -> None:
+    """
+    Test that the @check_types decorator falls through to the next member of
+    a Union when an earlier ``strict=True`` schema raises ``SchemaErrors``
+    (plural) due to extra columns. See issue #2325.
+    """
+
+    class StrictModel(DataFrameModel):
+        a: Series[int]
+
+        class Config:
+            strict = True
+
+    class ExtendedModel(DataFrameModel):
+        a: Series[int]
+        b: Series[int]
+
+        class Config:
+            strict = True
+
+    @check_types
+    def process(
+        df: typing.Union[DataFrame[StrictModel], DataFrame[ExtendedModel]],
+    ) -> typing.Union[DataFrame[StrictModel], DataFrame[ExtendedModel]]:
+        return df
+
+    # Matches ExtendedModel only; StrictModel raises SchemaErrors (plural)
+    # because of the extra "b" column. The decorator must catch that and
+    # try the next Union member.
+    process(pd.DataFrame({"a": [0, 1], "b": [2, 3]}))  # type: ignore [arg-type]
+
+    # Matches StrictModel only.
+    process(pd.DataFrame({"a": [0, 1]}))  # type: ignore [arg-type]
+
+    # Matches neither: collected errors should be raised as SchemaErrors.
+    with pytest.raises(errors.SchemaErrors):
+        process(pd.DataFrame({"a": [0, 1], "c": [4, 5]}))  # type: ignore [arg-type]
+
+
 def test_check_types_tuple_args() -> None:
     """Test that the @check_types decorator works with
     tuple[pandera.typing.DataFrame[S1], pandera.typing.DataFrame[S2]] type inputs/outputs


### PR DESCRIPTION
Closes #2325.

When a Union member is a `strict=True` schema, validation against extra columns goes through the pandas backend's lazy path and raises `errors.SchemaErrors` (plural) instead of `errors.SchemaError` (singular). `SchemaErrors` is a sibling of `SchemaError`, not a subclass, so the existing `except errors.SchemaError` in `_check_arg_value_against_union` did not catch it and the exception propagated, skipping every later member of the Union.

This adds a second `except errors.SchemaErrors` clause that flattens the inner errors into the collected list so the next Union member is tried, matching behavior for non-strict schemas.

Added a regression test (`test_check_types_union_with_strict_schema`) that exercises three cases: matches second member, matches first member, matches neither (expects `SchemaErrors`).