### PR TITLE
fix(checks): refresh dispatcher for built-in checks with user names (#2042)

### DIFF
--- a/pandera/api/base/checks.py
+++ b/pandera/api/base/checks.py
@@ -137,12 +137,24 @@ class BaseCheck(metaclass=MetaCheck):
         if statistics is None:
             statistics = check_kwargs
 
-        return cls(
+        instance = cls(
             cls.get_builtin_check_fn(name),
             statistics=statistics,
             native=False,  # type: ignore[call-arg]
             **kws,
         )
+        # Remember the registry key for this built-in check independently of
+        # the user-supplied ``name`` kwarg. ``Check.__call__`` consults this
+        # to refresh ``self._check_fn`` against the live registry, which
+        # matters because schema validation deep-copies Check instances —
+        # the deep-copied :class:`Dispatcher` carries a stale per-type
+        # registry, while the original (mutated by lazy backend
+        # registration during ``validate()``) is the one that should run.
+        # Without this, ``Check.gt(0, name="my_check")`` reaches the check
+        # backend with a stale dispatcher and KeyErrors on the input
+        # dtype. See pandera issue #2042.
+        instance._builtin_check_name = name
+        return instance
 
     @classmethod
     def register_backend(cls, type_: type, backend: type[BaseCheckBackend]):

--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -247,11 +247,22 @@ class Check(BaseCheck):
 
             ``failure_cases``: subset of the check_object that failed.
         """
-        if self.name is not None and self.is_builtin_check(self.name):
-            # we need to reload the function here in case additional
-            # type signatures have been registered for a specific built-in
-            # check.
-            self._check_fn = self.get_builtin_check_fn(self.name)
+        # Resolve the registry key for the underlying built-in check.
+        # ``self.name`` is unreliable: the user can override it via the
+        # ``name=`` kwarg on builders like :py:meth:`Check.gt`, in which case
+        # ``self.name`` is the user label rather than the built-in dispatch
+        # key. ``_builtin_check_name`` is set on instances created through
+        # :py:meth:`BaseCheck.from_builtin_check_name` and survives copy /
+        # deepcopy. Fall back to ``self.name`` for instances created
+        # directly (e.g. user-supplied check functions). See #2042.
+        builtin_key = getattr(self, "_builtin_check_name", None) or self.name
+        if builtin_key is not None and self.is_builtin_check(builtin_key):
+            # Refresh the dispatcher reference from the live class-level
+            # registry. Schema validation deep-copies Check instances, so
+            # ``self._check_fn`` may be a stale Dispatcher whose per-type
+            # function map is missing entries that backend registration
+            # added to the original after the deep-copy.
+            self._check_fn = self.get_builtin_check_fn(builtin_key)
         backend = self.get_backend(check_obj)(self)
         return backend(check_obj, column)
 

--- a/tests/pandas/test_checks.py
+++ b/tests/pandas/test_checks.py
@@ -520,3 +520,38 @@ def test_check_output_dtype_with_empty_datetime():
     df = pd.DataFrame({"year_mon": pd.Series(dtype="datetime64[D]")})
     check_result = check(df)
     assert check_result.check_output.dtype == bool
+
+
+def test_builtin_check_with_user_supplied_name() -> None:
+    """Regression for #2042.
+
+    Built-in check builders (``Check.gt``, ``Check.lt``, ``Check.isin``…)
+    accept a ``name=`` kwarg used to label the check in error messages.
+    The factory routes through :py:meth:`BaseCheck.from_builtin_check_name`
+    which captures the underlying dispatcher into ``Check._check_fn``.
+
+    Before the fix, ``Check.__call__`` resolved the live dispatcher only
+    when ``self.name`` matched a registered built-in name — but with a
+    user-supplied label it never matched, so the schema kept the
+    deep-copied dispatcher whose per-type function map is missing entries
+    that backend registration adds to the original ``Dispatcher`` instance
+    during ``schema.validate``. The result was
+    ``KeyError: <class 'pandas.Series'>`` at validation time.
+
+    Verify both the green path (validation passes for valid input) and that
+    the rebuild still produces the right SchemaError on invalid input.
+    """
+    schema = DataFrameSchema(
+        columns={
+            "test": Column(
+                float, checks=[Check.gt(0, name="positive_check")]
+            )
+        }
+    )
+    pd.testing.assert_frame_equal(
+        schema.validate(pd.DataFrame({"test": [1.0, 2.0]})),
+        pd.DataFrame({"test": [1.0, 2.0]}),
+    )
+    with pytest.raises(errors.SchemaError) as exc:
+        schema.validate(pd.DataFrame({"test": [-1.0]}))
+    assert "greater_than(0)" in str(exc.value)


### PR DESCRIPTION
## Summary

Built-in check builders accept a `name=` kwarg used to label the check in error messages (`Check.gt(0, name="my_check")`). On schema validation, this raised `KeyError: <class 'pandas.Series'>` because `Check.__call__`'s dispatcher-refresh guard relied on `self.name` matching a registered built-in name — which it never does once the user has supplied a custom label. Track the underlying built-in registry key separately and use it for the refresh decision.

Resolves #2042.

## Context

`Check.gt(0)` (default name) and `Check.gt(0, name="positive")` follow different paths in `Check.__call__`:

```python
# pandera/api/checks.py, line 250 on origin/main:
if self.name is not None and self.is_builtin_check(self.name):
    self._check_fn = self.get_builtin_check_fn(self.name)
```

The reload exists because schema validation **deep-copies** Check instances (via `copy.deepcopy(self)` in many `pandera/api/dataframe/container.py` methods). Deep-copying a `Dispatcher` produces a new instance with a *new* `_function_registry` dict — so per-type entries that lazy backend registration (`register_pandas_backends`) adds to the *original* dispatcher are invisible to the deep-copy.

The reload re-fetches the live dispatcher from the class-level `CHECK_FUNCTION_REGISTRY`, papering over the deep-copy. But it gates on `self.name`, which the user is allowed to override; with a custom name the gate never opens, the deep-copied stale dispatcher stays in place, and `dispatcher.__call__` KeyErrors when it tries `type(args[0])` lookup.

Verified by tracing dispatcher object identity: at validation time `Check.gt(0, name="my_check")._check_fn` has a different `id()` than `BaseCheck.CHECK_FUNCTION_REGISTRY["greater_than"]`, with a registry containing only `{typing.Any}` (the base function registered before any pandas-specific overload).

## Changes

- `pandera/api/base/checks.py`: `from_builtin_check_name` now sets `instance._builtin_check_name = name` on the returned check, capturing the registry key independently of the user-supplied label. A 7-line comment explains the deep-copy interaction so a future reader doesn't have to re-derive it.
- `pandera/api/checks.py`: `Check.__call__` now resolves a `builtin_key = getattr(self, "_builtin_check_name", None) or self.name` and uses *that* (not `self.name` directly) to decide whether to refresh `self._check_fn`. Falls back to `self.name` for instances built outside the factory (e.g. user-defined Check subclasses), preserving existing behaviour.
- `tests/pandas/test_checks.py`: regression test `test_builtin_check_with_user_supplied_name` covering both green path (validation passes for valid input) and red path (invalid input still produces a clean `SchemaError` with the underlying `greater_than(0)` formatting, not a `KeyError`).

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/unionai-oss/pandera.git /tmp/repro && cd /tmp/repro
python3 -m venv .venv && source .venv/bin/activate
pip install -e '.[pandas]'

# --- BEFORE (origin/main) ---
git checkout origin/main
python3 - <<'PY'
import pandera.pandas as pa
import pandas as pd

schema = pa.DataFrameSchema(
    columns={"test": pa.Column(float, checks=[pa.Check.gt(0, name="positive_check")])},
)
try:
    schema.validate(pd.DataFrame({"test": [1.0]}))
    print("OK")
except Exception as e:
    print(f"RAISED {type(e).__name__}: {str(e)[:90]}")
PY
# Expected: RAISED SchemaError ... KeyError("<class 'pandas.Series'>") ...

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pandera.git bugfix/2042-check-name-kwarg
git checkout FETCH_HEAD
pip install -e '.[pandas]' >/dev/null
python3 - <<'PY'
import pandera.pandas as pa
import pandas as pd

schema = pa.DataFrameSchema(
    columns={"test": pa.Column(float, checks=[pa.Check.gt(0, name="positive_check")])},
)
print("validation OK; rows:", len(schema.validate(pd.DataFrame({"test": [1.0]}))))
PY
# Expected: validation OK; rows: 1
```

## What I ran locally

- `pytest tests/pandas/test_checks.py::test_builtin_check_with_user_supplied_name -v` → 1/1 passed (regression test).
- `pytest tests/pandas/test_checks.py tests/pandas/test_checks_builtin.py -q` → 285 passed.
- Verified the regression test fails on `origin/main` with the documented `KeyError: <class 'pandas.Series'>` traceback.

## Edge cases tested

| # | Scenario                                                                                   | Expected                                  | Verified by |
|---|--------------------------------------------------------------------------------------------|-------------------------------------------|--------------|
| 1 | `Check.gt(0, name="positive")` on a column that satisfies the check                         | validation passes, returns the dataframe  | green path of new test |
| 2 | `Check.gt(0, name="positive")` on a column that fails the check                             | clean SchemaError with `greater_than(0)` failure-case formatting (not a KeyError) | red path of new test |
| 3 | `Check.gt(0)` (no `name=`) — pre-existing happy path                                        | unchanged                                 | full `tests/pandas/test_checks*.py` suite (285 passed) |
| 4 | Custom-defined `Check` subclasses without `_builtin_check_name`                             | falls back to `self.name`, original behaviour preserved | tests/pandas/test_checks.py (no regressions) |

## Risk / blast radius

The new attribute `_builtin_check_name` is set only on instances created via `from_builtin_check_name`; everywhere else, `getattr(self, "_builtin_check_name", None)` returns None and the resolution falls through to `self.name` — i.e. exactly the prior behaviour. No public API changes. The attribute is set by all existing call sites in `pandera/api/checks.py` (every `cls.from_builtin_check_name(...)` builder) and in `pandera/api/hypotheses.py`.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against pandera's check / dispatcher / backend layers and against the reporter's traceback in #2042.*
