### PR TITLE
feat(narwhals): support sample= subsampling for eager polars frames

### DIFF
--- a/pandera/backends/narwhals/base.py
+++ b/pandera/backends/narwhals/base.py
@@ -70,43 +70,54 @@ class NarwhalsSchemaBackend(BaseSchemaBackend):
     ):
         """Return a (possibly subsampled) version of check_obj.
 
-        Never materializes check_obj — delegates directly to .head()/.tail()
-        so the result stays lazy (nw.LazyFrame) for Polars inputs.
+        Stays lazy whenever possible. ``head=``/``tail=`` delegate to
+        ``nw.LazyFrame.head()/tail()`` — no ``_materialize()`` call.
+        ``sample=`` is only supported for eager frames (``nw.DataFrame``
+        wrapping a ``pl.DataFrame``); it requires ``nw.DataFrame.sample``
+        which is not available on ``nw.LazyFrame`` or SQL-lazy backends.
 
         :param head: Number of rows to take from the head.
         :param tail: Number of rows to take from the tail.
-        :param sample: Not supported — raises NotImplementedError.
-        :param random_state: Ignored (no random sampling supported).
-        :raises NotImplementedError: If sample is not None, or if tail= is
-            requested on a SQL-lazy backend (ibis.Table) that does not support
-            TAIL without forced full ordering.
+        :param sample: Number of rows to randomly sample (eager polars only).
+        :param random_state: Seed forwarded to ``sample(seed=...)``.
+        :raises NotImplementedError: If ``sample=`` is requested on a lazy or
+            SQL-lazy input, or if ``tail=`` is requested on a SQL-lazy backend
+            (ibis.Table) that does not support TAIL without forced full
+            ordering.
         """
-        if sample is not None:
-            raise NotImplementedError(
-                "sample= is not supported in the Narwhals backend. "
-                "Use head= or tail= instead."
-            )
-
-        if head is None and tail is None:
+        if head is None and tail is None and sample is None:
             return check_obj
 
-        # Guard: SQL-lazy backends don't support tail without full ordering
         if tail is not None and _is_sql_lazy(check_obj):
             raise NotImplementedError(
-                "tail= is not supported on SQL-lazy backends (Ibis, DuckDB, PySpark) "
-                "because SQL has no native TAIL without forced full ordering. "
-                "Use head= instead."
+                "tail= is not supported on SQL-lazy backends (Ibis, DuckDB, "
+                "PySpark) because SQL has no native TAIL without forced full "
+                "ordering. Use head= instead."
             )
+
+        if sample is not None:
+            # Sampling is not representable as a pure expression on lazy or
+            # SQL-lazy frames, so we restrict it to eager polars inputs. This
+            # matches the behaviour of the legacy Polars backend.
+            if isinstance(check_obj, nw.LazyFrame):
+                raise NotImplementedError(
+                    "sample= is not supported for lazy frames (polars "
+                    "LazyFrame). Use head=/tail= or call .collect() on the "
+                    "input before validation."
+                )
+            if _is_sql_lazy(check_obj):
+                raise NotImplementedError(
+                    "sample= is not supported on SQL-lazy backends (Ibis, "
+                    "DuckDB, PySpark). Use head= instead."
+                )
 
         obj_subsample = []
         if head is not None:
-            obj_subsample.append(
-                check_obj.head(head)
-            )  # lazy — no _materialize()
+            obj_subsample.append(check_obj.head(head))
         if tail is not None:
-            obj_subsample.append(
-                check_obj.tail(tail)
-            )  # lazy — polars-only (guarded above)
+            obj_subsample.append(check_obj.tail(tail))
+        if sample is not None:
+            obj_subsample.append(check_obj.sample(n=sample, seed=random_state))
 
         return nw.concat(obj_subsample).unique()
 

--- a/pandera/backends/narwhals/container.py
+++ b/pandera/backends/narwhals/container.py
@@ -136,16 +136,31 @@ class DataFrameSchemaBackend(NarwhalsSchemaBackend):
             check_lf, schema, column_info
         )
 
-        # subsample on the Narwhals LazyFrame — no native round-trip before checks
+        # ``sample=`` requires an eager frame (``nw.DataFrame``) since
+        # neither ``nw.LazyFrame`` nor SQL-lazy backends can express a
+        # uniform sample as a pure expression. When the user passed an
+        # eager polars DataFrame originally, materialize the wrapper back
+        # to ``nw.DataFrame`` before subsampling so eager sampling works
+        # — mirrors the polars backend's `_to_frame_kind` round-trip.
+        # Eager polars detection uses the same duck-typing as
+        # `_to_frame_kind_nw` (no module-import-time polars dependency).
+        caller_was_eager_polars = not hasattr(
+            return_type, "collect"
+        ) and return_type.__module__.startswith("polars")
+        if sample is not None and caller_was_eager_polars:
+            subsample_input: nw.LazyFrame | nw.DataFrame = check_lf.collect()
+        else:
+            subsample_input = check_lf
         sample_obj = self.subsample(
-            check_lf,
+            subsample_input,
             head,
             tail,
             sample,
             random_state,
         )
-        # subsample() returns nw.LazyFrame (unchanged) or nw.DataFrame (if head/tail used);
-        # normalize to LazyFrame for uniform check execution
+        # subsample() returns nw.LazyFrame (unchanged) or nw.DataFrame (if
+        # sample/head/tail materialized it); normalize to LazyFrame for
+        # uniform check execution downstream.
         if isinstance(sample_obj, nw.DataFrame):
             sample_lf = sample_obj.lazy()
         else:

--- a/tests/narwhals/test_components.py
+++ b/tests/narwhals/test_components.py
@@ -292,6 +292,64 @@ class TestSubsample:
         result = backend.subsample(frame)
         assert result is frame
 
+    def test_subsample_sample_eager_polars(self):
+        """sample= works on eager polars frames wrapped as nw.DataFrame."""
+        frame = nw.from_native(
+            pl.DataFrame({"x": list(range(20))}),
+            eager_only=True,
+        )
+        backend = NarwhalsSchemaBackend()
+        result = backend.subsample(frame, sample=5, random_state=42)
+        assert isinstance(result, nw.DataFrame)
+        native = nw.to_native(result)
+        assert native.shape[0] == 5
+        # Deterministic for the same seed (unique() may reorder the rows,
+        # so compare the row set rather than the exact row order).
+        result2 = backend.subsample(frame, sample=5, random_state=42)
+        assert set(nw.to_native(result2)["x"].to_list()) == set(
+            native["x"].to_list()
+        )
+
+    def test_subsample_sample_lazy_raises(self):
+        """sample= on a polars LazyFrame raises NotImplementedError."""
+        frame = self._polars_lazy_frame()
+        backend = NarwhalsSchemaBackend()
+        with pytest.raises(NotImplementedError, match="sample="):
+            backend.subsample(frame, sample=2)
+
+    @ibis_only
+    def test_subsample_sample_ibis_raises(self):
+        """sample= on a SQL-lazy backend (ibis) raises NotImplementedError."""
+        import pandas as pd
+
+        ibis_frame = nw.from_native(
+            _ibis_mod.memtable(pd.DataFrame({"x": [1, 2, 3, 4, 5]})),
+            eager_or_interchange_only=False,
+        )
+        backend = NarwhalsSchemaBackend()
+        with pytest.raises(NotImplementedError, match="sample="):
+            backend.subsample(ibis_frame, sample=2)
+
+    def test_subsample_head_and_sample_combined(self):
+        """head= and sample= can be combined on an eager polars frame.
+
+        ``sample(5)`` draws from the *full* frame, not from head(10), so the
+        union of head(10) + sample(5) contains at most 15 distinct rows
+        (fewer if the sample happens to overlap with the head).
+        """
+        frame = nw.from_native(
+            pl.DataFrame({"x": list(range(20))}),
+            eager_only=True,
+        )
+        backend = NarwhalsSchemaBackend()
+        result = backend.subsample(frame, head=10, sample=5, random_state=0)
+        native = nw.to_native(result)
+        n_rows = native.shape[0]
+        assert 10 <= n_rows <= 15
+        xs = set(native["x"].to_list())
+        # head(10) values must all be present.
+        assert set(range(10)).issubset(xs)
+
 
 # ---------------------------------------------------------------------------
 # Phase 6 RED baseline: failure_cases_metadata() returns ibis.Table for ibis input

--- a/tests/narwhals/test_components.py
+++ b/tests/narwhals/test_components.py
@@ -351,6 +351,49 @@ class TestSubsample:
         assert set(range(10)).issubset(xs)
 
 
+def test_validate_with_sample_works_on_eager_polars(monkeypatch, request):
+    """``schema.validate(eager_df, sample=N)`` runs end-to-end via the
+    Narwhals container.
+
+    Regression test: the container originally always passed
+    ``nw.LazyFrame`` to ``subsample()``, which made the eager-only
+    ``sample=`` path unreachable in the public API. The container now
+    materializes the LazyFrame back to ``nw.DataFrame`` when the caller
+    originally passed an eager polars frame.
+    """
+    import pandera.polars as pa
+    from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG
+
+    monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
+    request.addfinalizer(register_polars_backends.cache_clear)
+    register_polars_backends.cache_clear()
+    register_polars_backends()
+
+    schema = pa.DataFrameSchema({"x": pa.Column(pl.Int64)})
+    df = pl.DataFrame({"x": list(range(20))})
+    out = schema.validate(df, sample=5)
+    assert isinstance(out, pl.DataFrame)
+    assert out.shape == (20, 1)
+
+
+def test_validate_with_sample_on_lazyframe_raises(monkeypatch, request):
+    """``sample=`` on a LazyFrame still raises (sample is eager-only)."""
+    import pandera.polars as pa
+    from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG
+
+    monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
+    request.addfinalizer(register_polars_backends.cache_clear)
+    register_polars_backends.cache_clear()
+    register_polars_backends()
+
+    schema = pa.DataFrameSchema({"x": pa.Column(pl.Int64)})
+    lf = pl.LazyFrame({"x": list(range(20))})
+    with pytest.raises(NotImplementedError, match="sample="):
+        schema.validate(lf, sample=5)
+
+
 # ---------------------------------------------------------------------------
 # Phase 6 RED baseline: failure_cases_metadata() returns ibis.Table for ibis input
 # ---------------------------------------------------------------------------

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -620,11 +620,6 @@ def test_ordered(ldf_basic, ldf_schema_basic):
         invalid_order.pipe(ldf_schema_basic.validate).collect()
 
 
-@pytest.mark.xfail(
-    condition=CONFIG.use_narwhals_backend,
-    reason="sample= parameter not supported in Narwhals backend",
-    strict=True,
-)
 def test_sample_dataframe_schema(df_basic, ldf_basic, ldf_schema_basic):
     with pytest.raises(NotImplementedError):
         ldf_schema_basic.validate(ldf_basic, sample=1, random_state=1)


### PR DESCRIPTION
## Summary

Closes the Part-2 "sample= subsampling" gap from the Narwhals roadmap.
Previously `NarwhalsSchemaBackend.subsample(..., sample=N)` unconditionally
raised `NotImplementedError`; this PR enables it for eager polars frames and
wires it through the public API.

- **Eager `nw.DataFrame` (polars):** delegates to `frame.sample(n=sample,
  seed=random_state)`, matching the legacy polars backend.
- **`nw.LazyFrame` (polars lazy):** raises `NotImplementedError` — sampling
  a lazy frame requires materialization; users should `.collect()` first or
  use `head=` / `tail=`.
- **SQL-lazy backends (Ibis / DuckDB / PySpark):** raises
  `NotImplementedError` — representing sampling as a pure SQL expression is
  intentionally out of scope here.
- **`DataFrameSchemaBackend.validate`:** when the caller originally passed
  an eager `pl.DataFrame` and `sample=` is requested, we now materialize the
  `LazyFrame` back to `nw.DataFrame` before calling `subsample`, mirroring
  the polars backend's `_to_frame_kind` round-trip. Without this fix, the
  subsample logic was unreachable through the public API.

## Test plan

- [x] `tests/narwhals/test_components.py` — three direct backend cases
      (eager ok, lazy raises, ibis raises) plus a `head=` + `sample=`
      combination test, plus two end-to-end public-API regression tests.
- [x] Drops the now-stale `xfail(strict=True)` on
      `tests/polars/test_polars_container.py::test_sample_dataframe_schema`;
      the test passes on the Narwhals backend.
- [ ] CI: full narwhals + polars test suites.


Made with [Cursor](https://cursor.com)