### PR TITLE
feat(narwhals): cross-backend validation (pyspark via narwhals)

### DIFF
--- a/docs/source/ibis.md
+++ b/docs/source/ibis.md
@@ -438,6 +438,8 @@ Element-wise checks using ``DataFrameModel`` are not yet supported in
 the Ibis integration; use ``DataFrameSchema`` instead.
 :::
 
+(ibis-cross-backend)=
+
 ## Cross-Backend Validation (via Narwhals)
 
 Pandera's Ibis backend is built on top of
@@ -451,6 +453,7 @@ supported native input types are:
 - `polars.DataFrame`
 - `polars.LazyFrame`
 - `pyarrow.Table`
+- `pyspark.sql.DataFrame` *(experimental)*
 
 ```python
 import ibis.expr.datatypes as dt
@@ -473,10 +476,51 @@ schema.validate(pdf)
 ```
 
 The output is the same native type as the input. By default, eager
-inputs (`pandas.DataFrame`, `polars.DataFrame`) run both schema- and
-data-level checks; SQL-lazy inputs (`ibis.Table`) and `polars.LazyFrame`
-only run schema-level checks unless overridden via the
-``ValidationDepth`` config.
+inputs (`pandas.DataFrame`, `polars.DataFrame`, `pyarrow.Table`) run
+both schema- and data-level checks; SQL-lazy inputs (`ibis.Table`,
+`pyspark.sql.DataFrame`) and `polars.LazyFrame` only run schema-level
+checks unless overridden via the ``ValidationDepth`` config.
+
+(ibis-cross-backend-pyspark)=
+
+### PySpark via Narwhals
+
+PySpark `DataFrame`s are *SQL-lazy*; the cross-backend route applies a few
+extra constraints relative to the eager backends:
+
+```python
+import os
+os.environ["SPARK_LOCAL_IP"] = "127.0.0.1"
+
+import pandera.ibis as pa
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.master("local[1]").getOrCreate()
+df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["a", "b"])
+
+schema = pa.DataFrameSchema(
+    {
+        "a": pa.Column(int),
+        "b": pa.Column(str),
+    }
+)
+
+validated = schema.validate(df)
+# input type is preserved -> validated is a pyspark.sql.DataFrame
+```
+
+Notes and caveats:
+
+- **Validation depth**: `pyspark.sql.DataFrame` defaults to `SCHEMA_ONLY`.
+  Force `SCHEMA_AND_DATA` via `PANDERA_VALIDATION_DEPTH=SCHEMA_AND_DATA`
+  (or the {py:func}`pandera.config.config_context` manager) when you want
+  data-level checks to execute on the cluster.
+- **Subsampling**: only `head=` is supported; `tail=` and `sample=`
+  raise `NotImplementedError`.
+- **Native pyspark integration unaffected**: `import pandera.pyspark`
+  and the `pyspark.sql`-native backend continue to work as before. This
+  cross-backend route only activates when you call
+  `pandera.ibis.DataFrameSchema.validate(pyspark_df)`.
 
 ## Supported and Unsupported Functionality
 

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -834,6 +834,8 @@ Under the hood, the validation process will make `.collect()` calls on the
 LazyFrame in order to run data-level validation checks, and it will still
 return a `pl.LazyFrame` after validation is done.
 
+(polars-cross-backend)=
+
 ## Cross-Backend Validation (via Narwhals)
 
 When [Narwhals](https://narwhals-dev.github.io/narwhals/) is installed (which
@@ -847,6 +849,7 @@ narwhals-supported native frame** — not just `polars.DataFrame` /
 - `polars.LazyFrame`
 - `pandas.DataFrame`
 - `pyarrow.Table`
+- `pyspark.sql.DataFrame` *(experimental)*
 
 ```{code-cell} python
 import pandas as pd
@@ -872,13 +875,59 @@ Schema.validate(pdf)
 
 The output is the same native type as the input — a `pandas.DataFrame` in
 goes a `pandas.DataFrame` out. By default, eager native inputs (e.g.
-`pandas.DataFrame`, `polars.DataFrame`) run both schema- and data-level
-checks; lazy inputs (`polars.LazyFrame`) only run schema-level checks
-unless you set `validation_depth=ValidationDepth.SCHEMA_AND_DATA`.
+`pandas.DataFrame`, `polars.DataFrame`, `pyarrow.Table`) run both schema-
+and data-level checks; lazy / SQL-lazy inputs (`polars.LazyFrame`,
+`pyspark.sql.DataFrame`) only run schema-level checks unless you set
+`validation_depth=ValidationDepth.SCHEMA_AND_DATA`.
 
 Per-column `coerce=True` is not yet supported for non-polars native
 inputs (it's marked `xfail` for the polars backend in general — see
 {ref}`supported features matrix <supported-features>`).
+
+(polars-cross-backend-pyspark)=
+
+### PySpark via Narwhals
+
+PySpark `DataFrame`s are *SQL-lazy*; the cross-backend route applies a few
+extra constraints relative to the eager backends:
+
+```python
+import os
+os.environ["SPARK_LOCAL_IP"] = "127.0.0.1"
+
+import pandera.polars as pa
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.master("local[1]").getOrCreate()
+df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["a", "b"])
+
+schema = pa.DataFrameSchema(
+    {
+        "a": pa.Column(int),
+        "b": pa.Column(str),
+    }
+)
+
+validated = schema.validate(df)
+# input type is preserved -> validated is a pyspark.sql.DataFrame
+```
+
+Notes and caveats:
+
+- **Validation depth**: `pyspark.sql.DataFrame` defaults to `SCHEMA_ONLY` so
+  pandera does not trigger a full `.toPandas()` materialization for
+  data-level checks. Force `SCHEMA_AND_DATA` via
+  `PANDERA_VALIDATION_DEPTH=SCHEMA_AND_DATA` (or the
+  {py:func}`pandera.config.config_context` context manager) when you want
+  data-level checks to execute on the cluster.
+- **Subsampling**: only `head=` is supported. `tail=` raises
+  `NotImplementedError` because SQL has no notion of TAIL without a
+  forced full ordering. `sample=` is also unsupported on the Narwhals
+  backend.
+- **Native pyspark integration unaffected**: `import pandera.pyspark` and
+  the `pyspark.sql`-native backend continue to work as before. The
+  cross-backend route only activates when you call
+  `pandera.polars.DataFrameSchema.validate(pyspark_df)`.
 
 ## Supported and Unsupported Functionality
 

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -9,9 +9,11 @@ def _optional_native_frame_types() -> list[type]:
     """Collect optional narwhals-supported native frame classes.
 
     Each entry is registered against the ibis schema/backend dispatch so
-    users can validate, e.g., a ``pd.DataFrame`` with an ibis schema. The
-    narwhals backend wraps the native input internally, so the same
-    backend implementations work uniformly across native types.
+    users can validate, e.g., a ``pd.DataFrame`` or a ``pyspark.sql.DataFrame``
+    with an ibis schema. The narwhals backend wraps the native input
+    internally, so the same backend implementations work uniformly across
+    native types. Imports are best-effort — missing packages are silently
+    skipped.
     """
     classes: list[type] = []
     try:
@@ -30,6 +32,22 @@ def _optional_native_frame_types() -> list[type]:
         import pyarrow as pa
 
         classes.append(pa.Table)
+    except ImportError:
+        pass
+    try:
+        import pyspark.sql
+
+        classes.append(pyspark.sql.DataFrame)
+    except ImportError:
+        pass
+    # Spark Connect (pyspark>=3.4) ships its own ``DataFrame`` class which
+    # narwhals dispatches as ``Implementation.PYSPARK_CONNECT``. Registering
+    # both keeps cross-backend coverage in step with the legacy pyspark
+    # register at ``pandera.backends.pyspark.register``.
+    try:
+        from pyspark.sql.connect import dataframe as pyspark_connect
+
+        classes.append(pyspark_connect.DataFrame)
     except ImportError:
         pass
     return classes
@@ -80,16 +98,20 @@ def register_ibis_backends(
         Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
 
         # Cross-backend support: enable validating any narwhals-supported
-        # native frame (pandas, polars, pyarrow, ...) against an ibis schema.
+        # native frame (pandas, polars, pyarrow, pyspark.sql.DataFrame, ...)
+        # against an ibis schema. The narwhals backend wraps the native input
+        # via ``nw.from_native`` and operates on a Narwhals LazyFrame
+        # internally, so the same backend implementations work uniformly
+        # across native types.
         #
         # IMPORTANT: We deliberately do NOT register the cross-backend native
         # frames against ``Check``. ``Check.register_backend`` is first-write-
-        # wins, and the legacy pandas backend also claims ``pd.DataFrame``;
-        # letting both compete would silently break pandera's own pandas
-        # tests. Custom dataframe-level checks always receive a Narwhals frame
-        # inside the narwhals backend (``check_obj`` is wrapped to
-        # ``nw.LazyFrame`` before dispatch), so dispatch by the registered
-        # ``nw.LazyFrame`` entry is sufficient.
+        # wins, and the legacy pandas/pyspark backends already claim
+        # ``pd.DataFrame`` / ``pyspark.sql.DataFrame`` — letting both compete
+        # would silently break each other's tests. Custom dataframe-level
+        # checks always receive a Narwhals frame inside the narwhals backend
+        # (``check_obj`` is wrapped to ``nw.LazyFrame`` before dispatch), so
+        # dispatch by the registered ``nw.LazyFrame`` entry is sufficient.
         for native_cls in _optional_native_frame_types():
             DataFrameSchema.register_backend(
                 native_cls, DataFrameSchemaBackend

--- a/pandera/backends/narwhals/base.py
+++ b/pandera/backends/narwhals/base.py
@@ -78,8 +78,8 @@ class NarwhalsSchemaBackend(BaseSchemaBackend):
         :param sample: Not supported — raises NotImplementedError.
         :param random_state: Ignored (no random sampling supported).
         :raises NotImplementedError: If sample is not None, or if tail= is
-            requested on a SQL-lazy backend (ibis.Table) that does not support
-            TAIL without forced full ordering.
+            requested on a SQL-lazy backend (ibis.Table, pyspark.sql.DataFrame)
+            that does not support TAIL without forced full ordering.
         """
         if sample is not None:
             raise NotImplementedError(
@@ -90,7 +90,9 @@ class NarwhalsSchemaBackend(BaseSchemaBackend):
         if head is None and tail is None:
             return check_obj
 
-        # Guard: SQL-lazy backends don't support tail without full ordering
+        # Guard: SQL-lazy backends don't support tail without full ordering.
+        # ``_is_sql_lazy`` covers ibis, duckdb, and pyspark via the
+        # ``_SQL_LAZY_IMPLEMENTATIONS`` set in ``pandera.api.narwhals.utils``.
         if tail is not None and _is_sql_lazy(check_obj):
             raise NotImplementedError(
                 "tail= is not supported on SQL-lazy backends (Ibis, DuckDB, PySpark) "

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -9,8 +9,9 @@ def _optional_native_frame_types() -> list[type]:
     """Collect optional narwhals-supported native frame classes.
 
     Each entry is registered against the polars schema/backend dispatch so
-    users can validate, e.g., a ``pd.DataFrame`` with a polars schema.
-    Imports are best-effort — missing packages are silently skipped.
+    users can validate, e.g., a ``pd.DataFrame`` or a ``pyspark.sql.DataFrame``
+    with a polars schema. Imports are best-effort — missing packages are
+    silently skipped.
     """
     classes: list[type] = []
     try:
@@ -23,6 +24,22 @@ def _optional_native_frame_types() -> list[type]:
         import pyarrow as pa
 
         classes.append(pa.Table)
+    except ImportError:
+        pass
+    try:
+        import pyspark.sql
+
+        classes.append(pyspark.sql.DataFrame)
+    except ImportError:
+        pass
+    # Spark Connect (pyspark>=3.4) ships its own ``DataFrame`` class which
+    # narwhals dispatches as ``Implementation.PYSPARK_CONNECT``. Registering
+    # both keeps cross-backend coverage in step with the legacy pyspark
+    # register at ``pandera.backends.pyspark.register``.
+    try:
+        from pyspark.sql.connect import dataframe as pyspark_connect
+
+        classes.append(pyspark_connect.DataFrame)
     except ImportError:
         pass
     return classes
@@ -71,20 +88,22 @@ def register_polars_backends(
         Check.register_backend(nw.DataFrame, NarwhalsCheckBackend)
 
         # Cross-backend support: enable validating any narwhals-supported
-        # native frame (pandas, pyarrow, ...) against a polars schema.
-        # The narwhals backend wraps the native input via ``nw.from_native``
-        # and operates on a Narwhals LazyFrame internally, so the same
-        # backend implementations work uniformly across native types.
+        # native frame (pandas, pyarrow, pyspark.sql.DataFrame, ...) against
+        # a polars schema. The narwhals backend wraps the native input via
+        # ``nw.from_native`` and operates on a Narwhals LazyFrame internally,
+        # so the same backend implementations work uniformly across native
+        # types.
         #
         # IMPORTANT: We do NOT register the cross-backend native frames
         # against ``Check`` here. ``Check.register_backend`` is first-write-
-        # wins, and the legacy pandas backend also registers ``pd.DataFrame``
-        # against ``PandasCheckBackend``. Letting both compete would silently
-        # break pandera's own pandas tests. Custom dataframe-level checks
-        # always receive a Narwhals frame inside the narwhals backend
-        # (``check_obj`` is wrapped to ``nw.LazyFrame`` before dispatch),
-        # so dispatch by the registered ``nw.LazyFrame`` /  ``nw.DataFrame``
-        # entries is sufficient.
+        # wins, and the legacy pandas/pyspark backends already register
+        # ``pd.DataFrame`` / ``pyspark.sql.DataFrame`` against their own
+        # check backends. Letting both compete would silently break each
+        # other's tests. Custom dataframe-level checks always receive a
+        # Narwhals frame inside the narwhals backend (``check_obj`` is
+        # wrapped to ``nw.LazyFrame`` before dispatch), so dispatch by the
+        # registered ``nw.LazyFrame`` / ``nw.DataFrame`` entries is
+        # sufficient.
         for native_cls in _optional_native_frame_types():
             DataFrameSchema.register_backend(
                 native_cls, DataFrameSchemaBackend

--- a/tests/narwhals/test_pyspark_via_narwhals.py
+++ b/tests/narwhals/test_pyspark_via_narwhals.py
@@ -1,0 +1,254 @@
+"""Cross-backend validation: PySpark DataFrames via the narwhals backend.
+
+These tests demonstrate that a ``pyspark.sql.DataFrame`` can be validated
+against a ``pandera.polars`` or ``pandera.ibis`` schema by routing through
+the Narwhals backend (``nw.from_native(pyspark_df) -> nw.LazyFrame``).
+
+Notes
+-----
+- Tests are skipped if PySpark is not installed or a local SparkSession
+  cannot be created (e.g. unsupported Java version).
+- PySpark DataFrames are SQL-lazy; the default validation depth is
+  ``SCHEMA_ONLY``. Tests that exercise data-level checks explicitly opt
+  into ``SCHEMA_AND_DATA`` via ``config_context``.
+- ``sample=`` and ``tail=`` are not supported on SQL-lazy backends (Spark);
+  use ``head=`` only.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pandera.config import ValidationDepth, config_context
+from pandera.errors import SchemaError, SchemaErrors
+
+pyspark = pytest.importorskip("pyspark")
+
+# Configure Spark for local testing before importing SparkSession-related modules
+os.environ.setdefault("SPARK_LOCAL_IP", "127.0.0.1")
+os.environ.setdefault("PYARROW_IGNORE_TIMEZONE", "1")
+
+from pyspark.sql import SparkSession  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def spark():
+    """Create a local SparkSession; skip if Java/Spark cannot start."""
+    try:
+        builder = (
+            SparkSession.builder.master("local[1]")
+            .appName("pandera-narwhals-pyspark")
+            .config("spark.sql.ansi.enabled", False)
+            .config("spark.hadoop.fs.defaultFS", "file:///")
+            .config("spark.sql.warehouse.dir", "file:///tmp/spark-warehouse")
+        )
+        session = builder.getOrCreate()
+    except Exception as exc:  # pragma: no cover - environmental
+        pytest.skip(f"SparkSession could not be created: {exc}")
+    yield session
+    session.stop()
+
+
+@pytest.fixture
+def sample_df(spark):
+    return spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["a", "b"])
+
+
+# ---------------------------------------------------------------------------
+# Polars schemas validating PySpark DataFrames
+# ---------------------------------------------------------------------------
+
+
+def test_polars_schema_validates_pyspark_dataframe(sample_df):
+    """Schema-only checks pass for a well-formed pyspark.sql.DataFrame."""
+    import pandera.polars as pa
+
+    schema = pa.DataFrameSchema(
+        {
+            "a": pa.Column(int),
+            "b": pa.Column(str),
+        }
+    )
+
+    out = schema.validate(sample_df)
+    # input type is preserved on success
+    assert type(out).__name__ == "DataFrame"
+    assert out.schema == sample_df.schema
+
+
+def test_polars_schema_dtype_mismatch_raises(spark):
+    """Wrong dtype is detected at SCHEMA scope."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(1.0,), (2.0,)], ["x"])
+    schema = pa.DataFrameSchema({"x": pa.Column(int)})
+
+    with pytest.raises(SchemaError, match="expected column 'x' to have type"):
+        schema.validate(df)
+
+
+def test_polars_schema_strict_extra_column(spark):
+    """``strict=True`` rejects unexpected columns."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(1, "a", True)], ["a", "b", "extra"])
+    schema = pa.DataFrameSchema(
+        {"a": pa.Column(int), "b": pa.Column(str)}, strict=True
+    )
+
+    with pytest.raises(SchemaError, match="not in DataFrameSchema"):
+        schema.validate(df)
+
+
+def test_polars_schema_strict_filter_drops_extra_column(spark):
+    """``strict='filter'`` returns the schema columns only."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame(
+        [(1, "a", True), (2, "b", False)], ["a", "b", "extra"]
+    )
+    schema = pa.DataFrameSchema(
+        {"a": pa.Column(int), "b": pa.Column(str)}, strict="filter"
+    )
+
+    out = schema.validate(df)
+    assert out.columns == ["a", "b"]
+
+
+def test_polars_schema_data_check_skipped_by_default(spark):
+    """Data-level checks default to SCHEMA_ONLY for lazy/SQL-lazy frames."""
+    import pandera.polars as pa
+
+    # Failing data: 0 < 1 violates ge(1)
+    df = spark.createDataFrame([(0,), (1,), (2,)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int, pa.Check.ge(1))})
+
+    # Default validation depth for pyspark (SQL-lazy) is SCHEMA_ONLY,
+    # so the data-level check ``ge(1)`` is skipped.
+    out = schema.validate(df)
+    assert type(out).__name__ == "DataFrame"
+
+
+def test_polars_schema_data_check_runs_when_forced(spark):
+    """Forcing SCHEMA_AND_DATA runs data checks on pyspark frames."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(0,), (1,), (2,)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int, pa.Check.ge(1))})
+
+    with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+        with pytest.raises(SchemaError):
+            schema.validate(df)
+
+
+def test_polars_schema_unique_check_runs_when_forced(spark):
+    """``unique=True`` is a data-level check; runs when depth is forced."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(1,), (1,), (2,)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int, unique=True)})
+
+    with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+        with pytest.raises(SchemaError, match="not unique"):
+            schema.validate(df)
+
+
+def test_polars_schema_lazy_collects_multiple_errors(spark):
+    """``lazy=True`` returns all errors via SchemaErrors."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(0,), (1,)], ["a"])
+    schema = pa.DataFrameSchema(
+        {
+            "a": pa.Column(int, pa.Check.ge(5)),
+            "b": pa.Column(str),  # missing
+        }
+    )
+
+    with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+        with pytest.raises(SchemaErrors):
+            schema.validate(df, lazy=True)
+
+
+def test_polars_schema_head_subsample(spark):
+    """``head=`` is supported on SQL-lazy backends."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(i,) for i in range(10)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int)})
+
+    out = schema.validate(df, head=3)
+    assert type(out).__name__ == "DataFrame"
+
+
+def test_polars_schema_tail_unsupported_for_pyspark(spark):
+    """``tail=`` raises NotImplementedError on SQL-lazy backends."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(i,) for i in range(5)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int)})
+
+    with pytest.raises(NotImplementedError, match="tail="):
+        schema.validate(df, tail=2)
+
+
+def test_polars_schema_sample_unsupported(spark):
+    """``sample=`` is not supported in the narwhals backend."""
+    import pandera.polars as pa
+
+    df = spark.createDataFrame([(i,) for i in range(5)], ["a"])
+    schema = pa.DataFrameSchema({"a": pa.Column(int)})
+
+    with pytest.raises(NotImplementedError, match="sample="):
+        schema.validate(df, sample=2)
+
+
+# ---------------------------------------------------------------------------
+# Ibis schemas validating PySpark DataFrames
+# ---------------------------------------------------------------------------
+
+
+def test_ibis_schema_validates_pyspark_dataframe(sample_df):
+    """An ibis schema can validate a pyspark.sql.DataFrame."""
+    pytest.importorskip("ibis")
+    import pandera.ibis as pa
+
+    schema = pa.DataFrameSchema(
+        {
+            "a": pa.Column(int),
+            "b": pa.Column(str),
+        }
+    )
+
+    out = schema.validate(sample_df)
+    assert type(out).__name__ == "DataFrame"
+
+
+def test_ibis_schema_dtype_mismatch_raises(spark):
+    """Wrong dtype is detected via ibis schema as well."""
+    pytest.importorskip("ibis")
+    import pandera.ibis as pa
+
+    df = spark.createDataFrame([(1.0,), (2.0,)], ["x"])
+    schema = pa.DataFrameSchema({"x": pa.Column(int)})
+
+    with pytest.raises(SchemaError, match="expected column 'x' to have type"):
+        schema.validate(df)
+
+
+def test_ibis_schema_strict_filter_drops_extra_column(spark):
+    """``strict='filter'`` works through the ibis -> narwhals backend."""
+    pytest.importorskip("ibis")
+    import pandera.ibis as pa
+
+    df = spark.createDataFrame(
+        [(1, "a", True), (2, "b", False)], ["a", "b", "extra"]
+    )
+    schema = pa.DataFrameSchema(
+        {"a": pa.Column(int), "b": pa.Column(str)}, strict="filter"
+    )
+
+    out = schema.validate(df)
+    assert out.columns == ["a", "b"]


### PR DESCRIPTION
> **Stacked on top of #2333** — please review/merge that one first.

## Summary

Builds on the pandas/pyarrow cross-backend support in #2333 to enable
validating `pyspark.sql.DataFrame` objects against `pandera.polars` and
`pandera.ibis` schemas via the Narwhals backend. `nw.from_native(pyspark_df)`
returns a `nw.LazyFrame` whose native is the original Spark DataFrame, so the
existing Narwhals code path runs unchanged and the input type is preserved.

- Register `pyspark.sql.DataFrame` for `DataFrameSchemaBackend` /
  `ColumnBackend` in `pandera/backends/polars/register.py` and
  `pandera/backends/ibis/register.py`. `Check` is intentionally not
  re-registered (first-write-wins; the native `pandera.pyspark` backend owns
  that dispatch).
- Guard `subsample` to raise `NotImplementedError` for `tail=` on Spark
  (SQL-lazy), matching the existing ibis behavior.
- Default `validation_depth` for Spark inputs resolves to `SCHEMA_ONLY` (no
  forced `.toPandas()`); users opt into data-level checks via
  `PANDERA_VALIDATION_DEPTH=SCHEMA_AND_DATA` or `config_context`.

## Test plan

- [x] `tests/narwhals/test_pyspark_via_narwhals.py` (new) — covers dtype
      mismatch, `strict=True`/`strict='filter'`, `unique`, lazy multi-error
      collection, `head=`, and the `tail=` / `sample=` unsupported paths.
      Skips cleanly when PySpark or Java are unavailable.
- [x] Docs updated in `docs/source/polars.md` and `docs/source/ibis.md`.
- [ ] CI: full narwhals + polars + ibis + pyspark test suites.