### PR TITLE
feat(narwhals): hypothesis strategies for polars + ibis schemas

### DIFF
--- a/pandera/api/ibis/container.py
+++ b/pandera/api/ibis/container.py
@@ -119,6 +119,47 @@ class DataFrameSchema(_DataFrameSchema[ibis.Table]):
         """Set the dtype property."""
         self._dtype = ibis_engine.Engine.dtype(value) if value else None
 
+    def strategy(self, *, size: int | None = None, n_regex_columns: int = 1):
+        """Create a ``hypothesis`` strategy for generating an ibis Table.
+
+        Internally generates a pandas DataFrame using
+        :mod:`pandera.strategies.pandas_strategies` (for full check
+        coverage) and converts the result to an ``ibis.memtable``.
+
+        :param size: number of elements to generate.
+        :param n_regex_columns: number of regex columns to generate.
+        :returns: a strategy that produces ``ibis.Table`` objects.
+        """
+        import ibis
+
+        from pandera.strategies import narwhals_strategies as nws
+
+        self.register_default_backends(ibis.Table)
+        return nws.strategy_for_schema(
+            self,
+            target="ibis",
+            size=size,
+            n_regex_columns=n_regex_columns,
+        )
+
+    def example(self, size: int | None = None, n_regex_columns: int = 1):
+        """Generate a single example ibis Table from this schema.
+
+        :param size: number of elements in the generated table.
+        :returns: ``ibis.Table`` (memtable) object.
+        """
+        import ibis
+
+        from pandera.strategies import narwhals_strategies as nws
+
+        self.register_default_backends(ibis.Table)
+        return nws.example(
+            self,
+            target="ibis",
+            size=size,
+            n_regex_columns=n_regex_columns,
+        )
+
     #####################
     # Schema IO Methods #
     #####################

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -218,17 +218,21 @@ class Column(ComponentSchema[PolarsCheckObjects]):
         return self
 
     def strategy(self, *, size=None):
-        """Create a ``hypothesis`` strategy for generating a Column.
+        """Create a ``hypothesis`` strategy for generating a single-column polars DataFrame.
 
-        :param size: number of elements to generate
-        :returns: a dataframe strategy for a single column.
+        Delegates to :func:`pandera.strategies.narwhals_strategies.dataframe_strategy`
+        with a single-column wrapper schema.
 
-        .. warning::
-
-           This method is not implemented in the polars backend.
+        :param size: number of elements to generate.
+        :returns: a strategy that produces ``polars.DataFrame`` objects
+            with one column.
         """
-        raise NotImplementedError(
-            "Data synthesis is not supported in with polars schemas."
+        from pandera.strategies import narwhals_strategies as nws
+
+        return nws.dataframe_strategy(
+            columns={self.name or "x": self},
+            size=size,
+            target="polars_eager",
         )
 
     def strategy_component(self):
@@ -243,16 +247,18 @@ class Column(ComponentSchema[PolarsCheckObjects]):
         )
 
     def example(self, size=None):
-        """Generate an example of a particular size.
+        """Generate a single-column polars DataFrame from this Column.
 
-        :param size: number of elements in the generated Index.
-        :returns: pandas DataFrame object.
-
-        .. warning::
-
-           This method is not implemented in the polars backend.
+        :param size: number of elements to generate.
+        :returns: ``polars.DataFrame`` with one column.
         """
+        import warnings
 
-        raise NotImplementedError(
-            "Data synthesis is not supported in with polars schemas."
-        )
+        import hypothesis
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(
+                "ignore",
+                category=hypothesis.errors.NonInteractiveExampleWarning,
+            )
+            return self.strategy(size=size).example()

--- a/pandera/api/polars/container.py
+++ b/pandera/api/polars/container.py
@@ -92,32 +92,45 @@ class DataFrameSchema(_DataFrameSchema[PolarsCheckObjects]):
         self._dtype = polars_engine.Engine.dtype(value) if value else None
 
     def strategy(self, *, size: int | None = None, n_regex_columns: int = 1):
-        """Create a ``hypothesis`` strategy for generating a DataFrame.
+        """Create a ``hypothesis`` strategy for generating a polars DataFrame.
+
+        Internally generates a pandas DataFrame using
+        :mod:`pandera.strategies.pandas_strategies` (for full check
+        coverage) and converts the result to a ``polars.DataFrame`` via
+        ``pl.from_pandas``.
 
         :param size: number of elements to generate
         :param n_regex_columns: number of regex columns to generate.
-        :returns: a strategy that generates pandas DataFrame objects.
-
-        .. warning::
-
-           This method is not implemented in the polars backend.
+        :returns: a strategy that generates ``polars.DataFrame`` objects.
         """
-        raise NotImplementedError(
-            "Data synthesis is not supported in with polars schemas."
+        import polars as pl
+
+        from pandera.strategies import narwhals_strategies as nws
+
+        self.register_default_backends(pl.DataFrame)
+        return nws.strategy_for_schema(
+            self,
+            target="polars_eager",
+            size=size,
+            n_regex_columns=n_regex_columns,
         )
 
     def example(self, size: int | None = None, n_regex_columns: int = 1):
-        """Generate an example of a particular size.
+        """Generate a single example polars DataFrame from this schema.
 
         :param size: number of elements in the generated DataFrame.
-        :returns: pandas DataFrame object.
-
-        .. warning::
-
-           This method is not implemented in polars backend.
+        :returns: ``polars.DataFrame`` object.
         """
-        raise NotImplementedError(
-            "Data synthesis is not supported in with polars schemas."
+        import polars as pl
+
+        from pandera.strategies import narwhals_strategies as nws
+
+        self.register_default_backends(pl.DataFrame)
+        return nws.example(
+            self,
+            target="polars_eager",
+            size=size,
+            n_regex_columns=n_regex_columns,
         )
 
     #####################

--- a/pandera/strategies/narwhals_strategies.py
+++ b/pandera/strategies/narwhals_strategies.py
@@ -1,0 +1,297 @@
+"""Hypothesis strategies for the Narwhals-backed schemas (polars + ibis).
+
+The Narwhals backend does not yet have its own dtype-aware data
+generator. Instead, this module reuses the existing pandas strategies
+infrastructure:
+
+1. Translate each column's polars / ibis dtype into a numpy / pandas
+   equivalent dtype.
+2. Build a parallel pandas-flavoured ``DataFrameSchema``.
+3. Call :func:`pandera.strategies.pandas_strategies.dataframe_strategy`.
+4. Convert the resulting pandas DataFrame to the target backend
+   (polars eager DataFrame, polars LazyFrame, or ibis memtable).
+
+This keeps every built-in pandera check (``ge``, ``isin``,
+``in_range``, ``str_matches``, …) working out of the box because the
+pandas strategy already knows how to honour them.
+
+**Limitations**
+
+Only "primitive" dtypes that round-trip cleanly through pandas are
+supported (int, uint, float, bool, string, date, datetime). Complex
+polars/ibis types such as ``Struct``, ``List``, or
+``Categorical`` will raise ``NotImplementedError`` with a message
+pointing at the unsupported column.
+"""
+
+from __future__ import annotations
+
+import warnings
+from copy import deepcopy
+from typing import Any
+
+import pandas as pd
+
+from pandera.strategies.base_strategies import (
+    HAS_HYPOTHESIS,
+    strategy_import_error,
+)
+
+if HAS_HYPOTHESIS:
+    from hypothesis.strategies import SearchStrategy, composite
+else:  # pragma: no cover
+    from pandera.strategies.base_strategies import SearchStrategy, composite
+
+
+# ---------------------------------------------------------------------------
+# dtype translation helpers
+# ---------------------------------------------------------------------------
+
+
+def _polars_dtype_to_numpy(polars_dtype) -> Any:
+    """Return a pandas-compatible dtype for a polars dtype class/instance.
+
+    Uses polars itself as the source of truth: build an empty
+    ``pl.DataFrame`` typed as the requested column and ask polars for the
+    pandas dtype it would produce on ``to_pandas()``. This is robust to
+    upstream renames (Utf8 -> String, etc.).
+    """
+    import polars as pl
+
+    try:
+        empty = pl.DataFrame(schema={"x": polars_dtype})
+        return empty.to_pandas().dtypes["x"]
+    except Exception as exc:
+        raise NotImplementedError(
+            f"Cannot convert polars dtype {polars_dtype!r} to a pandas "
+            f"dtype for hypothesis strategy generation."
+        ) from exc
+
+
+def _ibis_dtype_to_numpy(ibis_dtype) -> Any:
+    """Return a pandas-compatible dtype for an ibis dtype."""
+    try:
+        return ibis_dtype.to_pandas()
+    except Exception as exc:
+        raise NotImplementedError(
+            f"Cannot convert ibis dtype {ibis_dtype!r} to a pandas "
+            f"dtype for hypothesis strategy generation."
+        ) from exc
+
+
+def _to_pandas_dtype(pandera_dtype) -> Any:
+    """Best-effort translation of a pandera dtype object to a pandas dtype.
+
+    Handles polars-engine dtypes (whose ``.type`` is a polars dtype) and
+    ibis-engine dtypes (whose ``.type`` is an ibis dtype). Falls back to
+    treating ``pandera_dtype.type`` itself as a pandas/numpy dtype if no
+    backend module can be identified.
+    """
+    if pandera_dtype is None:
+        return None
+
+    raw = getattr(pandera_dtype, "type", pandera_dtype)
+    module = getattr(raw, "__module__", "") or type(raw).__module__
+
+    if module.startswith("polars"):
+        return _polars_dtype_to_numpy(raw)
+    if module.startswith("ibis"):
+        return _ibis_dtype_to_numpy(raw)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Schema cloning
+# ---------------------------------------------------------------------------
+
+
+def _clone_columns_for_pandas(columns: dict) -> dict:
+    """Return a parallel ``dict[str, pandas Column]`` for pandas strategies.
+
+    Each input column's dtype is translated to a pandas-compatible dtype
+    and wrapped in a ``pandera.api.pandas.components.Column`` whose
+    other attributes (checks, nullable, unique, regex) are copied across.
+    The original schema's columns are left untouched.
+    """
+    from pandera.api.pandas.components import Column as PandasColumn
+
+    cloned: dict = {}
+    for name, col in columns.items():
+        target = _to_pandas_dtype(col.dtype)
+        if target is None:
+            raise NotImplementedError(
+                f"Hypothesis strategy generation requires a dtype for "
+                f"column {name!r}; got None."
+            )
+        try:
+            new_col = PandasColumn(
+                target,
+                checks=deepcopy(col.checks),
+                nullable=col.nullable,
+                unique=getattr(col, "unique", False),
+                regex=getattr(col, "regex", False),
+                name=name,
+            )
+        except Exception as exc:
+            raise NotImplementedError(
+                f"Hypothesis strategy generation does not support "
+                f"column {name!r} with dtype {col.dtype!r}: {exc}"
+            ) from exc
+        cloned[name] = new_col
+    return cloned
+
+
+# ---------------------------------------------------------------------------
+# Conversion of generated pandas DataFrame -> target backend
+# ---------------------------------------------------------------------------
+
+
+def _to_target(df: pd.DataFrame, target: str):
+    """Convert a generated pandas DataFrame into the requested backend type.
+
+    ``target`` is one of:
+
+    - ``"pandas"``: return the dataframe unchanged
+    - ``"polars"`` / ``"polars_eager"``: ``polars.DataFrame``
+    - ``"polars_lazy"``: ``polars.LazyFrame``
+    - ``"ibis"``: ``ibis.memtable``
+    """
+    if target == "pandas":
+        return df
+    if target in ("polars", "polars_eager"):
+        import polars as pl
+
+        return pl.from_pandas(df)
+    if target == "polars_lazy":
+        import polars as pl
+
+        return pl.from_pandas(df).lazy()
+    if target == "ibis":
+        import ibis
+
+        return ibis.memtable(df)
+    raise ValueError(f"Unknown target {target!r}")
+
+
+# ---------------------------------------------------------------------------
+# Public strategies
+# ---------------------------------------------------------------------------
+
+
+def _ensure_pandas_check_backends_registered() -> None:
+    """Register pandas check backends so ``Check(check_obj=pd.Series)`` works.
+
+    The pandas strategies fall back to ``strategy.filter(check)`` for
+    checks without a registered hypothesis strategy, which calls
+    ``check(pd.Series)`` to evaluate. That requires the pandas check
+    backend to be registered, which is normally only done lazily when a
+    pandas schema is instantiated. Here we proactively register both
+    ``pd.DataFrame`` and ``pd.Series`` backends.
+    """
+    from pandera.api.pandas.array import SeriesSchema
+    from pandera.api.pandas.container import (
+        DataFrameSchema as _PandasDataFrameSchema,
+    )
+
+    _PandasDataFrameSchema.register_default_backends(pd.DataFrame)
+    SeriesSchema.register_default_backends(pd.Series)
+
+
+@strategy_import_error
+def dataframe_strategy(
+    pandera_dtype=None,
+    strategy: SearchStrategy | None = None,
+    *,
+    columns: dict | None = None,
+    checks: list | None = None,
+    unique: list | None = None,
+    index=None,
+    size: int | None = None,
+    n_regex_columns: int = 1,
+    target: str = "polars",
+):
+    """Generate dataframes for narwhals-backed schemas (polars / ibis).
+
+    This is a thin wrapper around
+    :func:`pandera.strategies.pandas_strategies.dataframe_strategy` that
+    converts the generated pandas frame into the requested ``target``
+    backend. The check-aware data generation logic lives entirely in the
+    pandas strategies module.
+    """
+    from pandera.strategies import pandas_strategies as pst
+
+    _ensure_pandas_check_backends_registered()
+
+    columns = {} if columns is None else columns
+    pandas_columns = _clone_columns_for_pandas(columns)
+    pandas_dtype = _to_pandas_dtype(pandera_dtype) if pandera_dtype else None
+
+    base_strategy = pst.dataframe_strategy(
+        pandas_dtype,
+        strategy,
+        columns=pandas_columns,
+        checks=checks,
+        unique=unique,
+        index=index,
+        size=size,
+        n_regex_columns=n_regex_columns,
+    )
+
+    @composite
+    def _strategy(draw):
+        df = draw(base_strategy)
+        return _to_target(df, target)
+
+    return _strategy()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the schema/.example() integration
+# ---------------------------------------------------------------------------
+
+
+def example(
+    schema,
+    *,
+    target: str,
+    size: int | None = None,
+    n_regex_columns: int = 1,
+):
+    """Generate a single example for a narwhals-backed schema.
+
+    Suppresses ``hypothesis.NonInteractiveExampleWarning`` so the
+    behaviour mirrors the pandas implementation.
+    """
+    import hypothesis
+
+    with warnings.catch_warnings():
+        warnings.simplefilter(
+            "ignore", category=hypothesis.errors.NonInteractiveExampleWarning
+        )
+        return strategy_for_schema(
+            schema, target=target, size=size, n_regex_columns=n_regex_columns
+        ).example()
+
+
+def strategy_for_schema(
+    schema,
+    *,
+    target: str,
+    size: int | None = None,
+    n_regex_columns: int = 1,
+):
+    """Build a hypothesis strategy from a narwhals-backed schema.
+
+    Used by polars/ibis ``DataFrameSchema.strategy()`` to delegate to the
+    pandas backend.
+    """
+    return dataframe_strategy(
+        schema.dtype,
+        columns=schema.columns,
+        checks=schema.checks,
+        unique=schema.unique,
+        index=schema.index,
+        size=size,
+        n_regex_columns=n_regex_columns,
+        target=target,
+    )

--- a/tests/polars/test_polars_strategies.py
+++ b/tests/polars/test_polars_strategies.py
@@ -5,10 +5,26 @@ These previously asserted that ``strategy()`` and ``example()`` raised
 delegating to the pandas strategies and converting the result to polars.
 """
 
+import warnings
+
 import polars as pl
 import pytest
 
 import pandera.polars as pa
+
+pytest.importorskip("hypothesis")
+import hypothesis  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _silence_noninteractive_example_warning():
+    """``.example()`` emits a noisy warning that is irrelevant for these tests."""
+    with warnings.catch_warnings():
+        warnings.simplefilter(
+            "ignore",
+            category=hypothesis.errors.NonInteractiveExampleWarning,
+        )
+        yield
 
 
 def test_dataframe_schema_strategy_emits_polars_dataframe():

--- a/tests/polars/test_polars_strategies.py
+++ b/tests/polars/test_polars_strategies.py
@@ -1,28 +1,37 @@
-"""Unit tests for polars strategy methods."""
+"""Unit tests for polars strategy methods.
 
+These previously asserted that ``strategy()`` and ``example()`` raised
+``NotImplementedError``. The narwhals backend now implements them by
+delegating to the pandas strategies and converting the result to polars.
+"""
+
+import polars as pl
 import pytest
 
 import pandera.polars as pa
 
 
-def test_dataframe_schema_strategy():
-    schema = pa.DataFrameSchema()
+def test_dataframe_schema_strategy_emits_polars_dataframe():
+    schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64)})
+    out = schema.example(size=2)
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 2
 
+    strategy = schema.strategy(size=2)
+    drawn = strategy.example()
+    assert isinstance(drawn, pl.DataFrame)
+
+
+def test_column_schema_strategy_emits_polars_dataframe():
+    column = pa.Column(pl.Int64, name="x")
+    out = column.example(size=3)
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 3
+    assert "x" in out.columns
+
+
+def test_column_schema_strategy_component_still_unimplemented():
+    """``strategy_component`` is not part of the polars backend surface."""
+    column = pa.Column(pl.Int64, name="x")
     with pytest.raises(NotImplementedError):
-        schema.strategy()
-
-    with pytest.raises(NotImplementedError):
-        schema.example()
-
-
-def test_column_schema_strategy():
-    column_schema = pa.Column(str)
-
-    with pytest.raises(NotImplementedError):
-        column_schema.strategy()
-
-    with pytest.raises(NotImplementedError):
-        column_schema.example()
-
-    with pytest.raises(NotImplementedError):
-        column_schema.strategy_component()
+        column.strategy_component()

--- a/tests/strategies/test_narwhals_strategies.py
+++ b/tests/strategies/test_narwhals_strategies.py
@@ -1,0 +1,234 @@
+"""Tests for :mod:`pandera.strategies.narwhals_strategies`.
+
+Strategy generation for the Narwhals-backed schemas (polars + ibis) is
+implemented by piggy-backing on ``pandera.strategies.pandas_strategies``:
+generate a pandas DataFrame, then convert to the requested target.
+
+These tests exercise:
+
+- Direct :func:`narwhals_strategies.dataframe_strategy` calls for both
+  polars and ibis targets.
+- The container-level ``DataFrameSchema.example()`` /
+  ``DataFrameSchema.strategy()`` shortcuts on the polars and ibis
+  schemas.
+- Built-in checks (``ge``, ``in_range``, ``isin``) survive the
+  pandas-to-target conversion and the generated frame round-trips
+  through ``schema.validate`` cleanly.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+pytest.importorskip("hypothesis")
+
+import hypothesis  # noqa: E402
+import polars as pl  # noqa: E402
+
+import pandera.polars as pa_pl  # noqa: E402
+from pandera.api.checks import Check  # noqa: E402
+from pandera.strategies import narwhals_strategies as nws  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _silence_noninteractive_example_warning():
+    """``.example()`` emits a noisy warning that's irrelevant for these tests."""
+    with warnings.catch_warnings():
+        warnings.simplefilter(
+            "ignore", category=hypothesis.errors.NonInteractiveExampleWarning
+        )
+        yield
+
+
+# ---------------------------------------------------------------------------
+# dtype translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "polars_dtype,expected",
+    [
+        (pl.Int8, "int8"),
+        (pl.Int64, "int64"),
+        (pl.UInt32, "uint32"),
+        (pl.Float64, "float64"),
+        (pl.Boolean, "bool"),
+        (pl.String, "object"),
+    ],
+)
+def test_polars_dtype_to_numpy(polars_dtype, expected):
+    pd_dtype = nws._polars_dtype_to_numpy(polars_dtype)
+    assert str(pd_dtype) == expected
+
+
+def test_ibis_dtype_to_numpy():
+    dt = pytest.importorskip("ibis.expr.datatypes")
+    assert str(nws._ibis_dtype_to_numpy(dt.int64)) == "int64"
+    assert str(nws._ibis_dtype_to_numpy(dt.float64)) == "float64"
+    assert str(nws._ibis_dtype_to_numpy(dt.boolean)) == "bool"
+
+
+# ---------------------------------------------------------------------------
+# Polars DataFrameSchema strategy / example
+# ---------------------------------------------------------------------------
+
+
+def test_polars_schema_example_returns_polars_dataframe():
+    schema = pa_pl.DataFrameSchema(
+        {
+            "a": pa_pl.Column(pl.Int64, checks=Check.ge(0)),
+            "b": pa_pl.Column(pl.String),
+            "c": pa_pl.Column(pl.Float64, nullable=True),
+        }
+    )
+    out = schema.example(size=5)
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 5
+    schema.validate(out)
+
+
+def test_polars_schema_example_respects_in_range():
+    schema = pa_pl.DataFrameSchema(
+        {"x": pa_pl.Column(pl.Int64, checks=Check.in_range(10, 20))}
+    )
+    out = schema.example(size=10)
+    assert isinstance(out, pl.DataFrame)
+    xs = out["x"].to_list()
+    assert all(10 <= v <= 20 for v in xs)
+
+
+def test_polars_schema_example_respects_isin():
+    schema = pa_pl.DataFrameSchema(
+        {"g": pa_pl.Column(pl.String, checks=Check.isin(["a", "b", "c"]))}
+    )
+    out = schema.example(size=10)
+    assert set(out["g"].to_list()) <= {"a", "b", "c"}
+
+
+def test_polars_schema_strategy_can_draw():
+    """``schema.strategy()`` returns a hypothesis SearchStrategy."""
+    from hypothesis.strategies import SearchStrategy
+
+    schema = pa_pl.DataFrameSchema(
+        {"a": pa_pl.Column(pl.Int64, checks=Check.ge(0))}
+    )
+    strategy = schema.strategy(size=4)
+    assert isinstance(strategy, SearchStrategy)
+    drawn = strategy.example()
+    assert isinstance(drawn, pl.DataFrame)
+    schema.validate(drawn)
+
+
+# ---------------------------------------------------------------------------
+# Polars Column strategy / example
+# ---------------------------------------------------------------------------
+
+
+def test_polars_column_example_returns_dataframe():
+    col = pa_pl.Column(pl.Int64, name="a", checks=Check.ge(5))
+    out = col.example(size=4)
+    assert isinstance(out, pl.DataFrame)
+    assert "a" in out.columns
+    assert all(v >= 5 for v in out["a"].to_list())
+
+
+# ---------------------------------------------------------------------------
+# Ibis DataFrameSchema strategy / example
+# ---------------------------------------------------------------------------
+
+
+def test_ibis_schema_example_returns_ibis_table():
+    ibis = pytest.importorskip("ibis")
+    dt = pytest.importorskip("ibis.expr.datatypes")
+
+    import pandera.ibis as pa_ib
+
+    ibis.set_backend("duckdb")
+
+    schema = pa_ib.DataFrameSchema(
+        {
+            "a": pa_ib.Column(dt.int64, checks=Check.ge(0)),
+            "b": pa_ib.Column(dt.string),
+        }
+    )
+    out = schema.example(size=4)
+    assert isinstance(out, ibis.Table)
+    df = out.execute()
+    assert df.shape == (4, 2)
+    assert all(v >= 0 for v in df["a"].tolist())
+    schema.validate(out)
+
+
+def test_ibis_schema_strategy_can_draw():
+    ibis = pytest.importorskip("ibis")
+    dt = pytest.importorskip("ibis.expr.datatypes")
+
+    from hypothesis.strategies import SearchStrategy
+
+    import pandera.ibis as pa_ib
+
+    ibis.set_backend("duckdb")
+
+    schema = pa_ib.DataFrameSchema(
+        {"x": pa_ib.Column(dt.int64, checks=Check.in_range(10, 20))}
+    )
+    strategy = schema.strategy(size=6)
+    assert isinstance(strategy, SearchStrategy)
+    drawn = strategy.example()
+    df = drawn.execute()
+    assert all(10 <= v <= 20 for v in df["x"].tolist())
+
+
+# ---------------------------------------------------------------------------
+# Lazy target (polars LazyFrame)
+# ---------------------------------------------------------------------------
+
+
+def test_dataframe_strategy_polars_lazy_target():
+    """The ``polars_lazy`` target wraps the result with ``.lazy()``."""
+    schema = pa_pl.DataFrameSchema(
+        {"v": pa_pl.Column(pl.Int64, checks=Check.ge(0))}
+    )
+
+    strategy = nws.dataframe_strategy(
+        columns=schema.columns,
+        size=3,
+        target="polars_lazy",
+    )
+    drawn = strategy.example()
+    assert isinstance(drawn, pl.LazyFrame)
+    collected = drawn.collect()
+    assert collected.height == 3
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_dataframe_strategy_unknown_target_rejected():
+    schema = pa_pl.DataFrameSchema({"a": pa_pl.Column(pl.Int64)})
+    strategy = nws.dataframe_strategy(
+        columns=schema.columns,
+        size=1,
+        target="not-a-real-target",
+    )
+    with pytest.raises(ValueError, match="Unknown target"):
+        strategy.example()
+
+
+def test_to_pandas_dtype_returns_none_for_none():
+    """``_to_pandas_dtype(None)`` short-circuits to ``None``."""
+    assert nws._to_pandas_dtype(None) is None
+
+
+def test_polars_dtype_unknown_raises_not_implemented():
+    """A bogus polars dtype object surfaces a clear NotImplementedError."""
+
+    class _BadDtype:
+        __module__ = "polars.datatypes._fake"
+
+    with pytest.raises(NotImplementedError, match="polars dtype"):
+        nws._polars_dtype_to_numpy(_BadDtype)


### PR DESCRIPTION
## Summary

Implements `DataFrameSchema.strategy()` / `DataFrameSchema.example()` for the
narwhals-backed polars and ibis schemas, plus `Column.strategy()` /
`Column.example()` for polars columns. These were previously placeholders
that raised `NotImplementedError`.

- New `pandera.strategies.narwhals_strategies` module reuses the existing
  pandas strategies infrastructure rather than re-implementing it. Each
  polars / ibis dtype is translated to a pandas-compatible dtype, columns
  are cloned into pandas `Column` objects, and
  `pandas_strategies.dataframe_strategy` does the heavy lifting. The
  generated pandas DataFrame is then converted to the requested target via
  `pl.from_pandas`, `.lazy()`, or `ibis.memtable`.
- Built-in checks (`ge`, `le`, `in_range`, `isin`, `str_*`, ...) work out of
  the box because the pandas strategies already honour them.
- A small registration helper proactively registers the pandas check
  backend for `pd.DataFrame` / `pd.Series` so the `strategy.filter(check)`
  fallback in `pandas_strategies` does not fail with `BackendNotFound` when
  only the polars/ibis schemas have been materialised.
- Polars strategy tests now wrap `.example()` calls in a `catch_warnings`
  fixture (matching the new narwhals strategy tests) to silence
  hypothesis's `NonInteractiveExampleWarning`.

**Limitations:** only "primitive" dtypes round-trip cleanly (int, uint,
float, bool, string, date, datetime). Complex polars/ibis types (Struct,
List, Categorical, ...) raise `NotImplementedError` with a clear message.
`Column.strategy_component` is still unimplemented (and pinned by tests).

## Test plan

- [x] `tests/strategies/test_narwhals_strategies.py` (new, 18 cases) —
      dtype translation (polars + ibis), end-to-end `schema.example()` on
      both targets, `in_range` / `isin` honoured, polars `LazyFrame`
      target, error paths for unknown targets and unknown polars dtypes.
- [x] `tests/polars/test_polars_strategies.py` — replaced the
      `NotImplementedError` contract tests with positive-path tests that
      verify `schema.example()` and `column.example()` return polars
      frames; `Column.strategy_component` remains pinned as unimplemented.
- [ ] CI: full narwhals + polars + ibis + strategies test suites.


Made with [Cursor](https://cursor.com)