### PR TITLE
docs: clarify optional missing columns

### DIFF
--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -427,6 +427,12 @@ df = pd.DataFrame({"a": ["2001", "2002", "2003"]})
 Schema.validate(df)
 ```
 
+`Optional` means that a field may be absent from the input DataFrame. It
+does not add the field during validation. To add missing fields, use
+{ref}`add_missing_columns=True <adding-missing-columns>` in the model
+`Config` with required fields that specify a `default` value or
+`nullable=True`.
+
 ## Schema Inheritance
 
 You can also use inheritance to build schemas on top of a base schema.

--- a/docs/source/dataframe_schemas.md
+++ b/docs/source/dataframe_schemas.md
@@ -209,6 +209,11 @@ except pa.errors.SchemaError as exc:
     print(exc)
 ```
 
+`required=False` means that a column may be absent from the input
+DataFrame. It does not add the column during validation. To add missing
+columns, use {ref}`add_missing_columns=True <adding-missing-columns>`
+with required columns that specify a `default` value or `nullable=True`.
+
 (column-validation-1)=
 
 ### Stand-alone Column Validation
@@ -508,6 +513,9 @@ When you call `schema.validate(data)`, the schema will add any missing columns
 to the dataframe, defaulting to the `default` value if supplied at the column-level,
 or to `NaN` if the column is nullable.
 
+Columns declared with `required=False` are allowed to be absent from the
+input data and are not added to the validated output.
+
 ```{code-cell} python
 import pandas as pd
 import pandera.pandas as pa
@@ -517,6 +525,7 @@ schema = pa.DataFrameSchema(
         "a": pa.Column(int),
         "b": pa.Column(int, default=1),
         "c": pa.Column(float, nullable=True),
+        "d": pa.Column(str, required=False),
     },
     add_missing_columns=True,
     coerce=True,


### PR DESCRIPTION
Closes #2137.

- clarifies that `required=False` / `Optional[...]` allows a column to be absent from input, and does not add it during validation.
- notes that missing columns are only added by `add_missing_columns=True` for required columns with a default or nullable value

Validation:
- commit hooks passed for changed files
- locally reproduced described schema/model behavior