### PR TITLE
Improvement/ enable raising schema error in custom check

### DIFF
--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -285,6 +285,20 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 )
             except SchemaDefinitionError:
                 raise
+            except SchemaError as err:
+                # catch SchemaError exception that may be raised in custom check
+                err_msg = err.args[0] if err.args else ""
+                check_results.append(
+                    CoreCheckResult(
+                        passed=False,
+                        check=check,
+                        check_index=check_index,
+                        reason_code=SchemaErrorReason.DATAFRAME_CHECK,
+                        message=err_msg,
+                        failure_cases=err.failure_cases,
+                        original_exc=err,
+                    )
+                )
             except Exception as err:
                 # catch other exceptions that may occur when executing the check
                 err_msg = f'"{err.args[0]}"' if err.args else ""

--- a/tests/pandas/test_checks.py
+++ b/tests/pandas/test_checks.py
@@ -520,3 +520,74 @@ def test_check_output_dtype_with_empty_datetime():
     df = pd.DataFrame({"year_mon": pd.Series(dtype="datetime64[D]")})
     check_result = check(df)
     assert check_result.check_output.dtype == bool
+
+
+def test_custom_check_raise_schema_error():
+    """Test that raising an SchemaError in a custom check is processed properly"""
+    from pandera.errors import SchemaError
+    from pandera.extensions import register_check_method
+
+    @register_check_method(statistics=["no_columns", "custom_error_message"])
+    def correct_columns_number(
+        pandas_obj, *, no_columns, custom_error_message
+    ):
+        result = pandas_obj.shape[1] == no_columns
+        if not result:
+            raise SchemaError(
+                None,
+                None,
+                message=f"{custom_error_message}. Number of columns given: '{pandas_obj.shape[1]}'",
+            )
+        return result
+
+    @register_check_method(statistics=["no_rows", "custom_error_message"])
+    def correct_rows_number(pandas_obj, *, no_rows, custom_error_message):
+        result = pandas_obj.shape[0] == no_rows
+        if not result:
+            raise SchemaError(
+                None,
+                None,
+                message=f"{custom_error_message}. Number of rows given: '{pandas_obj.shape[0]}'",
+            )
+        return result
+
+    test_schema = DataFrameSchema(
+        columns={
+            "a": Column(
+                str,
+                checks=[
+                    Check.correct_rows_number(
+                        no_rows=2,
+                        custom_error_message="Dataframe should have two rows",
+                    )
+                ],
+            )
+        },
+        checks=[
+            Check.correct_columns_number(
+                no_columns=1,
+                custom_error_message="Dataframe should have one column",
+            )
+        ],
+    )
+
+    df = pd.DataFrame(
+        [
+            {"a": "1", "b": None, "c": 1},
+            {"a": "2", "b": None, "c": 2},
+            {"a": "3", "b": 2, "c": 3},
+        ]
+    )
+
+    try:
+        test_schema.validate(df, lazy=True)
+    except errors.SchemaErrors as err:
+        assert err.error_counts == {"DATAFRAME_CHECK": 2}
+        assert (
+            err.message["DATA"]["DATAFRAME_CHECK"][0]["error"]
+            == "Dataframe should have two rows. Number of rows given: '3'"
+        )
+        assert (
+            err.message["DATA"]["DATAFRAME_CHECK"][1]["error"]
+            == "Dataframe should have one column. Number of columns given: '3'"
+        )


### PR DESCRIPTION
Proposed changes enable raising pandera SchemaError in custom check for entire dataframe in similar way as for column. 

Example code for test:
```
import pandera.pandas as pa
import pandera.extensions as pa_extensions
import pandera.errors as pa_err
import pandas as pd
from pandera.errors import SchemaError, SchemaErrors

@pa_extensions.register_check_method(statistics=["no_columns", "custom_error_message"])
def correct_columns_number(pandas_obj, *, no_columns, custom_error_message):
    result = pandas_obj.shape[1] == no_columns
    if not result:
        raise pa_err.SchemaError(None, None, message=f"{custom_error_message}. Number of columns given: '{pandas_obj.shape[1]}'")
    return result

@pa_extensions.register_check_method(statistics=["no_rows", "custom_error_message"])
def correct_rows_number(pandas_obj, *, no_rows, custom_error_message):
    result = pandas_obj.shape[0] == no_rows
    if not result:
        raise pa_err.SchemaError(None, None, message=f"{custom_error_message}. Number of rows given: '{pandas_obj.shape[0]}'")
    return result

schema_pandera = pa.DataFrameSchema(
    columns = {
    "a": pa.Column(str, checks=[
        pa.Check.correct_rows_number(no_rows=2, custom_error_message="Dataframe should have two rows")
        ])
    },
    checks=[
        pa.Check.correct_columns_number(no_columns=1, custom_error_message="Dataframe should have one column")
        ]
    )

raw_data = [{"a": "1", "b": None, "c": 1}, {"a": "2", "b": None, "c": 2}, {"a": "3", "b": 2, "c": 3}]
df = pd.DataFrame(raw_data)

try:
    schema_pandera.validate(df, lazy=True)
except SchemaErrors as exc:
    errors = exc

print(errors.message)
```

currently error message looks like this: 
```
{'DATA': {'DATAFRAME_CHECK': [{'schema': None,
    'column': 'a',
    'check': 'correct_rows_number(no_rows=2, custom_error_message=Dataframe should have two rows)',
    'error': "Dataframe should have two rows. Number of rows given: '3'"}],
  'CHECK_ERROR': [{'schema': None,
    'column': None,
    'check': 'correct_columns_number(no_columns=1, custom_error_message=Dataframe should have one column)',
    'error': 'Error while executing check function: SchemaError("Dataframe should have one column. Number of columns given: \'3\'")Traceback (most recent call last):  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\backends\\pandas\\container.py", line 284, in run_checks    self.run_check(check_obj, schema, check, check_index)  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\backends\\pandas\\base.py", line 122, in run_check    check_result: CheckResult = check(check_obj, *args)                                ^^^^^^^^^^^^^^^^^^^^^^^  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\api\\checks.py", line 237, in __call__    return backend(check_obj, column)           ^^^^^^^^^^^^^^^^^^^^^^^^^^  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\backends\\pandas\\checks.py", line 358, in __call__    check_output = self.apply(check_obj)                   ^^^^^^^^^^^^^^^^^^^^^  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\backends\\pandas\\checks.py", line 157, in apply    return apply_fn(check_obj)           ^^^^^^^^^^^^^^^^^^^  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\backends\\pandas\\checks.py", line 170, in apply_table    return self.check_fn(check_obj)           ^^^^^^^^^^^^^^^^^^^^^^^^  File "e:\\Programs\\Python\\Python312\\Lib\\site-packages\\pandera\\api\\extensions.py", line 268, in check_fn_wrapper    return check_fn(validate_obj, **kwargs)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  File "C:\\Users\\Jaroslaw Rolski\\AppData\\Local\\Temp\\ipykernel_26316\\1876260013.py", line 11, in correct_columns_number    raise pa_err.SchemaError(None, None, message=f"{custom_error_message}. Number of columns given: \'{pandas_obj.shape[1]}\'")pandera.errors.SchemaError: Dataframe should have one column. Number of columns given: \'3\''}]}}
```

Changes replace `CHECK_ERROR` with `DATAFRAME_CHECK`:
```
{'DATA': {'DATAFRAME_CHECK': [{'schema': None,
    'column': 'a',
    'check': 'correct_rows_number(no_rows=2, custom_error_message=Dataframe should have two rows)',
    'error': "Dataframe should have two rows. Number of rows given: '3'"},
   {'schema': None,
    'column': None,
    'check': 'correct_columns_number(no_columns=1, custom_error_message=Dataframe should have one column)',
    'error': "Dataframe should have one column. Number of columns given: '3'"}]}}
```

