### PR TITLE
fix(polars): stringify nested dtypes in lazy failure-case formatter

### DIFF
--- a/pandera/backends/polars/base.py
+++ b/pandera/backends/polars/base.py
@@ -188,6 +188,24 @@ class PolarsSchemaBackend(BaseSchemaBackend):
                         {err.failure_cases.columns[0]: "failure_case"}
                     )
 
+                # Nested dtypes (List, Array, Struct, and arbitrary
+                # nestings thereof) cannot be cast directly to Utf8.
+                # JSON-encode via a singleton struct wrapper, then
+                # strip the wrapper so the failure-case report keeps
+                # the column's own shape.
+                failure_case_dtype = failure_cases_df.schema["failure_case"]
+                if isinstance(
+                    failure_case_dtype, (pl.List, pl.Array, pl.Struct)
+                ):
+                    failure_cases_df = failure_cases_df.with_columns(
+                        failure_case=(
+                            pl.struct(pl.col("failure_case").alias("v"))
+                            .struct.json_encode()
+                            .str.slice(5)
+                            .str.head(-1)
+                        )
+                    )
+
                 failure_cases_df = failure_cases_df.with_columns(
                     schema_context=pl.lit(err.schema.__class__.__name__),
                     column=pl.lit(err.schema.name),

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -1,5 +1,7 @@
 """Unit tests for polars check class."""
 
+import datetime as dt
+
 import polars as pl
 import pytest
 
@@ -298,3 +300,137 @@ def test_polars_dataframe_check_n_failure_cases(lf):
         schema.validate(lf, lazy=True)
     except pa.errors.SchemaErrors as exc:
         assert exc.failure_cases.shape[0] == n_failure_cases
+
+
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="Custom check signature incompatible with Narwhals backend",
+    strict=True,
+)
+@pytest.mark.parametrize(
+    "label, column, dtype, expected_substr",
+    [
+        (
+            "List[str]",
+            pl.Series([["gold", "magenta"], ["green"]]),
+            pl.List(pl.String),
+            '"magenta"',
+        ),
+        (
+            "Array[int, 2]",
+            pl.Series([[1, 2], [3, 4]], dtype=pl.Array(pl.Int64, 2)),
+            pl.Array(pl.Int64, 2),
+            "1",
+        ),
+        (
+            "Struct",
+            pl.Series([{"x": 1}, {"x": 2}]),
+            pl.Struct({"x": pl.Int64}),
+            '"x"',
+        ),
+        (
+            "List[Struct]",
+            pl.Series([[{"a": 1}], [{"a": 2}]]),
+            pl.List(pl.Struct({"a": pl.Int64})),
+            '"a"',
+        ),
+        (
+            "List[List[int]]",
+            pl.Series([[[1, 2]], [[3, 4]]]),
+            pl.List(pl.List(pl.Int64)),
+            "1",
+        ),
+        (
+            "Struct[List]",
+            pl.Series(
+                [{"items": [1, 2]}, {"items": [3]}],
+                dtype=pl.Struct({"items": pl.List(pl.Int64)}),
+            ),
+            pl.Struct({"items": pl.List(pl.Int64)}),
+            '"items"',
+        ),
+        (
+            "Array[Struct, 2]",
+            pl.Series(
+                [[{"a": 1}, {"a": 2}], [{"a": 3}, {"a": 4}]],
+                dtype=pl.Array(pl.Struct({"a": pl.Int64}), 2),
+            ),
+            pl.Array(pl.Struct({"a": pl.Int64}), 2),
+            '"a"',
+        ),
+        (
+            "List[Date]",
+            pl.Series(
+                [[dt.date(2026, 1, 1)], [dt.date(2026, 2, 2)]],
+                dtype=pl.List(pl.Date),
+            ),
+            pl.List(pl.Date),
+            "2026",
+        ),
+    ],
+)
+def test_polars_lazy_failure_cases_nested_column(
+    label, column, dtype, expected_substr
+):
+    """Regression: lazy=True must not crash when a column-level check
+    fails on a nested-dtype column (List, Array, Struct, and their
+    nestings). The failure-case formatter previously cast the offending
+    column to Utf8 directly, which Polars rejects for nested dtypes."""
+    del label
+
+    df = pl.DataFrame({"id": ["a", "b"], "nested": column})
+
+    class S(pa.DataFrameModel):
+        id: str
+        nested: dtype  # type: ignore[valid-type]
+
+        @pa.check("nested", name="always_fail")
+        @classmethod
+        def always_fail(cls, data: pa.PolarsData) -> pl.LazyFrame:
+            return data.lazyframe.select(pl.lit(False).alias(data.key))
+
+    with pytest.raises(pa.errors.SchemaErrors) as exc_info:
+        S.validate(df, lazy=True)
+
+    failure_cases = exc_info.value.failure_cases
+    assert failure_cases.shape[0] >= 1
+    assert "nested" in failure_cases["column"].to_list()
+    rendered = failure_cases["failure_case"].to_list()
+    assert any(expected_substr in str(v) for v in rendered)
+
+
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="Custom check signature incompatible with Narwhals backend",
+    strict=True,
+)
+def test_polars_lazy_failure_cases_empty_and_null_list():
+    """Pin behaviour for empty lists and nulls inside lists in the
+    failure-case formatter."""
+
+    df = pl.DataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "vals": pl.Series(
+                [[], [1, None, 2], [3]], dtype=pl.List(pl.Int64)
+            ),
+        }
+    )
+
+    class S(pa.DataFrameModel):
+        id: str
+        vals: pl.List = pa.Field(dtype_kwargs={"inner": pl.Int64})
+
+        @pa.check("vals", name="always_fail")
+        @classmethod
+        def always_fail(cls, data: pa.PolarsData) -> pl.LazyFrame:
+            return data.lazyframe.select(
+                pl.col(data.key).is_null().alias(data.key)
+            )
+
+    with pytest.raises(pa.errors.SchemaErrors) as exc_info:
+        S.validate(df, lazy=True)
+
+    rendered = exc_info.value.failure_cases["failure_case"].to_list()
+    assert "[]" in rendered
+    assert any("null" in str(v) for v in rendered)

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -320,7 +320,7 @@ def test_polars_dataframe_check_n_failure_cases(lf):
             "Array[int, 2]",
             pl.Series([[1, 2], [3, 4]], dtype=pl.Array(pl.Int64, 2)),
             pl.Array(pl.Int64, 2),
-            "1",
+            "[1,2]",
         ),
         (
             "Struct",
@@ -338,7 +338,7 @@ def test_polars_dataframe_check_n_failure_cases(lf):
             "List[List[int]]",
             pl.Series([[[1, 2]], [[3, 4]]]),
             pl.List(pl.List(pl.Int64)),
-            "1",
+            "[[1,2]]",
         ),
         (
             "Struct[List]",


### PR DESCRIPTION
## What's going on

If you put a Pandera schema check on a Polars column whose dtype is a list, array, or struct, and the check fails while you're validating with `lazy=True`, Pandera doesn't tell you the data was bad. Instead you get a crash from inside Pandera itself:

```
polars.exceptions.InvalidOperationError:
  cannot cast List type (inner: 'String', to: 'String')

This error occurred in the following expression:
  col("failure_case").strict_cast(String)
```

The real validation failure is hidden behind that crash, which makes it pretty unhelpful when you're trying to find out why your data didn't validate.

## Why it happens

When `lazy=True` validation collects failures, the polars backend builds a small report frame describing each failing row. As the last step, every column of that report is cast to a string so it can be rendered. For most columns that's fine, but if the failing column was a `List`, `Array`, or `Struct`, the `failure_case` column inherits that nested dtype, and Polars refuses to cast nested types straight to `Utf8`. So the report builder explodes before it can tell you what actually failed.

## Reproduction

```python
import pandera.polars as pa
import polars as pl
from pandera.api.polars.types import PolarsData

ALLOWED = ["gold", "green", "purple"]

class S(pa.DataFrameModel):
    color: pl.List = pa.Field(dtype_kwargs={"inner": pl.String})

    @pa.check("color")
    @classmethod
    def color_allowed(cls, data: PolarsData) -> pl.LazyFrame:
        return data.lazyframe.select(
            pl.col(data.key)
            .list.eval(pl.element().is_in(ALLOWED))
            .list.all()
        )

df = pl.DataFrame({"color": [["gold", "magenta"], ["green"]]})
S.validate(df, lazy=True)  # crashes instead of reporting the failure
```

## The fix

Before that final cast, check whether the `failure_case` column is a nested dtype. If it is, turn it into a readable string using Polars' JSON encoder, then carry on with the rest of the cast as normal.

The column is wrapped in a one-field struct, JSON-encoded, and the surrounding `{"v":` / `}` is sliced off so the rendered value keeps the shape of the original column:

```python
pl.struct(pl.col("failure_case").alias("v"))
  .struct.json_encode()
  .str.slice(5)
  .str.head(-1)
```

That single branch handles `List`, `Array`, `Struct`, and any nesting of those (`List[Struct]`, `Struct[List]`, `Array[Struct]`, `List[List[*]]`, and so on). It is all native Polars, no Python UDFs, and primitive dtypes go down the existing path unchanged.

Worth noting: the multi-column branch a few lines above already uses `struct.json_encode()` for the same reason. This PR brings the single-column path to parity. Happy to hoist both into a small shared helper if you would prefer.

## Tests

Added a parametrised regression test in `tests/polars/test_polars_check.py` that exercises:

- `List[str]`
- `Array[int, 2]`
- `Struct`
- `List[Struct]`
- `List[List[int]]`
- `Struct[List]`
- `Array[Struct, 2]`
- `List[Date]` (a non-string-castable inner dtype)

Plus a second test pinning the rendered output for empty lists (`"[]"`) and nulls inside lists (`null`), so future changes cannot silently regress those.

Full polars test suite: 426 passed, 1 skipped.

## A small question

The slice-and-head trick depends on the literal `{"v":` / `}` produced by `struct.json_encode()`. If there is a more direct way to JSON-encode a single column that I missed, I am happy to swap it in.