### PR TITLE
fix(polars): avoid coercing missing required columns

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -513,10 +513,12 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                 obj = getattr(schema.dtype, coerce_fn)(obj)
             else:
                 for col_schema in schema.columns.values():
-                    if (
-                        not col_schema.required
-                        and col_schema.name not in lf_columns
-                    ):
+                    missing_column = col_schema.name not in lf_columns
+                    required_regex = col_schema.required and col_schema.regex
+
+                    # Required regex columns use the selector path below;
+                    # other missing columns are handled by later checks.
+                    if missing_column and not required_regex:
                         continue
 
                     if schema.coerce or col_schema.coerce:

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -321,6 +321,20 @@ def test_missing_required_column_when_lazy_is_true():
     )
 
 
+def test_missing_required_column_with_coerce_raises_schema_error():
+    """Test missing required columns with coerce=True raise SchemaError."""
+    schema = DataFrameSchema({"missing_column": Column(int, coerce=True)})
+    df = pl.DataFrame()
+
+    with pytest.raises(pa.errors.SchemaError) as exc:
+        schema.validate(df)
+
+    assert (
+        exc.value.reason_code
+        == pa.errors.SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME
+    )
+
+
 def test_unique_column_names():
     """Test unique column names."""
     with pytest.warns(
@@ -604,6 +618,21 @@ def test_regex_coerce(
         column.coerce = True
 
     ldf_for_regex_match.pipe(ldf_schema_with_regex_name.validate).collect()
+
+
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="Narwhals backend does not support coerce or regex column selection",
+    strict=True,
+)
+def test_required_regex_coerce():
+    """Test required regex columns are coerced by selector."""
+    schema = DataFrameSchema({r"^column_[0-9]+$": Column(int, coerce=True)})
+    ldf = pl.DataFrame({"column_1": ["1"]}).lazy()
+
+    result = ldf.pipe(schema.validate).collect()
+
+    assert result.schema["column_1"] == pl.Int64
 
 
 def test_ordered(ldf_basic, ldf_schema_basic):


### PR DESCRIPTION
Closes #2085.

- skips Polars column-level coercion for missing non-regex columns, so Pandera
raises its missing-column error instead of Polars' `ColumnNotFoundError`.
- preserves selector-based coercion for required regex columns.

**Tests**

- `ruff format --check pandera/backends/polars/container.py tests/polars/test_polars_container.py`
- `ruff check pandera/backends/polars/container.py tests/polars/test_polars_container.py`
- `.venv\Scripts\python.exe -m pytest -q tests/polars/test_polars_container.py`
- `.venv\Scripts\python.exe -m pytest -q tests/polars -k "not test_polars_parallel"`
