### PR TITLE
fix(extensions): reject extra positional args in register_check_method (#480)

### DIFF
--- a/pandera/api/extensions.py
+++ b/pandera/api/extensions.py
@@ -327,8 +327,28 @@ def register_check_method(
             """Wrapper function that serves as the Check method."""
             stats, check_kwargs = {}, {}
 
+            # Reject silent argument loss: if the user passes more positional
+            # arguments than the check declares statistics for, the extras
+            # would otherwise be dropped on the floor by ``zip`` (issue #480),
+            # producing checks that look configured but ignore their inputs.
+            if len(args) > len(statistics):
+                raise TypeError(
+                    f"{check_fn.__name__}() takes at most "
+                    f"{len(statistics)} positional argument(s) "
+                    f"({list(statistics)}), but {len(args)} were given."
+                )
+
             if args:
                 stats = dict(zip(statistics, args))
+
+            # Statistics passed by keyword that duplicate a positional value
+            # would also be silently lost without this guard.
+            duplicate = set(stats) & set(kwargs)
+            if duplicate:
+                raise TypeError(
+                    f"{check_fn.__name__}() got multiple values for "
+                    f"argument(s): {sorted(duplicate)}"
+                )
 
             for k, v in kwargs.items():
                 if k in statistics:

--- a/tests/pandas/test_extensions.py
+++ b/tests/pandas/test_extensions.py
@@ -331,3 +331,39 @@ def test_custom_error_message(custom_check_teardown):
 
     check = Check.custom_check(error="custom error message")
     assert check.error == "custom error message"
+
+
+def test_register_check_rejects_extra_positional_args(
+    custom_check_teardown: None,
+) -> None:
+    """Regression test for #480.
+
+    Custom checks registered with no statistics (or fewer statistics than the
+    number of positional args supplied at call-time) used to silently drop the
+    extras, producing a check that looked configured but ignored its inputs.
+    The fix raises TypeError instead, matching standard Python call semantics.
+    """
+
+    @extensions.register_check_method()
+    def eq_1_no_stats(pandas_obj):
+        return pandas_obj == 1
+
+    # Extra positional args on a no-statistic check must raise.
+    with pytest.raises(TypeError, match="positional argument"):
+        Check.eq_1_no_stats("foo", "bar")
+
+    @extensions.register_check_method(statistics=["val"])
+    def eq_val_one_stat(pandas_obj, *, val):
+        return pandas_obj == val
+
+    # One declared statistic — passing two positional args must raise.
+    with pytest.raises(TypeError, match="positional argument"):
+        Check.eq_val_one_stat(1, 2)
+
+    # Passing a single positional value still works.
+    check = Check.eq_val_one_stat(1)
+    assert check(pd.Series([1, 1, 1])).check_passed
+
+    # Mixing positional + duplicate keyword for the same statistic must raise.
+    with pytest.raises(TypeError, match="multiple values"):
+        Check.eq_val_one_stat(1, val=2)


### PR DESCRIPTION
## Summary

Custom checks registered through `@pa.extensions.register_check_method`
silently dropped any positional argument that did not map to a declared
statistic. Calls like `pa.Check.eq_1("foo", "bar")` succeeded and built
a check that ignored its supposed configuration, masking typos and
schema mistakes. This PR validates the positional/keyword inputs up-front
and raises `TypeError` instead — matching standard Python call
semantics.

Fixes unionai-oss/pandera#480 — *Registered checks with no statistics
accept positional arguments*

## Context

The wrapper generated by `register_check_method` zips the supplied
positional `args` with the declared `statistics` list. When
`statistics=[]` (the default), `dict(zip([], args))` evaluates to an
empty dict and every positional value is silently discarded. The same
loss can happen when the user accidentally duplicates a statistic
positionally and by keyword: the kwarg silently overrode the positional
without complaint.

See the existing wrapper at
[`pandera/api/extensions.py#L325-L347`](https://github.com/unionai-oss/pandera/blob/main/pandera/api/extensions.py#L325-L347).

## Changes

- `pandera/api/extensions.py`: in the `check_method` wrapper, raise
  `TypeError` when (a) more positional args are passed than there are
  declared statistics, or (b) the same statistic is passed both
  positionally and by keyword. Two short code comments explain why the
  guards exist — both failure modes are silent today, so a reviewer
  reading the diff cold needs the "why".
- `tests/pandas/test_extensions.py`: add
  `test_register_check_rejects_extra_positional_args` as a regression
  test covering the three failure shapes from the issue and the
  duplicate-keyword case.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/unionai-oss/pandera.git /tmp/pandera-480 \
  && cd /tmp/pandera-480
uv venv .venv --python 3.11 && source .venv/bin/activate
uv pip install -e . pandas numpy pytest pytest-timeout hypothesis

# --- BEFORE (origin/main) ---
git checkout origin/main
git checkout fix/480-register-check-positional -- tests/pandas/test_extensions.py
PYTHONPATH=$(pwd) python -m pytest \
  tests/pandas/test_extensions.py::test_register_check_rejects_extra_positional_args \
  -x --timeout=60
# Expected: FAILED — "DID NOT RAISE <class 'TypeError'>"

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pandera.git fix/480-register-check-positional
git checkout FETCH_HEAD
PYTHONPATH=$(pwd) python -m pytest \
  tests/pandas/test_extensions.py::test_register_check_rejects_extra_positional_args \
  -x --timeout=60
# Expected: PASSED — TypeError is raised on extra args / duplicate kwargs
```

## What I ran locally

- `pytest tests/pandas/test_extensions.py -x --timeout=60`
  → 21 passed (was 20 on `origin/main`; +1 regression test).
- `pytest tests/pandas/test_checks.py tests/pandas/test_decorators.py tests/pandas/test_extensions.py tests/pandas/test_checks_builtin.py --timeout=60`
  → 377 passed, 1 skipped — no regression on the surrounding suite.
- `ruff check pandera/api/extensions.py tests/pandas/test_extensions.py`
  → all checks passed.
- `ruff format --check ...` → 2 files already formatted.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | No statistics, extra positional | `Check.eq_1("foo", "bar")` | `TypeError` mentioning "positional argument" | `test_register_check_rejects_extra_positional_args` |
| 2 | One statistic, two positional | `Check.eq_val_one_stat(1, 2)` | `TypeError` | same test |
| 3 | One statistic, one positional | `Check.eq_val_one_stat(1)` | succeeds, validates correctly | same test |
| 4 | Duplicate positional + kwarg | `Check.eq_val_one_stat(1, val=2)` | `TypeError` "multiple values" | same test |
| 5 | Existing kwarg-only usage | `Check.custom_check(val=10)` | unchanged | the pre-existing 20 tests in `test_extensions.py` still pass |

## Risk / blast radius

The change only adds two `raise TypeError` paths in the wrapper produced
by `register_check_method`. Callers that pass the right number of
positional args (i.e. `<= len(statistics)`) and don't duplicate a
statistic by keyword see no behavior change — confirmed by the 377
green tests across `tests/pandas/`. There is a small public-API
sharpening risk: code that was relying on the silent-drop behavior
(passing junk extras "just in case") will now error loudly, but that
behavior was the bug.

## Release note

```release-note
Fix `register_check_method` silently dropping extra positional
arguments. Custom checks now raise `TypeError` when given more
positional arguments than declared statistics, or when the same
statistic is passed both positionally and by keyword.
```

---

*PR drafted with assistance from Claude Code (data engineer working
through stale-issue triage on pandera). The change was reviewed
manually against `pandera/api/extensions.py` and the issue
reproducer; all `pytest` runs above were executed locally on
`fix/480-register-check-positional` and on `origin/main`.*
