### PR TITLE
docs(pydantic): clarify v2 string coercion semantics

### DIFF
--- a/docs/source/pydantic_integration.md
+++ b/docs/source/pydantic_integration.md
@@ -101,6 +101,24 @@ apply the pydantic model validation process to each row of the dataframe,
 converting the model back to a dictionary with the `BaseModel.dict()` method.
 :::
 
+:::{note}
+`PydanticModel` coercion follows the pydantic model's own validation
+semantics. On pydantic v2, numeric values are not coerced to strings by
+default. If you want row-wise validation to coerce values like `1` into
+`"1"` for `str` fields, configure the pydantic model explicitly:
+
+```python
+from pydantic import ConfigDict
+
+
+class Record(BaseModel):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+    name: str
+    xcoord: int
+    ycoord: int
+```
+:::
+
 The equivalent pandera schema would look like this:
 
 ```{code-cell} python

--- a/tests/pandas/test_pydantic.py
+++ b/tests/pandas/test_pydantic.py
@@ -24,6 +24,7 @@ if pydantic_version().release >= (2, 0, 0):
     PYDANTIC_V2 = True
     import pydantic_core
     from packaging import version
+    from pydantic import ConfigDict
 
 
 class SimpleSchema(pa.DataFrameModel):
@@ -317,3 +318,38 @@ def test_pydantic_model_empty_dataframe():
     err_msg = exc_info.value.schema_errors[0].args[0]
     assert "Missing columns" in err_msg
     assert "y" in err_msg and "z" in err_msg
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 already coerces numbers to strings by default",
+)
+def test_dataframemodel_with_pydantic_model_coerce_numbers_to_str():
+    """Test DataFrameModel validation with explicit pydantic v2 string coercion."""
+
+    class Record(BaseModel):
+        model_config = ConfigDict(coerce_numbers_to_str=True)
+
+        name: str
+        age: int
+        city: str
+
+    class Schema(pa.DataFrameModel):
+        class Config:
+            dtype = pa.engines.pandas_engine.PydanticModel(Record)
+            coerce = True
+
+    data = pd.DataFrame(
+        {
+            "name": [1, "Bob", "Charlie"],
+            "age": [25, 30, 22],
+            "city": ["New York", "London", "Paris"],
+        }
+    )
+
+    validated = Schema.validate(data)
+    assert validated.to_dict(orient="list") == {
+        "name": ["1", "Bob", "Charlie"],
+        "age": [25, 30, 22],
+        "city": ["New York", "London", "Paris"],
+    }

--- a/tests/pandas/test_pydantic_dtype.py
+++ b/tests/pandas/test_pydantic_dtype.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel
 
 import pandera.pandas as pa
 from pandera.api.pandas.array import ArraySchema
+from pandera.engines import pydantic_version
 from pandera.engines.pandas_engine import PydanticModel
+
+PYDANTIC_V2 = pydantic_version().release >= (2, 0, 0)
+if PYDANTIC_V2:
+    from pydantic import ConfigDict
 
 
 class Record(BaseModel):
@@ -89,3 +94,34 @@ def test_pydantic_model_coerce(coerce: bool):
         dtype=PydanticModel(Record), coerce=coerce
     )
     assert dataframe_schema.coerce is True
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="Pydantic <2 already coerces numbers to strings by default",
+)
+def test_pydantic_model_coerce_numbers_to_str():
+    """Test that pydantic v2 string coercion can be enabled explicitly."""
+
+    class Row(BaseModel):
+        model_config = ConfigDict(coerce_numbers_to_str=True)
+
+        name: str
+        age: int
+        city: str
+
+    schema = pa.DataFrameSchema(dtype=PydanticModel(Row), coerce=True)
+    data = pd.DataFrame(
+        {
+            "name": [1, "Bob", "Charlie"],
+            "age": [25, 30, 22],
+            "city": ["New York", "London", "Paris"],
+        }
+    )
+
+    validated = schema.validate(data)
+    assert validated.to_dict(orient="list") == {
+        "name": ["1", "Bob", "Charlie"],
+        "age": [25, 30, 22],
+        "city": ["New York", "London", "Paris"],
+    }


### PR DESCRIPTION
## Description:

Issue #2054 reported that coercion looked different when validating a dataframe with `Config.dtype = PydanticModel(...)` compared with a direct pandera schema.

On the latest `main`, the remaining failing case comes from Pydantic v2 semantics: row-model validation does not coerce numeric values to strings by default. Pandera's `PydanticModel` follows the Pydantic model's own validation rules, so changing Pandera runtime behavior here would override Pydantic semantics.

This PR documents the supported Pydantic v2 configuration for this case and adds a regression test covering `ConfigDict(coerce_numbers_to_str=True)` with a dataframe-level `PydanticModel`.

Related to #2054.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files docs/source/pydantic_integration.md tests/pandas/test_pydantic_dtype.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/pandas/test_pydantic_dtype.py`.


### The validation screenshot of the tests run, locally:

<img width="2559" height="1220" alt="image" src="https://github.com/user-attachments/assets/fda7bfce-920d-462e-916d-efffb46166a0" />
