### PR TITLE
fix: handle mixed-timezone pandas datetime coercion

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -965,7 +965,9 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
         }
 
         def _to_datetime(col: PandasObject) -> PandasObject:
-            col = to_datetime_fn(col, **self.to_datetime_kwargs)
+            col = self._coerce_mixed_timezones(
+                to_datetime_fn=to_datetime_fn, data_container=col
+            )
             pdtype_tz = getattr(pandas_dtype, "tz", None)
             coltype_tz = getattr(col.dtype, "tz", None)
             if pdtype_tz is not None or coltype_tz is not None:
@@ -999,6 +1001,89 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
             return data_container.transform(_to_datetime)
 
         return _to_datetime(data_container)
+
+    def _coerce_mixed_timezones(
+        self,
+        to_datetime_fn: Callable[..., PandasObject],
+        data_container: PandasObject,
+    ) -> PandasObject:
+        try:
+            col, should_try_utc = self._call_to_datetime(
+                to_datetime_fn=to_datetime_fn, data_container=data_container
+            )
+        except ValueError as exc:
+            if not self._should_try_utc_conversion(exc):
+                raise
+            col = to_datetime_fn(
+                data_container, **self.to_datetime_kwargs, utc=True
+            )
+        else:
+            if should_try_utc:
+                col = to_datetime_fn(
+                    data_container, **self.to_datetime_kwargs, utc=True
+                )
+
+        if self._should_convert_object_dtype_with_utc(col):
+            col = to_datetime_fn(
+                data_container, **self.to_datetime_kwargs, utc=True
+            )
+
+        return col
+
+    def _call_to_datetime(
+        self,
+        to_datetime_fn: Callable[..., PandasObject],
+        data_container: PandasObject,
+    ) -> tuple[PandasObject, bool]:
+        if "utc" in self.to_datetime_kwargs:
+            return to_datetime_fn(
+                data_container, **self.to_datetime_kwargs
+            ), False
+
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always", FutureWarning)
+            col = to_datetime_fn(data_container, **self.to_datetime_kwargs)
+
+        should_try_utc = False
+        for warning in captured_warnings:
+            if self._should_try_utc_conversion_warning(warning.message):
+                should_try_utc = True
+            else:
+                warnings.warn(warning.message, warning.category, stacklevel=2)
+
+        return col, should_try_utc
+
+    def _should_try_utc_conversion(self, exc: ValueError) -> bool:
+        return "utc=True" in str(exc) and "utc" not in self.to_datetime_kwargs
+
+    @staticmethod
+    def _should_try_utc_conversion_warning(warning: Any) -> bool:
+        return "unless `utc=True`" in str(warning)
+
+    def _should_convert_object_dtype_with_utc(
+        self, data_container: PandasObject
+    ) -> bool:
+        if (
+            getattr(data_container, "dtype", None) != object
+            or "utc" in self.to_datetime_kwargs
+        ):
+            return False
+
+        return all(
+            pd.isna(value)
+            or (
+                self._to_datetime_scalar(value) is not pd.NaT
+                and self._to_datetime_scalar(value).tzinfo is not None
+            )
+            for value in data_container
+        )
+
+    def _to_datetime_scalar(self, value: Any) -> Any:
+        if pd.isna(value):
+            return pd.NaT
+        return self._get_to_datetime_fn(value)(
+            value, **self.to_datetime_kwargs
+        )
 
     @classmethod
     def from_parametrized_dtype(cls, pd_dtype: pd.DatetimeTZDtype):
@@ -1036,23 +1121,19 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
             object.__setattr__(self, "tz", tz)
             object.__setattr__(self, "type", type_)
         # If there are multiple timezones, convert them to the specified tz and set the type accordingly
-        elif all(isinstance(x, datetime.datetime) for x in data_container):
-            container_type = type(data_container)
+        elif all(self._is_datetime_like_value(x) for x in data_container):
             tz = self.tz
             unit = (
                 self.unit
                 if self.unit
                 else getattr(data_container.dtype, "unit", "ns")
             )
-            data_container = container_type(
+            data_container = self._rebuild_data_container(
+                data_container,
                 [
-                    (
-                        pd.Timestamp(ts).tz_convert(tz)  # type: ignore[arg-type]
-                        if pd.Timestamp(ts).tzinfo
-                        else pd.Timestamp(ts).tz_localize(tz)  # type: ignore[arg-type, call-overload]
-                    )
+                    self._coerce_scalar_to_timezone(ts, tz)
                     for ts in data_container
-                ]
+                ],
             )
             type_ = pd.DatetimeTZDtype(unit, tz)  # type: ignore[arg-type]
             object.__setattr__(self, "tz", tz)
@@ -1068,6 +1149,35 @@ class DateTime(_BaseDateTime, dtypes.Timestamp):
                 ),
             )
         return data_container
+
+    @staticmethod
+    def _rebuild_data_container(
+        data_container: PandasObject, values: list[Any]
+    ) -> PandasObject:
+        if isinstance(data_container, pd.Series):
+            return pd.Series(
+                values, index=data_container.index, name=data_container.name
+            )
+        if isinstance(data_container, pd.Index):
+            return pd.Index(values, name=data_container.name)
+        return type(data_container)(values)
+
+    def _coerce_scalar_to_timezone(
+        self, value: Any, tz: datetime.tzinfo
+    ) -> Any:
+        value = self._to_datetime_scalar(value)
+        if value is pd.NaT:
+            return value
+        if value.tzinfo is not None:
+            return value.tz_convert(tz)
+        return value.tz_localize(tz)  # type: ignore[call-overload]
+
+    def _is_datetime_like_value(self, value: Any) -> bool:
+        try:
+            self._to_datetime_scalar(value)
+        except (TypeError, ValueError):
+            return False
+        return True
 
     def coerce_value(self, value: Any) -> Any:
         """Coerce an value to specified datatime type."""

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -530,6 +530,25 @@ def test_coerce_dt(examples, type_, has_tz, is_index):
     assert data_type.try_coerce(data).to_list() == expected
 
 
+def test_coerce_dt_with_mixed_offsets():
+    """Test coercion of mixed-offset strings to a timezone-naive DateTime."""
+    data = pd.Series(
+        [
+            "2023-10-30T11:27:20.082372+01:00",
+            "2023-10-27T15:37:25.562608+02:00",
+        ]
+    )
+    data_type = pandas_engine.Engine.dtype(pandas_engine.DateTime)
+
+    coerced = data_type.try_coerce(data)
+
+    expected = [
+        to_datetime("2023-10-30T10:27:20.082372"),
+        to_datetime("2023-10-27T13:37:25.562608"),
+    ]
+    assert coerced.to_list() == expected
+
+
 def test_coerce_string():
     """Test that strings can be coerced."""
     data = pd.Series([1, None], dtype="Int32")

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -448,6 +448,70 @@ def test_pandas_datetime_time_zone_agnostic_coerce_mixed_offset_strings():
     assert validated_df["timestamp"].tolist() == expected
 
 
+def test_pandas_datetime_call_to_datetime_respects_explicit_utc():
+    """Test datetime parsing when utc is already specified."""
+    dtype = pandas_engine.DateTime(to_datetime_kwargs={"utc": True})
+    data = pd.Series(
+        [
+            "2023-10-30T11:27:20.082372+01:00",
+            "2023-10-27T15:37:25.562608+02:00",
+        ]
+    )
+
+    result, should_try_utc = dtype._call_to_datetime(pd.to_datetime, data)
+
+    assert not should_try_utc
+    assert str(result.dtype) == "datetime64[ns, UTC]"
+
+
+def test_pandas_datetime_coerce_mixed_timezones_retries_with_utc():
+    """Test mixed-timezone coercion retries with utc on pandas errors."""
+    dtype = pandas_engine.DateTime()
+    data = pd.Series(
+        [
+            "2023-10-30T11:27:20.082372+01:00",
+            "2023-10-27T15:37:25.562608+02:00",
+        ]
+    )
+
+    def to_datetime_fn(data_container, **kwargs):
+        if kwargs.get("utc"):
+            return pd.to_datetime(data_container, utc=True)
+        raise ValueError(
+            "parsing datetimes with mixed time zones requires utc=True"
+        )
+
+    result = dtype._coerce_mixed_timezones(to_datetime_fn, data)
+
+    assert str(result.dtype) == "datetime64[ns, UTC]"
+
+
+def test_pandas_datetime_helper_methods():
+    """Test helper methods used by mixed-timezone coercion."""
+    dtype = pandas_engine.DateTime()
+
+    assert not dtype._should_try_utc_conversion(ValueError("other error"))
+    assert not dtype._should_try_utc_conversion_warning(
+        UserWarning("other warning")
+    )
+    assert dtype._to_datetime_scalar(pd.NaT) is pd.NaT
+    assert not dtype._is_datetime_like_value("not_a_date")
+    assert not dtype._should_convert_object_dtype_with_utc(
+        pd.Series(pd.to_datetime(["2022-04-30T00:00:00Z"], utc=True))
+    )
+    assert not pandas_engine.DateTime(
+        to_datetime_kwargs={"utc": True}
+    )._should_convert_object_dtype_with_utc(
+        pd.Series(["2023-10-30T11:27:20.082372+01:00"])
+    )
+
+    rebuilt = dtype._rebuild_data_container(
+        pd.Index(["a", "b"], name="timestamp"), [1, 2]
+    )
+    assert isinstance(rebuilt, pd.Index)
+    assert rebuilt.name == "timestamp"
+
+
 @hypothesis.settings(max_examples=1000)
 @pytest.mark.parametrize("to_df", [True, False])
 @given(

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -390,6 +390,64 @@ def test_dt_time_zone_agnostic(examples, tz, coerce, expected_output, raises):
         )
 
 
+def test_pandas_datetime_coerce_mixed_timezones_to_target_timezone():
+    """Test coercion of mixed timezones to a target timezone."""
+
+    class SimpleSchema(DataFrameModel):
+        # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+        timestamp: pandas_engine.DateTime(
+            tz=pytz.timezone("America/Chicago")
+        ) = Field(coerce=True)
+
+    data = pd.DataFrame(
+        {
+            "timestamp": [
+                pytz.timezone("America/Chicago").localize(
+                    dt.datetime(2023, 3, 1, 13)
+                ),
+                pytz.timezone("America/New_York").localize(
+                    dt.datetime(2023, 3, 1, 13)
+                ),
+            ]
+        }
+    )
+
+    validated_df = SimpleSchema.validate(data)
+
+    expected = [
+        pytz.timezone("America/Chicago").localize(dt.datetime(2023, 3, 1, 13)),
+        pytz.timezone("America/Chicago").localize(dt.datetime(2023, 3, 1, 12)),
+    ]
+    assert validated_df["timestamp"].tolist() == expected
+
+
+def test_pandas_datetime_time_zone_agnostic_coerce_mixed_offset_strings():
+    """Test timezone-agnostic coercion of mixed-offset strings."""
+
+    class SimpleSchema(DataFrameModel):
+        # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+        timestamp: pandas_engine.DateTime(
+            time_zone_agnostic=True, tz=pytz.UTC
+        ) = Field(coerce=True)
+
+    data = pd.DataFrame(
+        {
+            "timestamp": [
+                "2023-10-30T11:27:20.082372+01:00",
+                "2023-10-27T15:37:25.562608+02:00",
+            ]
+        }
+    )
+
+    validated_df = SimpleSchema.validate(data)
+
+    expected = [
+        pd.Timestamp("2023-10-30T10:27:20.082372Z"),
+        pd.Timestamp("2023-10-27T13:37:25.562608Z"),
+    ]
+    assert validated_df["timestamp"].tolist() == expected
+
+
 @hypothesis.settings(max_examples=1000)
 @pytest.mark.parametrize("to_df", [True, False])
 @given(

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -461,7 +461,8 @@ def test_pandas_datetime_call_to_datetime_respects_explicit_utc():
     result, should_try_utc = dtype._call_to_datetime(pd.to_datetime, data)
 
     assert not should_try_utc
-    assert str(result.dtype) == "datetime64[ns, UTC]"
+    assert isinstance(result.dtype, pd.DatetimeTZDtype)
+    assert str(result.dtype.tz) == "UTC"
 
 
 def test_pandas_datetime_coerce_mixed_timezones_retries_with_utc():
@@ -483,7 +484,8 @@ def test_pandas_datetime_coerce_mixed_timezones_retries_with_utc():
 
     result = dtype._coerce_mixed_timezones(to_datetime_fn, data)
 
-    assert str(result.dtype) == "datetime64[ns, UTC]"
+    assert isinstance(result.dtype, pd.DatetimeTZDtype)
+    assert str(result.dtype.tz) == "UTC"
 
 
 def test_pandas_datetime_helper_methods():

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -1,6 +1,7 @@
 """Test pandas engine."""
 
 import datetime as dt
+import warnings
 from typing import Any, Optional
 
 import hypothesis
@@ -488,6 +489,82 @@ def test_pandas_datetime_coerce_mixed_timezones_retries_with_utc():
     assert str(result.dtype.tz) == "UTC"
 
 
+def test_pandas_datetime_coerce_mixed_timezones_reraises_other_errors():
+    """Test mixed-timezone coercion re-raises unrelated parse errors."""
+    dtype = pandas_engine.DateTime()
+    data = pd.Series(["not_a_datetime"])
+
+    def to_datetime_fn(data_container, **kwargs):
+        raise ValueError("other error")
+
+    with pytest.raises(ValueError, match="other error"):
+        dtype._coerce_mixed_timezones(to_datetime_fn, data)
+
+
+def test_pandas_datetime_coerce_object_dtype_with_utc():
+    """Test mixed-timezone coercion retries when parsing returns object."""
+    dtype = pandas_engine.DateTime()
+    data = pd.Series(
+        [
+            "2023-10-30T11:27:20.082372+01:00",
+            "2023-10-27T15:37:25.562608+02:00",
+        ]
+    )
+
+    def to_datetime_fn(data_container, **kwargs):
+        if kwargs.get("utc"):
+            return pd.to_datetime(data_container, utc=True)
+        return pd.Series(data_container, dtype=object)
+
+    result = dtype._coerce_mixed_timezones(to_datetime_fn, data)
+
+    assert isinstance(result.dtype, pd.DatetimeTZDtype)
+    assert str(result.dtype.tz) == "UTC"
+
+
+def test_pandas_datetime_coerce_mixed_timezones_retries_after_warning():
+    """Test mixed-timezone coercion retries with utc after warnings."""
+    dtype = pandas_engine.DateTime()
+    data = pd.Series(
+        [
+            "2023-10-30T11:27:20.082372+01:00",
+            "2023-10-27T15:37:25.562608+02:00",
+        ]
+    )
+
+    def to_datetime_fn(data_container, **kwargs):
+        if kwargs.get("utc"):
+            return pd.to_datetime(data_container, utc=True)
+        warnings.warn(
+            "parsing datetimes with mixed time zones will raise an error "
+            "unless `utc=True`",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return pd.Series(data_container, dtype=object)
+
+    result = dtype._coerce_mixed_timezones(to_datetime_fn, data)
+
+    assert isinstance(result.dtype, pd.DatetimeTZDtype)
+    assert str(result.dtype.tz) == "UTC"
+
+
+def test_pandas_datetime_call_to_datetime_reemits_other_warnings():
+    """Test non-UTC warnings are re-emitted during datetime parsing."""
+    dtype = pandas_engine.DateTime()
+    data = pd.Series(["2023-10-30T11:27:20.082372+01:00"])
+
+    def to_datetime_fn(data_container, **kwargs):
+        warnings.warn("other warning", FutureWarning, stacklevel=2)
+        return pd.to_datetime(data_container, **kwargs)
+
+    with pytest.warns(FutureWarning, match="other warning"):
+        result, should_try_utc = dtype._call_to_datetime(to_datetime_fn, data)
+
+    assert not should_try_utc
+    assert result.tolist() == pd.to_datetime(data).tolist()
+
+
 def test_pandas_datetime_helper_methods():
     """Test helper methods used by mixed-timezone coercion."""
     dtype = pandas_engine.DateTime()
@@ -512,6 +589,22 @@ def test_pandas_datetime_helper_methods():
     )
     assert isinstance(rebuilt, pd.Index)
     assert rebuilt.name == "timestamp"
+
+    rebuilt_df = dtype._rebuild_data_container(
+        pd.DataFrame({"timestamp": [1, 2]}),
+        [{"timestamp": 3}, {"timestamp": 4}],
+    )
+    assert isinstance(rebuilt_df, pd.DataFrame)
+    assert rebuilt_df["timestamp"].tolist() == [3, 4]
+    assert dtype._coerce_scalar_to_timezone(pd.NaT, pytz.UTC) is pd.NaT
+
+
+def test_pandas_datetime_time_zone_agnostic_invalid_data_raises():
+    """Test timezone-agnostic coercion rejects non-datetime-like data."""
+    dtype = pandas_engine.DateTime(time_zone_agnostic=True, tz=pytz.UTC)
+
+    with pytest.raises(errors.ParserError, match="time_zone_agnostic=True"):
+        dtype._prepare_coerce_time_zone_agnostic(pd.Series(["not_a_datetime"]))
 
 
 @hypothesis.settings(max_examples=1000)


### PR DESCRIPTION
## Description:

Issue #1309 reported that pandas datetime coercion could fail when a column contained mixed timezones or mixed offsets.

This PR updates the pandas DateTime engine to retry parsing with `utc=True` only for mixed-timezone inputs that would otherwise fail coercion or remain object-typed after `pd.to_datetime(...)`.

It also broadens the existing `time_zone_agnostic=True` coercion path so it accepts parseable datetime strings with mixed offsets in addition to datetime objects.

It adds regression tests covering:
- mixed timezone-aware datetime objects coerced to a target timezone
- mixed-offset strings coerced to timezone-naive datetimes
- mixed-offset strings on the `time_zone_agnostic=True` path

Closes #1309.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files pandera/engines/pandas_engine.py tests/pandas/test_pandas_engine.py tests/pandas/test_dtypes.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/pandas/test_pandas_engine.py -k 'mixed_timezones or mixed_offset_strings or time_zone_agnostic' && pytest -q tests/pandas/test_dtypes.py -k 'coerce_dt or test_try_coerce'`.

### The validation tests sceenshot, that were run locally:

<img width="2536" height="363" alt="image" src="https://github.com/user-attachments/assets/5df92d8e-9e5c-4342-9351-30fe4f6d5f69" />
