### PR TITLE
fix(pandas): keep ArrowString resolution stable

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -232,9 +232,6 @@ class Engine(
 
                 np_or_pd_dtype = data_type
             elif is_pyarrow_dtype(data_type):
-                # register pyarrow datatypes
-                import pandera.engines.pyarrow_engine
-
                 np_or_pd_dtype = data_type.pyarrow_dtype
             elif is_extension_dtype(data_type) and isinstance(data_type, type):
                 try:

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -1175,3 +1175,32 @@ def test_python_std_list_dict_error():
                 "bar": "2",
             }
             assert exc.failure_cases["failure_case"].iloc[1] == ["1.0", 2.0]
+
+
+def test_direct_pyarrow_engine_import_registers_pyarrow_dtypes():
+    """Test direct pyarrow engine import without leaking registry mutation."""
+    import copy
+
+    import pyarrow
+
+    from pandera.engines import engine
+
+    registry_snapshot = copy.deepcopy(
+        engine.Engine._registry[pandas_engine.Engine]
+    )
+
+    try:
+        from pandera.engines import pyarrow_engine
+
+        assert isinstance(
+            pyarrow_engine.Engine.dtype(pd.ArrowDtype(pyarrow.string())),
+            pyarrow_engine.ArrowString,
+        )
+        assert isinstance(
+            pyarrow_engine.Engine.dtype(
+                pd.ArrowDtype(pyarrow.list_(pyarrow.string()))
+            ),
+            pyarrow_engine.ArrowList,
+        )
+    finally:
+        engine.Engine._registry[pandas_engine.Engine] = registry_snapshot

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -690,6 +690,45 @@ class TestArrowStringSerializationRoundTrip:
             roundtripped.columns["col"].dtype, pandas_engine.STRING
         )
 
+    def test_pyarrow_dtype_lookup_does_not_change_arrow_string_resolution(
+        self,
+    ):
+        """Resolving another pyarrow-backed dtype should not replace
+        pandas ArrowString with the pyarrow-engine variant."""
+        import pyarrow
+
+        pandas_engine.Engine.dtype(
+            pd.ArrowDtype(pyarrow.list_(pyarrow.string()))
+        )
+
+        resolved = pandas_engine.Engine.dtype(pd.ArrowDtype(pyarrow.string()))
+
+        assert isinstance(resolved, pandas_engine.ArrowString)
+        assert str(resolved) == "arrow_string"
+
+    def test_schema_arrow_string_stays_stable_after_pyarrow_dtype_lookup(
+        self,
+    ):
+        """Schema construction should keep using pandas ArrowString after
+        resolving another pyarrow-backed dtype."""
+        import pyarrow
+
+        from pandera.pandas import DataFrameModel
+        from pandera.typing import Series as TypedSeries
+
+        pandas_engine.Engine.dtype(
+            pd.ArrowDtype(pyarrow.list_(pyarrow.string()))
+        )
+
+        class ArrowModel(DataFrameModel):
+            col: TypedSeries[pyarrow.string]
+
+        schema = ArrowModel.to_schema()
+
+        assert isinstance(
+            schema.columns["col"].dtype, pandas_engine.ArrowString
+        )
+
 
 def test_default_numeric_dtypes():
     """


### PR DESCRIPTION
## Description:

Issue #2351 reported that resolving another pyarrow-backed pandas dtype could change how `pd.ArrowDtype(pyarrow.string())` is resolved.

This PR updates the pandas engine to resolve pyarrow-backed pandas dtypes without importing `pandera.engines.pyarrow_engine` in that path, so the pandas-engine `ArrowString` registration stays stable.

It also adds regression tests that cover ArrowString resolution after another pyarrow-backed dtype lookup, including the `DataFrameModel` schema path.

This is a regression related to #2228 and #2229.

Closes #2351.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files pandera/engines/pandas_engine.py tests/pandas/test_dtypes.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/pandas/test_dtypes.py -k 'ArrowStringSerializationRoundTrip'`.
- [x] I have run the broader pandas regression reproduction in WSL using `pytest -q tests/pandas/test_pandas_engine.py tests/pandas/test_dtypes.py`.

### The validation tests run screenshots, which were run locally:

<img width="2496" height="825" alt="image" src="https://github.com/user-attachments/assets/6c6b17d0-089a-4dda-9720-0efb8b5d31d9" />

<img width="2526" height="1283" alt="image" src="https://github.com/user-attachments/assets/8cf9c06a-7674-42aa-9683-e06a2355992c" />
