### PR TITLE
fix(pandas): preserve drop_invalid_rows in schema IO

### DIFF
--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -161,6 +161,7 @@ def _serialize_component_stats(component_stats):
                 "coerce",
                 "required",
                 "regex",
+                "drop_invalid_rows",
             ]
             if key in component_stats
         },
@@ -254,6 +255,7 @@ def serialize_schema(
         "add_missing_columns": dataframe_schema.add_missing_columns,
         "title": dataframe_schema.title,
         "description": dataframe_schema.description,
+        "drop_invalid_rows": dataframe_schema.drop_invalid_rows,
     }
     if lib != "pandas":
         out["dataframe_library"] = lib
@@ -342,6 +344,7 @@ def _deserialize_component_stats(serialized_component_stats):
                 "coerce",
                 "required",
                 "regex",
+                "drop_invalid_rows",
             ]
             if key in serialized_component_stats
         },
@@ -446,6 +449,7 @@ def deserialize_schema(serialized_schema):
         title=serialized_schema.get("title", None),
         description=serialized_schema.get("description", None),
         metadata=metadata,
+        drop_invalid_rows=serialized_schema.get("drop_invalid_rows", False),
     )
 
 

--- a/pandera/schema_statistics/pandas.py
+++ b/pandera/schema_statistics/pandas.py
@@ -111,6 +111,7 @@ def get_dataframe_schema_statistics(dataframe_schema):
                 "unique": column.unique,
                 "description": column.description,
                 "title": column.title,
+                "drop_invalid_rows": column.drop_invalid_rows,
             }
             for col_name, column in dataframe_schema.columns.items()
         },
@@ -135,6 +136,7 @@ def _get_series_base_schema_statistics(series_schema_base):
         "unique": series_schema_base.unique,
         "title": series_schema_base.title,
         "description": series_schema_base.description,
+        "drop_invalid_rows": series_schema_base.drop_invalid_rows,
     }
 
 

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -38,6 +38,26 @@ _PANDERA_VERSION = pandera_base.__version__
 _PANDERA_STR_DTYPE = str(pandas_engine.Engine.dtype(pandera.String))
 
 
+def _with_drop_invalid_rows_defaults(serialized_schema):
+    """Add default drop_invalid_rows fields expected in non-minimal output."""
+    serialized_schema = dict(serialized_schema)
+    serialized_schema.setdefault("drop_invalid_rows", False)
+
+    columns = serialized_schema.get("columns")
+    if isinstance(columns, dict):
+        for column in columns.values():
+            if isinstance(column, dict):
+                column.setdefault("drop_invalid_rows", False)
+
+    index = serialized_schema.get("index")
+    if isinstance(index, list):
+        for index_component in index:
+            if isinstance(index_component, dict):
+                index_component.setdefault("drop_invalid_rows", False)
+
+    return serialized_schema
+
+
 # skip all tests in module if "io" depends aren't installed
 pytestmark = pytest.mark.skipif(
     not HAS_IO, reason='needs "io" module dependencies'
@@ -1128,10 +1148,14 @@ def test_to_yaml():
         f.write(yaml_str)
     with tempfile.NamedTemporaryFile("w+") as f:
         f.write(YAML_SCHEMA)
-    assert yaml_str.strip() == YAML_SCHEMA.strip()
+    assert yaml.safe_load(yaml_str) == _with_drop_invalid_rows_defaults(
+        yaml.safe_load(YAML_SCHEMA)
+    )
 
     yaml_str_schema_method = schema.to_yaml(minimal=False)
-    assert yaml_str_schema_method.strip() == YAML_SCHEMA.strip()
+    assert yaml.safe_load(
+        yaml_str_schema_method
+    ) == _with_drop_invalid_rows_defaults(yaml.safe_load(YAML_SCHEMA))
 
 
 @pytest.mark.skipif(
@@ -1977,9 +2001,10 @@ def test_frictionless_schema_parses_correctly(frictionless_schema):
     """Test parsing frictionless schema from yaml and json."""
     schema = io.from_frictionless_schema(frictionless_schema)
 
-    assert (
-        str(schema.to_yaml(minimal=False)).strip()
-        == YAML_FROM_FRICTIONLESS.strip()
+    assert yaml.safe_load(
+        str(schema.to_yaml(minimal=False))
+    ) == _with_drop_invalid_rows_defaults(
+        yaml.safe_load(YAML_FROM_FRICTIONLESS)
     )
 
     assert isinstance(schema, DataFrameSchema), (

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1340,6 +1340,52 @@ def test_io_json(index):
         assert schema_from_json == schema
 
 
+def test_io_json_roundtrip_preserves_drop_invalid_rows():
+    """Test JSON roundtrip preserves dataframe and column drop_invalid_rows."""
+    import json
+
+    schema = pandera.DataFrameSchema(
+        {"x": pandera.Column(int, drop_invalid_rows=True)},
+        drop_invalid_rows=True,
+    )
+
+    text = schema.to_json()
+    assert text is not None
+
+    payload = json.loads(text)
+    assert payload["drop_invalid_rows"] is True
+    assert payload["columns"]["x"]["drop_invalid_rows"] is True
+
+    restored = schema.from_json(text)
+    assert restored.drop_invalid_rows is True
+    assert restored.columns["x"].drop_invalid_rows is True
+    assert restored == schema
+
+
+@pytest.mark.skipif(
+    SKIP_YAML_TESTS,
+    reason="pyyaml >= 5.1.0 required",
+)
+def test_io_yaml_roundtrip_preserves_drop_invalid_rows():
+    """Test YAML roundtrip preserves dataframe and column drop_invalid_rows."""
+    schema = pandera.DataFrameSchema(
+        {"x": pandera.Column(int, drop_invalid_rows=True)},
+        drop_invalid_rows=True,
+    )
+
+    yaml_text = schema.to_yaml()
+    assert yaml_text is not None
+
+    payload = yaml.safe_load(yaml_text)
+    assert payload["drop_invalid_rows"] is True
+    assert payload["columns"]["x"]["drop_invalid_rows"] is True
+
+    restored = schema.from_yaml(yaml_text)
+    assert restored.drop_invalid_rows is True
+    assert restored.columns["x"].drop_invalid_rows is True
+    assert restored == schema
+
+
 def test_io_json_with_multiindex_column_labels():
     """Test JSON serialization for schemas with tuple column labels."""
     import json

--- a/tests/pandas/test_schema_statistics.py
+++ b/tests/pandas/test_schema_statistics.py
@@ -526,6 +526,7 @@ def test_get_dataframe_schema_statistics():
                 "regex": False,
                 "description": "Integer column with title",
                 "title": "integer_col",
+                "drop_invalid_rows": False,
             },
             "float": {
                 "dtype": DEFAULT_FLOAT,
@@ -554,6 +555,7 @@ def test_get_dataframe_schema_statistics():
                 "regex": False,
                 "description": "Float col no title",
                 "title": None,
+                "drop_invalid_rows": False,
             },
             "str": {
                 "dtype": pandas_engine.Engine.dtype(str),
@@ -574,6 +576,7 @@ def test_get_dataframe_schema_statistics():
                 "regex": False,
                 "description": None,
                 "title": None,
+                "drop_invalid_rows": False,
             },
         },
         "index": [
@@ -595,6 +598,7 @@ def test_get_dataframe_schema_statistics():
                 "unique": False,
                 "description": None,
                 "title": None,
+                "drop_invalid_rows": False,
             }
         ],
         "coerce": False,
@@ -640,6 +644,7 @@ def test_get_series_schema_statistics():
         "unique": False,
         "description": None,
         "title": None,
+        "drop_invalid_rows": False,
     }
 
 
@@ -683,6 +688,7 @@ def test_get_series_schema_statistics():
                     "unique": False,
                     "description": None,
                     "title": None,
+                    "drop_invalid_rows": False,
                 }
             ],
         ]


### PR DESCRIPTION
## Description:

Issues #1339 and #1357 reported that `drop_invalid_rows` was lost when pandas `DataFrameSchema` objects were serialized to JSON or YAML and then deserialized.

This PR updates the pandas schema statistics and pandas IO serialization paths to preserve `drop_invalid_rows` for both `DataFrameSchema` objects and pandas schema components.

It also adds regression tests that cover JSON and YAML round-trips for schema-level and column-level `drop_invalid_rows`.

Closes #1339.
Closes #1357.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files pandera/schema_statistics/pandas.py pandera/io/pandas_io.py tests/io/test_pandas_io.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/io/test_pandas_io.py -k "drop_invalid_rows or test_io_json or test_io_yaml"`.

### The validation tests run screenshot, run locally:

<img width="2538" height="1520" alt="image" src="https://github.com/user-attachments/assets/207de866-689a-43ce-bb3b-c42662eae35c" />

### The linting check, run locally:

<img width="1220" height="526" alt="image" src="https://github.com/user-attachments/assets/5b33cd84-d493-4d7d-970c-72348b9acf9f" />
