### PR TITLE
Fix `PydanticModel` polars coercion dropping dtype info and mis-inferring all-null columns as `Null`

### DIFF
--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -982,6 +982,34 @@ class PydanticModel(DataType):
             self._check_column_names(lf, column_names)
             return lf
 
+        input_schema = df.collect_schema()
+        # Dtypes the pydantic model produces after coercion. Preferred over the
+        # input schema when repairing fully-null columns, since the model may
+        # coerce a column to a different type (e.g. Utf8 input -> int field).
+        model_schema = self._get_polars_schema()
+
+        def _repair_dtype(name: str) -> DataTypeClass | pl.DataType | None:
+            for candidate in (model_schema.get(name), input_schema.get(name)):
+                if candidate is not None and candidate != pl.Null:
+                    return candidate
+            return None
+
+        def _build_frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
+            # Scan every row (infer_schema_length=None) so a nullable column
+            # whose first ``infer_schema_length`` rows are all None is not
+            # mis-inferred from too small a sample. A fully-null column still
+            # infers as pl.Null, so repair those using the model's coerced
+            # output dtype (falling back to the input frame's known dtype).
+            frame = pl.DataFrame(rows, infer_schema_length=None)
+            casts = [
+                pl.col(name).cast(repair)
+                for name, dtype in frame.schema.items()
+                if dtype == pl.Null and (repair := _repair_dtype(name))
+            ]
+            if casts:
+                frame = frame.with_columns(casts)
+            return frame
+
         coerced_rows: list[dict[str, Any]] = []
         failure_cases: list[str] = []
         row_passed: list[bool] = []
@@ -1005,7 +1033,7 @@ class PydanticModel(DataType):
 
         if failure_cases:
             check_output = pl.DataFrame({CHECK_OUTPUT_KEY: row_passed})
-            fc_df = pl.DataFrame(coerced_rows).filter(
+            fc_df = _build_frame(coerced_rows).filter(
                 pl.lit(pl.Series(row_passed)).not_()
             )
             raise errors.ParserError(
@@ -1014,7 +1042,7 @@ class PydanticModel(DataType):
                 parser_output=check_output,
             )
 
-        return pl.DataFrame(coerced_rows).lazy()
+        return _build_frame(coerced_rows).lazy()
 
     def try_coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container, raising ParserError on failure."""

--- a/tests/polars/test_polars_pydantic_dtype.py
+++ b/tests/polars/test_polars_pydantic_dtype.py
@@ -239,6 +239,152 @@ def test_pydantic_model_schema_validate():
         schema.validate(invalid_df)
 
 
+def test_pydantic_model_nullable_column_late_value():
+    """Regression: a nullable string column whose first 100+ rows are None
+    must not be inferred as pl.Null, which would drop later real values."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    # First 120 rows have code=None; a later row carries a real string value
+    # beyond the default infer_schema_length window of 100.
+    rows = [{"name": "A", "code": None} for _ in range(120)]
+    rows.append({"name": "B", "code": "00435L108"})
+    df = pl.DataFrame(rows, schema={"name": pl.Utf8, "code": pl.Utf8})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.String
+    assert validated["code"].to_list()[-1] == "00435L108"
+    assert validated.shape == (121, 2)
+
+
+def test_pydantic_model_fully_null_column_keeps_dtype():
+    """Regression: a fully-null nullable column infers as pl.Null on its own.
+    It should be repaired to a concrete dtype so downstream ops don't break."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    rows = [{"name": "A", "code": None} for _ in range(5)]
+    df = pl.DataFrame(rows, schema={"name": pl.Utf8, "code": pl.Utf8})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.String
+    assert validated["code"].to_list() == [None] * 5
+
+
+def test_pydantic_model_fully_null_column_uses_coerced_dtype():
+    """A fully-null column should be repaired to the pydantic model's coerced
+    output dtype, not the (possibly different) input dtype.
+
+    Here the input is Utf8 but the field is `int | None`, so the output column
+    should be an integer type, consistent with PydanticModel.empty().
+    """
+
+    class Record(BaseModel):
+        code: int | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    df = pl.DataFrame({"code": pl.Series([None, None], dtype=pl.Utf8)})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.Int64
+    assert validated["code"].to_list() == [None, None]
+
+
+def test_pydantic_model_fully_null_column_unrepairable_dtype():
+    """When a fully-null column maps to pl.Null in both the model schema and
+    the input schema, there is no concrete dtype to repair it with, so it is
+    left as pl.Null (exercises the _repair_dtype fall-through)."""
+
+    class Custom:
+        pass
+
+    class Record(BaseModel):
+        class Config:
+            arbitrary_types_allowed = True
+
+        blob: Custom | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    # No explicit schema: an all-None column infers as pl.Null on input too,
+    # and Custom is unsupported so the model schema is pl.Null as well.
+    df = pl.DataFrame({"blob": [None, None]})
+    assert df.schema["blob"] == pl.Null
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["blob"] == pl.Null
+    assert validated["blob"].to_list() == [None, None]
+
+
+def test_pydantic_model_nullable_late_value_failure_path():
+    """The failure-path frame construction must also scan all rows so the
+    ParserError surfaces real parser failure cases rather than the polars
+    "could not append value" inference error from a Null-typed builder."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+        xcoord: int
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    rows = [{"name": "A", "code": None, "xcoord": 1} for _ in range(120)]
+    rows.append({"name": "B", "code": "00435L108", "xcoord": 2})
+    # One invalid row triggers the failure path (fc_df) construction.
+    rows.append({"name": "C", "code": "X", "xcoord": "not-an-int"})
+    df = pl.DataFrame(
+        rows,
+        schema={"name": pl.Utf8, "code": pl.Utf8, "xcoord": pl.Utf8},
+    )
+
+    with pytest.raises(pa.errors.SchemaError) as exc_info:
+        RecordSchema.validate(df)
+
+    # The error must be the intended parser failure, not the polars
+    # "could not append value" inference error that the bug produced.
+    assert "could not append value" not in str(exc_info.value)
+
+    # The failure_cases frame must carry the genuinely-invalid row (the bad
+    # xcoord), and the late "code" value must have been preserved as a string
+    # rather than dropped by a Null-typed builder.
+    failure_cases = exc_info.value.failure_cases
+    assert failure_cases.schema["code"] == pl.String
+    assert failure_cases["xcoord"].to_list() == ["not-an-int"]
+
+
 def test_pydantic_model_with_check_types():
     """Test PydanticModel with @check_types decorator."""
     from pandera.typing.polars import DataFrame as PolarsDataFrame


### PR DESCRIPTION
## Summary

When a polars `DataFrameModel` uses `Config.dtype = PydanticModel(...)`, validation could fail with:

```
SchemaError: Error while coercing '<Schema>' to type <class '...'>: could not append
value: "<some string>" of type: str to the builder; make sure that all rows have the
same schema or consider increasing `infer_schema_length`
it might also be that a value overflows the data-type's capacity
```

even though every row is individually valid against the pydantic model and the input DataFrame is correctly typed. There is no associated issue, so the minimal reproducer is included below.

## What this PR changes

`PydanticModel.coerce` now reconstructs the coerced frame through a single `_build_frame` helper that (1) scans **every** row when inferring dtypes and (2) repairs any column that still lands on `pl.Null` using a concrete dtype. Both the success-return path and the `fc_df` failure path go through this helper, so neither can emit the `Null`-append error anymore.

```python
input_schema = df.collect_schema()
# Dtypes the pydantic model produces after coercion.
model_schema = self._get_polars_schema()

def _repair_dtype(name):
    for candidate in (model_schema.get(name), input_schema.get(name)):
        if candidate is not None and candidate != pl.Null:
            return candidate
    return None

def _build_frame(rows):
    # Scan every row so a nullable column whose first infer_schema_length
    # rows are all None is not mis-inferred from too small a sample.
    frame = pl.DataFrame(rows, infer_schema_length=None)
    # A fully-null column still infers as pl.Null; repair it with the model's
    # coerced output dtype (falling back to the input frame's known dtype).
    casts = [
        pl.col(name).cast(repair)
        for name, dtype in frame.schema.items()
        if dtype == pl.Null and (repair := _repair_dtype(name))
    ]
    if casts:
        frame = frame.with_columns(casts)
    return frame
```

The three decisions that make this robust:

- **`infer_schema_length=None`** scans all rows, so a column that is `None` for its first 100 rows but real afterwards is no longer mis-typed from too small a sample. This alone fixes the reported crash.
- **`pl.Null` repair prefers the pydantic model's coerced output dtype** (`_get_polars_schema()` — the same source `DataFrameModel.empty()` uses), falling back to the input frame's declared dtype. A fully-null column still infers as `pl.Null` even after scanning all rows, so it must be repaired; using the model's dtype keeps the output consistent with what the model actually produces — e.g. an all-null `Utf8` input column for an `int | None` field becomes `Int64`, not `String`.
- **Casts are restricted to `Null`-inferred columns**, so columns that already inferred a concrete type are never clobbered (the model may legitimately coerce a type, and we don't want to override that).

## Root cause

`PydanticModel.coerce` (`pandera/engines/polars_engine.py`) rebuilt the output frame from a `list[dict]` produced by `model_dump()`, using a bare `pl.DataFrame(coerced_rows)` with **no** `schema=` and the default `infer_schema_length=100`:

```python
fc_df = pl.DataFrame(coerced_rows).filter(...)   # failure path
...
return pl.DataFrame(coerced_rows).lazy()         # return path
```

Two consequences followed:

1. The already-known, correct column dtypes from the collected input frame were discarded — so callers could not fix the problem by explicitly typing their input.
2. A nullable column that is `None` for the first 100+ rows was inferred as `pl.Null`. The first later row carrying a real value could not be appended to the `Null`-typed builder, surfacing the `ComputeError` above as a pandera `SchemaError`.

This is a realistic scenario when optional identifiers are absent for an initial run of records and present later.

## Minimal reproducer

```python
import polars as pl
import pandera.polars as pa
from pandera.engines.polars_engine import PydanticModel
from pydantic import BaseModel


class Record(BaseModel):
    name: str | None = None
    code: str | None = None  # nullable string identifier


class RecordSchema(pa.DataFrameModel):
    class Config:
        dtype = PydanticModel(Record)
        coerce = True
        strict = False


# First 120 rows have code=None; a later row carries a real string identifier,
# beyond the default infer_schema_length window of 100.
rows = [{"name": "A", "code": None} for _ in range(120)]
rows.append({"name": "B", "code": "00435L108"})

# The input frame's dtype is irrelevant: even an explicit all-Utf8 schema is discarded,
# because PydanticModel.coerce rebuilds the frame internally from model_dump() output.
df = pl.DataFrame(rows, schema={"name": pl.Utf8, "code": pl.Utf8})

RecordSchema.validate(df)  # before: SchemaError: could not append value "00435L108" ...
```

Reordering so the real value falls within the first 100 rows makes it pass — confirming the sampling boundary, not the data, is the cause.

## Tests

Added regression tests in `tests/polars/test_polars_pydantic_dtype.py`:

- `test_pydantic_model_nullable_column_late_value` — the exact reproducer; asserts the column stays `String` and all 121 rows survive.
- `test_pydantic_model_fully_null_column_keeps_dtype` — an all-`None` column is repaired to a concrete dtype rather than collapsing to `Null`.
- `test_pydantic_model_fully_null_column_uses_coerced_dtype` — an all-null `Utf8` input column for an `int | None` field becomes `Int64`, matching the model's output type.
- `test_pydantic_model_nullable_late_value_failure_path` — exercises the failure-path frame construction; asserts the error is a real parser failure (the bad row appears in `failure_cases` with the late value preserved as a string) and **not** the polars "could not append value" inference error.

All existing polars `PydanticModel` tests continue to pass.

## Workaround (for affected users on prior versions)

Avoid `PydanticModel` as the column dtype; declare native `DataFrameModel` field annotations instead (pandera already emits a performance warning recommending this). Native annotations bypass the per-row `model_validate`/`model_dump` round-trip and the unschema'd frame reconstruction entirely.
