### PR TITLE
refactor: pydantic/polars cleanup and benchmark coverage

### DIFF
--- a/asv_bench/benchmarks/polars_pydantic_model.py
+++ b/asv_bench/benchmarks/polars_pydantic_model.py
@@ -1,0 +1,66 @@
+# Airspeed Velocity Benchmarks for pandera polars PydanticModel coercion
+import os
+
+# PydanticModel emits a per-call performance warning. pandera reads this env
+# var into its config at import time, so it must be set before importing
+# pandera below or the warning will not be silenced.
+os.environ["SILENCE_WARNING_PYDANTIC_MODEL"] = "true"
+
+import polars as pl  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
+
+import pandera.polars as pa  # noqa: E402
+from pandera.engines.polars_engine import PydanticModel  # noqa: E402
+
+N = 50_000
+
+
+class Record(BaseModel):
+    name: str | None = None
+    code: str | None = None  # nullable id, None for a long leading run
+    xcoord: int | None = None
+
+
+class RecordSchema(pa.DataFrameModel):
+    class Config:
+        dtype = PydanticModel(Record)
+        coerce = True
+        strict = False
+
+
+class PydanticModelCoerce:
+    """Benchmark PydanticModel coercion on the success and failure paths.
+
+    Tracks time and peak RSS for both paths so future work on the row-wise
+    ``model_dump()`` ``list[dict]`` (the dominant allocation) has a baseline.
+    """
+
+    def setup(self):
+        # The "code" column is None well past the default infer_schema_length
+        # window, then carries a real value, mirroring the bug's data shape.
+        valid = [{"name": "A", "code": None, "xcoord": i} for i in range(N)]
+        valid.append({"name": "B", "code": "00435L108", "xcoord": N})
+        schema = {"name": pl.Utf8, "code": pl.Utf8, "xcoord": pl.Object}
+
+        self.success_df = pl.DataFrame(valid, schema=schema)
+        # One invalid row near the end triggers the failure path.
+        invalid = valid + [{"name": "C", "code": None, "xcoord": "not-an-int"}]
+        self.failure_df = pl.DataFrame(invalid, schema=schema)
+
+    def time_success(self):
+        RecordSchema.validate(self.success_df)
+
+    def peakmem_success(self):
+        RecordSchema.validate(self.success_df)
+
+    def time_failure(self):
+        try:
+            RecordSchema.validate(self.failure_df)
+        except pa.errors.SchemaError:
+            pass
+
+    def peakmem_failure(self):
+        try:
+            RecordSchema.validate(self.failure_df)
+        except pa.errors.SchemaError:
+            pass

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -982,6 +982,34 @@ class PydanticModel(DataType):
             self._check_column_names(lf, column_names)
             return lf
 
+        input_schema = df.collect_schema()
+        # Dtypes the pydantic model produces after coercion. Preferred over the
+        # input schema when repairing fully-null columns, since the model may
+        # coerce a column to a different type (e.g. Utf8 input -> int field).
+        model_schema = self._get_polars_schema()
+
+        def _repair_dtype(name: str) -> DataTypeClass | pl.DataType | None:
+            for candidate in (model_schema.get(name), input_schema.get(name)):
+                if candidate is not None and candidate != pl.Null:
+                    return candidate
+            return None
+
+        def _build_frame(rows: list[dict[str, Any]]) -> pl.DataFrame:
+            # Scan every row (infer_schema_length=None) so a nullable column
+            # whose first ``infer_schema_length`` rows are all None is not
+            # mis-inferred from too small a sample. A fully-null column still
+            # infers as pl.Null, so repair those using the model's coerced
+            # output dtype (falling back to the input frame's known dtype).
+            frame = pl.DataFrame(rows, infer_schema_length=None)
+            casts = [
+                pl.col(name).cast(repair)
+                for name, dtype in frame.schema.items()
+                if dtype == pl.Null and (repair := _repair_dtype(name))
+            ]
+            if casts:
+                frame = frame.with_columns(casts)
+            return frame
+
         coerced_rows: list[dict[str, Any]] = []
         failure_cases: list[str] = []
         row_passed: list[bool] = []
@@ -1005,7 +1033,7 @@ class PydanticModel(DataType):
 
         if failure_cases:
             check_output = pl.DataFrame({CHECK_OUTPUT_KEY: row_passed})
-            fc_df = pl.DataFrame(coerced_rows).filter(
+            fc_df = _build_frame(coerced_rows).filter(
                 pl.lit(pl.Series(row_passed)).not_()
             )
             raise errors.ParserError(
@@ -1014,7 +1042,7 @@ class PydanticModel(DataType):
                 parser_output=check_output,
             )
 
-        return pl.DataFrame(coerced_rows).lazy()
+        return _build_frame(coerced_rows).lazy()
 
     def try_coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Coerce data container, raising ParserError on failure."""

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -1011,7 +1011,6 @@ class PydanticModel(DataType):
             return frame
 
         coerced_rows: list[dict[str, Any]] = []
-        failure_cases: list[str] = []
         row_passed: list[bool] = []
 
         for row in df.iter_rows(named=True):
@@ -1022,17 +1021,22 @@ class PydanticModel(DataType):
                     coerced = self.type.parse_obj(row).dict()
                 coerced_rows.append(coerced)
                 row_passed.append(True)
-            except ValidationError as exc:
-                failed_fields = {
-                    k: row.get(k, "<missing>")
-                    for k in (x["loc"][0] for x in exc.errors())
-                }
-                failure_cases.append(str(failed_fields))
+            except ValidationError:
                 coerced_rows.append(row)
                 row_passed.append(False)
 
-        if failure_cases:
+        # The input frame is no longer needed once every row has been read;
+        # drop it before rebuilding so its buffers don't coexist with the new
+        # frame.
+        del df
+
+        if not all(row_passed):
             check_output = pl.DataFrame({CHECK_OUTPUT_KEY: row_passed})
+            # Build from all coerced rows, then filter to the failing ones, so
+            # the failure_cases frame keeps every column it would otherwise
+            # have: model-output fields contributed by the successful rows
+            # (e.g. fields with defaults that are absent from the raw input)
+            # stay present rather than vanishing with a failed-rows-only build.
             fc_df = _build_frame(coerced_rows).filter(
                 pl.lit(pl.Series(row_passed)).not_()
             )

--- a/tests/polars/test_polars_pydantic_dtype.py
+++ b/tests/polars/test_polars_pydantic_dtype.py
@@ -385,6 +385,37 @@ def test_pydantic_model_nullable_late_value_failure_path():
     assert failure_cases["xcoord"].to_list() == ["not-an-int"]
 
 
+def test_pydantic_model_failure_cases_preserves_model_output_columns():
+    """failure_cases must retain model-output columns contributed by the valid
+    rows even when those fields are absent from the raw input (e.g. fields with
+    defaults). Regression guard: building the failure frame from only the
+    failing rows would drop such columns."""
+
+    class Record(BaseModel):
+        xcoord: int
+        defaulted: str | None = None  # absent from the input frame
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    # Input lacks the model's "defaulted" field; one valid row, one invalid.
+    df = pl.DataFrame(
+        {"xcoord": ["1", "not-an-int"]}, schema={"xcoord": pl.Utf8}
+    )
+
+    with pytest.raises(pa.errors.SchemaError) as exc_info:
+        RecordSchema.validate(df)
+
+    failure_cases = exc_info.value.failure_cases
+    # The valid row's model output establishes "defaulted"; it must survive
+    # into the failure frame rather than disappearing.
+    assert "defaulted" in failure_cases.columns
+    assert failure_cases["xcoord"].to_list() == ["not-an-int"]
+
+
 def test_pydantic_model_with_check_types():
     """Test PydanticModel with @check_types decorator."""
     from pandera.typing.polars import DataFrame as PolarsDataFrame

--- a/tests/polars/test_polars_pydantic_dtype.py
+++ b/tests/polars/test_polars_pydantic_dtype.py
@@ -239,6 +239,152 @@ def test_pydantic_model_schema_validate():
         schema.validate(invalid_df)
 
 
+def test_pydantic_model_nullable_column_late_value():
+    """Regression: a nullable string column whose first 100+ rows are None
+    must not be inferred as pl.Null, which would drop later real values."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    # First 120 rows have code=None; a later row carries a real string value
+    # beyond the default infer_schema_length window of 100.
+    rows = [{"name": "A", "code": None} for _ in range(120)]
+    rows.append({"name": "B", "code": "00435L108"})
+    df = pl.DataFrame(rows, schema={"name": pl.Utf8, "code": pl.Utf8})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.String
+    assert validated["code"].to_list()[-1] == "00435L108"
+    assert validated.shape == (121, 2)
+
+
+def test_pydantic_model_fully_null_column_keeps_dtype():
+    """Regression: a fully-null nullable column infers as pl.Null on its own.
+    It should be repaired to a concrete dtype so downstream ops don't break."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    rows = [{"name": "A", "code": None} for _ in range(5)]
+    df = pl.DataFrame(rows, schema={"name": pl.Utf8, "code": pl.Utf8})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.String
+    assert validated["code"].to_list() == [None] * 5
+
+
+def test_pydantic_model_fully_null_column_uses_coerced_dtype():
+    """A fully-null column should be repaired to the pydantic model's coerced
+    output dtype, not the (possibly different) input dtype.
+
+    Here the input is Utf8 but the field is `int | None`, so the output column
+    should be an integer type, consistent with PydanticModel.empty().
+    """
+
+    class Record(BaseModel):
+        code: int | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    df = pl.DataFrame({"code": pl.Series([None, None], dtype=pl.Utf8)})
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["code"] == pl.Int64
+    assert validated["code"].to_list() == [None, None]
+
+
+def test_pydantic_model_fully_null_column_unrepairable_dtype():
+    """When a fully-null column maps to pl.Null in both the model schema and
+    the input schema, there is no concrete dtype to repair it with, so it is
+    left as pl.Null (exercises the _repair_dtype fall-through)."""
+
+    class Custom:
+        pass
+
+    class Record(BaseModel):
+        class Config:
+            arbitrary_types_allowed = True
+
+        blob: Custom | None = None
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    # No explicit schema: an all-None column infers as pl.Null on input too,
+    # and Custom is unsupported so the model schema is pl.Null as well.
+    df = pl.DataFrame({"blob": [None, None]})
+    assert df.schema["blob"] == pl.Null
+
+    validated = RecordSchema.validate(df)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated.schema["blob"] == pl.Null
+    assert validated["blob"].to_list() == [None, None]
+
+
+def test_pydantic_model_nullable_late_value_failure_path():
+    """The failure-path frame construction must also scan all rows so the
+    ParserError surfaces real parser failure cases rather than the polars
+    "could not append value" inference error from a Null-typed builder."""
+
+    class Record(BaseModel):
+        name: str | None = None
+        code: str | None = None
+        xcoord: int
+
+    class RecordSchema(pa.DataFrameModel):
+        class Config:
+            dtype = PydanticModel(Record)
+            coerce = True
+            strict = False
+
+    rows = [{"name": "A", "code": None, "xcoord": 1} for _ in range(120)]
+    rows.append({"name": "B", "code": "00435L108", "xcoord": 2})
+    # One invalid row triggers the failure path (fc_df) construction.
+    rows.append({"name": "C", "code": "X", "xcoord": "not-an-int"})
+    df = pl.DataFrame(
+        rows,
+        schema={"name": pl.Utf8, "code": pl.Utf8, "xcoord": pl.Utf8},
+    )
+
+    with pytest.raises(pa.errors.SchemaError) as exc_info:
+        RecordSchema.validate(df)
+
+    # The error must be the intended parser failure, not the polars
+    # "could not append value" inference error that the bug produced.
+    assert "could not append value" not in str(exc_info.value)
+
+    # The failure_cases frame must carry the genuinely-invalid row (the bad
+    # xcoord), and the late "code" value must have been preserved as a string
+    # rather than dropped by a Null-typed builder.
+    failure_cases = exc_info.value.failure_cases
+    assert failure_cases.schema["code"] == pl.String
+    assert failure_cases["xcoord"].to_list() == ["not-an-int"]
+
+
 def test_pydantic_model_with_check_types():
     """Test PydanticModel with @check_types decorator."""
     from pandera.typing.polars import DataFrame as PolarsDataFrame


### PR DESCRIPTION
Depends on: #2356 

This PR also includes a small cleanup of `PydanticModel.coerce` and adds benchmark coverage. There is **no measurable peak-RSS change** after preserving the `failure_cases` shape (see below); the value here is dead-code removal, regression coverage, and an asv benchmark for future work.

What changed in `PydanticModel.coerce`:

- **Removed dead work.** The validation loop built a `{field: value}` dict and `str(...)` for every failing row into a `list[str]` that was only ever read for its truthiness. That accumulation — and the per-failed-row `exc.errors()` walk feeding it — is gone; failure detection now keys off `row_passed`.
- **`del df` before rebuilding.** The collected input frame is dropped once every row has been read, so its buffers do not coexist with the rebuilt frame. This is harmless memory hygiene; it has no measurable effect on the benchmark below and helps only on frames wide enough that the input frame rivals the per-row `list[dict]`.
- **Failure-case frame shape preserved.** The failure path still builds from all coerced rows and filters to the failing ones, so model-output fields contributed by the valid rows (e.g. fields with defaults that are absent from the raw input) remain present in `failure_cases`. An earlier attempt to build from only the failing rows was reverted because it dropped those columns.

Why there is no headline performance number: the dominant allocation in this code path is **not** the polars frames but `coerced_rows`, the `list[dict]` that `model_dump()` produces one entry per row. That Python object dwarfs the Arrow buffers at scale, so the changes above do not move peak memory. Bounding the `list[dict]` itself would require chunked frame construction, which reintroduces the per-chunk dtype-inference divergence this PR's correctness fix exists to prevent; that is the remaining real lever and is deliberately left as a separate, higher-risk follow-up.

Measured peak RSS, 200,000 rows, one trailing invalid row for the failure case (Python 3.14, polars 1.38.1, pydantic 2.12.5):

| path | peak RSS before | peak RSS after | delta |
| --- | --- | --- | --- |
| success | 242 MB | 242 MB | ~0% |
| failure | 246 MB | 246 MB | ~0% |

Tests and benchmark:

- `test_pydantic_model_failure_cases_preserves_model_output_columns` — regression guard ensuring `failure_cases` keeps model-output columns contributed by valid rows.
- `asv_bench/benchmarks/polars_pydantic_model.py` — `time_`/`peakmem_` methods for the success and failure paths, for long-term tracking. asv's `peakmem_` is RSS-based, so it captures the polars/Arrow (Rust) buffers correctly — unlike `tracemalloc`, which only sees the Python heap and would miss them entirely.
