### PR TITLE
update narwhals docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,9 +207,9 @@ html_theme = "furo"
 # documentation.
 
 announcement = """
-📢 Pandera 0.31.0 introduces the <i> pandera-xarray integration </i>!
-Validate all supported xarray data structures, including Dataset, DataArray, and DataTree.
-Learn more details <a href='./xarray_guide/index.html'>here</a>
+📢 Pandera 0.32.0 introduces the <i> Narwhals-powered backend </i>!
+Use a unified backend to power the validation of different dataframe libraries.
+Learn more details <a href='./narwhals_backend.html'>here</a>
 """
 
 html_logo = "_static/pandera-banner.png"

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -57,5 +57,5 @@ in the same process, call `register_polars_backends.cache_clear()`,
 If `PANDERA_USE_NARWHALS_BACKEND=True` but `narwhals` is not installed,
 schema construction raises an `ImportError` pointing you at
 `pandera[narwhals]`. See the
-{ref}`Narwhals-powered backends <narwhals-backends>` section of the
-supported libraries page for the full feature comparison.
+{ref}`Narwhals-powered backends <narwhals-backend>` page for the full
+feature comparison.

--- a/docs/source/ibis.md
+++ b/docs/source/ibis.md
@@ -33,17 +33,19 @@ You can find the command to install the Ibis backend of your choice on the
 
 :::{note}
 *new in 0.32.0*; Pandera ships an optional
-{ref}`Narwhals-powered backend <narwhals-backends>` that runs validation
-against the native Ibis expression graph without materializing tables and
-shares its check implementations with the Polars backend. It is **opt-in**:
-install the `narwhals` extra and set
-`PANDERA_USE_NARWHALS_BACKEND=True` (or `pandera.config.CONFIG.use_narwhals_backend = True`)
-before importing `pandera.ibis`. By default Pandera uses the native Ibis
-backend. The public API shown on this page is unchanged either way.
+{ref}`Narwhals-powered backend <narwhals-backend>` that runs validation
+against the native Ibis expression graph without materializing tables.
+To opt into the Narwhals backend do the following:
 
 ```bash
-pip install 'pandera[ibis,narwhals]' 'ibis-framework[duckdb]'
+# install the narwhals extra
+pip install 'pandera[ibis,narwhals]'
+
+# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
+
+# or set the config option in Python
+pandera.config.CONFIG.use_narwhals_backend = True
 ```
 :::
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -92,22 +92,22 @@ settings. With `pandera`, you can:
 1. Define a schema once and use it to validate {ref}`different dataframe types <supported-dataframe-libraries>`
    including [pandas](http://pandas.pydata.org), [polars](https://docs.pola.rs/), [dask](https://dask.org/),
    [modin](https://modin.readthedocs.io/), [ibis](https://ibis-project.org/), and
-   [pyspark](https://spark.apache.org/docs/latest/api/python/index.html).
-2. {ref}`Check<checks>` the types and properties of columns in a
+   [pyspark](https://spark.apache.org/docs/latest/api/python/index.html). Use the {ref}`Narwhals-powered backend <narwhals-backend>` to keep validation fully lazy when possible.
+1. {ref}`Check<checks>` the types and properties of columns in a
    `pd.DataFrame` or values in a `pd.Series`.
-3. Perform more complex statistical validation like
+1. Perform more complex statistical validation like
    {ref}`hypothesis testing<hypothesis>`.
-4. {ref}`Parse<parsers>` data to standardize the preprocessing steps needed to
+1. {ref}`Parse<parsers>` data to standardize the preprocessing steps needed to
    produce valid data.
-5. Seamlessly integrate with existing data analysis/processing pipelines
+1. Seamlessly integrate with existing data analysis/processing pipelines
    via {ref}`function decorators<decorators>`.
-6. Define dataframe models with the {ref}`class-based API <dataframe-models>` with
+1. Define dataframe models with the {ref}`class-based API <dataframe-models>` with
    pydantic-style syntax and validate dataframes using the typing syntax.
-7. {ref}`Synthesize data <data-synthesis-strategies>` from schema objects for
+1. {ref}`Synthesize data <data-synthesis-strategies>` from schema objects for
    property-based testing with pandas data structures.
-8. {ref}`Lazily Validate <lazy-validation>` dataframes so that all validation
+1. {ref}`Lazily Validate <lazy-validation>` dataframes so that all validation
    rules are executed before raising an error.
-9. {ref}`Integrate <integrations>` with a rich ecosystem of python tools like
+1. {ref}`Integrate <integrations>` with a rich ecosystem of python tools like
    [pydantic](https://pydantic-docs.helpmanual.io/),
    [fastapi](https://fastapi.tiangolo.com/) and [mypy](http://mypy-lang.org/).
 
@@ -160,6 +160,7 @@ pip install 'pandera[geopandas]'    # validate geopandas geodataframes
 pip install 'pandera[polars]'       # validate polars dataframes
 pip install 'pandera[ibis]'         # validate ibis tables
 pip install 'pandera[xarray]'       # validate xarray data structures
+pip install 'pandera[narwhals]'     # use the Narwhals-powered backend
 ```
 :::
 
@@ -179,6 +180,7 @@ conda install -c conda-forge pandera-modin-dask   # validate modin dataframes wi
 conda install -c conda-forge pandera-geopandas    # validate geopandas geodataframes
 conda install -c conda-forge pandera-polars       # validate polars dataframes
 conda install -c conda-forge pandera-ibis         # validate ibis tables
+conda install -c conda-forge pandera-narwhals     # use the Narwhals-powered backend
 ```
 :::
 ::::
@@ -391,6 +393,25 @@ and `ibis`. The table below shows which of pandera's features are available for 
 :::{note}
 The `dask`, `modin`, `geopandas`, and `pyspark.pandas` support in pandera all
 leverage the pandas validation backend.
+:::
+
+:::{important}
+*new in 0.32.0*; Pandera ships an optional
+{ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
+fully lazy when possible. To opt into the Narwhals backend do the following:
+
+```bash
+# install the narwhals extra with the supported dataframe libraries
+pip install 'pandera[narwhals,pyspark]'    # for PySpark SQL
+pip install 'pandera[narwhals,polars]'    # for Polars
+pip install 'pandera[narwhals,ibis]'      # for Ibis
+
+# set the environment variable
+export PANDERA_USE_NARWHALS_BACKEND=True
+
+# or set the config option in Python
+pandera.config.CONFIG.use_narwhals_backend = True
+```
 :::
 
 

--- a/docs/source/narwhals_backend.md
+++ b/docs/source/narwhals_backend.md
@@ -1,0 +1,175 @@
+(narwhals-backend)=
+
+# Narwhals
+
+As of *0.32.0*, Pandera ships an optional
+[Narwhals](https://narwhals-dev.github.io/narwhals/)-based validation
+backend that powers the {ref}`Polars <polars>`, {ref}`Ibis <ibis>`, and
+{ref}`PySpark SQL <native-pyspark>` integrations behind a single unified code
+path. The Narwhals backend is **opt-in**: by default Pandera continues to use
+the native Polars, Ibis, and PySpark backends. The public API
+(`import pandera.polars as pa`, `import pandera.ibis as pa`,
+`import pandera.pyspark as pa`) is unchanged regardless of which backend is
+active.
+
+## Enabling the Narwhals backend
+
+To switch the Polars, Ibis, and PySpark SQL integrations onto the
+Narwhals-powered backend, install the `narwhals` extra and set the
+`PANDERA_USE_NARWHALS_BACKEND` environment variable to `True` before
+importing `pandera.polars`, `pandera.ibis`, or `pandera.pyspark`:
+
+```bash
+pip install 'pandera[narwhals]'
+export PANDERA_USE_NARWHALS_BACKEND=True
+```
+
+You can also enable it programmatically by setting
+{py:attr}`pandera.config.CONFIG.use_narwhals_backend` to `True` before any
+`pandera.polars` / `pandera.ibis` / `pandera.pyspark` schema is constructed:
+
+```python
+import pandera.config
+
+pandera.config.CONFIG.use_narwhals_backend = True
+
+import pandera.polars as pa  # narwhals backend now registered
+```
+
+The backend choice is locked in the first time a Polars or Ibis schema is
+created (the registration step is `lru_cache`-d). To switch backends in the
+same process, clear the cache and re-register:
+
+```python
+from pandera.backends.polars.register import register_polars_backends
+from pandera.backends.ibis.register import register_ibis_backends
+from pandera.backends.pyspark.register import register_pyspark_backends
+
+register_polars_backends.cache_clear()
+register_ibis_backends.cache_clear()
+register_pyspark_backends.cache_clear()
+```
+
+If `PANDERA_USE_NARWHALS_BACKEND=True` but `narwhals` is not installed,
+schema construction raises an `ImportError` directing you to install
+`pandera[narwhals]`.
+
+## What it is
+
+Narwhals is a lightweight compatibility layer that provides a subset of the
+Polars expression API on top of multiple underlying DataFrame libraries
+(Polars, pandas, PyArrow, Modin, cuDF, Dask, Ibis, DuckDB, PySpark, etc.).
+Pandera uses it to express validation logic &mdash; column selection, type
+coercion, check evaluation, failure-case collection &mdash; once, and have
+it executed natively by each supported engine.
+
+## What it changes for you
+
+* **Unified checks across Polars, Ibis, and PySpark SQL.** Built-in checks
+  (`isin`, `in_range`, `str_matches`, etc.) are implemented as Narwhals
+  expressions and run unchanged on Polars LazyFrames, Ibis tables, and
+  PySpark SQL DataFrames when the Narwhals backend is enabled. PySpark SQL
+  is a SQL-lazy backend: element-wise checks are not supported, and row
+  sampling (`sample=` / `tail=` parameters) is not supported.
+* **Lazy validation stays lazy.** For Polars LazyFrames, Ibis tables, and
+  PySpark SQL DataFrames, Pandera threads validation through the native lazy
+  API: no full-frame `.collect()` / `.execute()` is triggered during
+  validation. Only the bounded `failure_cases` frame is materialized, and
+  only on error.
+* **Custom checks become portable.** A check written against
+  `pandera.polars` typically works against `pandera.ibis` (and vice versa)
+  as long as it uses Narwhals expressions. The `native` parameter on `Check`
+  controls which frame type the check function receives: `native=True`
+  (the **default**) passes the native backend frame (e.g. `pl.DataFrame`,
+  `ibis.Table`) so the check is backend-specific; setting `native=False`
+  passes a Narwhals-wrapped frame so the check can run unchanged across all
+  supported backends using only the Narwhals expression API.
+
+(narwhals-pyspark-differences)=
+
+## PySpark SQL: differences from the native backend
+
+Because the Narwhals backend for PySpark shares its check implementations with
+the Polars and Ibis backends, several behaviours differ from the native PySpark
+backend:
+
+- **SQL-lazy execution.** No element-wise checks (no `map_batches` on SQL-lazy
+  frames), and no row sampling via `sample=` / `tail=` parameters.
+- **`coerce=True` is a no-op.** The Narwhals `ColumnBackend` has no coercion
+  step. Setting `coerce=True` on a `Field` or `Column` performs no coercion;
+  Pandera emits a ``SchemaWarning`` per column to make the subsequent
+  ``WRONG_DATATYPE`` error understandable rather than silent. Setting
+  ``coerce=True`` at the `Config` level (row-wise `auto_coerce` dtype) is
+  handled and does not warn.
+  If you rely on `coerce=True` to convert column dtypes, use the native PySpark
+  backend (`PANDERA_USE_NARWHALS_BACKEND=False`).
+- **Custom checks using `PysparkDataframeColumnObject` are incompatible.**
+  Custom checks registered via `@register_check_method` that expect a
+  `pyspark_obj: PysparkDataframeColumnObject` argument will not work under the
+  Narwhals backend. The Narwhals backend passes a `NarwhalsData(frame, key)`
+  named tuple to check functions instead, so the custom check signature and
+  body must be rewritten against the Narwhals frame API (or kept on the
+  native backend).
+- **`failure_cases` rows may be omitted for scalar Polars errors.** Schema-level
+  failure cases produced as scalar Polars frames (e.g. from a wrong-dtype check)
+  are still reported in the ``errors`` dict but their rows are omitted from the
+  aggregated ``failure_cases`` frame. See the
+  {ref}`Known gaps <narwhals-known-gaps>` section for details.
+- **Unified `SchemaErrors` contract.** Like the Polars and Ibis Narwhals
+  backends, the PySpark Narwhals backend raises `pandera.errors.SchemaErrors`
+  on validation failure (or `SchemaError` for the first error when
+  `lazy=False`). This differs from the native PySpark backend, which attaches
+  errors to `dataframe.pandera.errors`. If you depend on the
+  `dataframe.pandera.errors` accessor, use the native PySpark backend
+  (`PANDERA_USE_NARWHALS_BACKEND=False`).
+
+## Opting out
+
+The Narwhals backend is **off by default**, so no action is needed to
+continue using the native Polars and Ibis backends. If you previously
+opted in and want to switch back, unset the environment variable (or set
+it to `False`):
+
+```bash
+unset PANDERA_USE_NARWHALS_BACKEND
+# or
+export PANDERA_USE_NARWHALS_BACKEND=False
+```
+
+The native paths remain fully supported alongside the Narwhals path.
+
+(narwhals-known-gaps)=
+
+## Known gaps
+
+A small number of features are currently not wired through the Narwhals
+backend. Follow-up milestones track each of the gaps below:
+
+* Under the PySpark Narwhals backend, schema-level ``failure_cases`` produced as
+  scalar Polars frames (e.g. from a wrong-dtype error) are still reported in the
+  ``errors`` dict but their rows are omitted from the aggregated ``failure_cases``
+  frame. This is because scalar Polars frames cannot be converted to PySpark
+  without a live ``SparkSession`` at the error-collection site; this gap is
+  tracked for a future release.
+* Column-level `coerce=True` is currently a no-op for **all** Narwhals backends
+  (Polars, Ibis, PySpark SQL). Pandera emits a one-time ``SchemaWarning`` per
+  column so the subsequent ``WRONG_DATATYPE`` error is understandable rather than
+  silent. Full column-level coercion support is tracked as a follow-up.
+* `coerce` for the Ibis backend (deferred; `Ibis` coerces eagerly today)
+* `add_missing_columns` parser and `set_default` for `Column` fields
+* `group_by`-based checks beyond element-wise and column-wise expressions
+* Element-wise checks for SQL-lazy backends (Ibis and PySpark SQL). As a consequence,
+  the shared built-in check suite in ``tests/common/`` does not run for the PySpark
+  Narwhals backend (all shared checks are element-wise; running them would produce only
+  skips with no useful coverage signal).
+* Schema IO (YAML/JSON) for Narwhals-backed schemas
+* Hypothesis data-synthesis strategies
+* `sample=` / `tail=` row sampling for SQL-lazy backends (Ibis and PySpark SQL)
+* `check_unique` (column-level uniqueness) does not produce a per-row boolean
+  `check_output`, so `drop_invalid_rows=True` cannot filter rows that fail a
+  uniqueness constraint — those rows remain in the output. This gap is tracked
+  for a future release.
+
+See the {ref}`Supported DataFrame Libraries <supported-dataframe-libraries>`
+page for the user-facing integrations; the Narwhals layer is an
+implementation detail that keeps them consistent.

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -30,16 +30,18 @@ As of `pandera >= 0.21.0`, only `polars >= 1.0.0` is supported.
 
 :::{note}
 *new in 0.32.0*; Pandera ships an optional
-{ref}`Narwhals-powered backend <narwhals-backends>` that keeps validation
-fully lazy and unifies the implementation with the Ibis backend. It is
-**opt-in**: install the `narwhals` extra and set
-`PANDERA_USE_NARWHALS_BACKEND=True` (or `pandera.config.CONFIG.use_narwhals_backend = True`)
-before importing `pandera.polars`. By default Pandera uses the native
-Polars backend. The public API shown on this page is unchanged either way.
+{ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
+fully lazy. To opt into the Narwhals backend do the following:
 
 ```bash
+# install the narwhals extra
 pip install 'pandera[polars,narwhals]'
+
+# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
+
+# or set the config option in Python
+pandera.config.CONFIG.use_narwhals_backend = True
 ```
 :::
 

--- a/docs/source/pyspark_sql.md
+++ b/docs/source/pyspark_sql.md
@@ -27,53 +27,25 @@ pip install 'pandera[pyspark]'
 ```
 
 :::{note}
-Pandera ships an optional
-{ref}`Narwhals-powered backend <narwhals-backends>` that runs validation
-against the native PySpark SQL execution path and shares its check
-implementations with the Polars and Ibis backends. It is **opt-in**:
-install the `narwhals` extra and set
-`PANDERA_USE_NARWHALS_BACKEND=True` (or `pandera.config.CONFIG.use_narwhals_backend = True`)
-before importing `pandera.pyspark`. By default Pandera uses the native PySpark
-backend. The public API shown on this page is unchanged either way.
+*new in 0.32.0*; Pandera ships an optional
+{ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
+fully lazy. To opt into the Narwhals backend do the following:
+
+```bash
+# install the narwhals extra
+pip install 'pandera[pyspark,narwhals]'
+
+# set the environment variable
+export PANDERA_USE_NARWHALS_BACKEND=True
+
+# or set the config option in Python
+pandera.config.CONFIG.use_narwhals_backend = True
+```
 
 Because the Narwhals backend for PySpark shares its check implementations with
 the Polars and Ibis backends, several behaviours differ from the native PySpark
-backend:
-
-- **SQL-lazy execution.** No element-wise checks (no `map_batches` on SQL-lazy
-  frames), and no row sampling via `sample=` / `tail=` parameters.
-- **`coerce=True` is a no-op.** The Narwhals `ColumnBackend` has no coercion
-  step. Setting `coerce=True` on a `Field` or `Column` performs no coercion;
-  Pandera emits a ``SchemaWarning`` per column to make the subsequent
-  ``WRONG_DATATYPE`` error understandable rather than silent. Setting
-  ``coerce=True`` at the `Config` level (row-wise `auto_coerce` dtype) is
-  handled and does not warn.
-  If you rely on `coerce=True` to convert column dtypes, use the native PySpark
-  backend (`PANDERA_USE_NARWHALS_BACKEND=False`).
-- **Custom checks using `PysparkDataframeColumnObject` are incompatible.**
-  Custom checks registered via `@register_check_method` that expect a
-  `pyspark_obj: PysparkDataframeColumnObject` argument will not work under the
-  Narwhals backend. The Narwhals backend passes a `NarwhalsData(frame, key)`
-  named tuple to check functions instead, so the custom check signature and
-  body must be rewritten against the Narwhals frame API (or kept on the
-  native backend).
-- **`failure_cases` rows may be omitted for scalar Polars errors.** Schema-level
-  failure cases produced as scalar Polars frames (e.g. from a wrong-dtype check)
-  are still reported in the ``errors`` dict but their rows are omitted from the
-  aggregated ``failure_cases`` frame. See the
-  {ref}`Narwhals Known gaps <narwhals-backends>` section for details.
-- **Unified `SchemaErrors` contract.** Like the Polars and Ibis Narwhals
-  backends, the PySpark Narwhals backend raises `pandera.errors.SchemaErrors`
-  on validation failure (or `SchemaError` for the first error when
-  `lazy=False`). This differs from the native PySpark backend, which attaches
-  errors to `dataframe.pandera.errors`. If you depend on the
-  `dataframe.pandera.errors` accessor, use the native PySpark backend
-  (`PANDERA_USE_NARWHALS_BACKEND=False`).
-
-```bash
-pip install 'pandera[pyspark,narwhals]'
-export PANDERA_USE_NARWHALS_BACKEND=True
-```
+backend: see the {ref}`Narwhals backend page <narwhals-pyspark-differences>`
+for details.
 :::
 
 ## What's different?

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -28,6 +28,8 @@
      - Utility functions for reading/writing schemas
    * - :ref:`Data Synthesis Strategies <api-strategies>`
      - Module of functions for generating data from schemas.
+   * - :ref:`Narwhals Backend <api-narwhals>`
+     - Opt-in Narwhals-powered backend unifying the Polars, Ibis, and PySpark SQL validation paths.
    * - :ref:`Extensions <api-extensions>`
      - Utility functions for extending pandera functionality
    * - :ref:`Errors <api-errors>`
@@ -79,6 +81,7 @@ decorators
 schema_inference
 io
 strategies
+narwhals
 extensions
 errors
 xarray

--- a/docs/source/reference/narwhals.rst
+++ b/docs/source/reference/narwhals.rst
@@ -1,0 +1,103 @@
+.. _api-narwhals:
+
+Narwhals Backend
+================
+
+*new in 0.32.0*
+
+Opt-in `Narwhals <https://narwhals-dev.github.io/narwhals/>`__-powered
+validation backend that powers the Polars, Ibis, and PySpark SQL
+integrations behind a single unified code path. Requires the ``narwhals``
+extra. See :ref:`Narwhals-powered backends <narwhals-backend>` for the
+user-facing guide.
+
+Data Objects
+------------
+
+Objects passed to custom check functions when the Narwhals backend is
+active.
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.api.narwhals.types.NarwhalsData
+   pandera.api.narwhals.types.NarwhalsCheckResult
+
+Backends
+--------
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.backends.narwhals.base.NarwhalsSchemaBackend
+   pandera.backends.narwhals.container.DataFrameSchemaBackend
+   pandera.backends.narwhals.components.ColumnBackend
+   pandera.backends.narwhals.checks.NarwhalsCheckBackend
+
+Narwhals Dtypes
+---------------
+
+.. autosummary::
+   :toctree: generated
+   :template: dtype.rst
+   :nosignatures:
+
+   pandera.engines.narwhals_engine.DataType
+   pandera.engines.narwhals_engine.Int8
+   pandera.engines.narwhals_engine.Int16
+   pandera.engines.narwhals_engine.Int32
+   pandera.engines.narwhals_engine.Int64
+   pandera.engines.narwhals_engine.UInt8
+   pandera.engines.narwhals_engine.UInt16
+   pandera.engines.narwhals_engine.UInt32
+   pandera.engines.narwhals_engine.UInt64
+   pandera.engines.narwhals_engine.Float32
+   pandera.engines.narwhals_engine.Float64
+   pandera.engines.narwhals_engine.String
+   pandera.engines.narwhals_engine.Bool
+   pandera.engines.narwhals_engine.Date
+   pandera.engines.narwhals_engine.DateTime
+   pandera.engines.narwhals_engine.Duration
+   pandera.engines.narwhals_engine.Categorical
+   pandera.engines.narwhals_engine.List
+   pandera.engines.narwhals_engine.Struct
+
+Engine
+------
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.engines.narwhals_engine.Engine
+
+Built-in Check Expressions
+--------------------------
+
+Narwhals expression implementations of the built-in checks, shared by the
+Polars, Ibis, and PySpark SQL integrations when the Narwhals backend is
+enabled.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   pandera.backends.narwhals.builtin_checks.equal_to
+   pandera.backends.narwhals.builtin_checks.not_equal_to
+   pandera.backends.narwhals.builtin_checks.greater_than
+   pandera.backends.narwhals.builtin_checks.greater_than_or_equal_to
+   pandera.backends.narwhals.builtin_checks.less_than
+   pandera.backends.narwhals.builtin_checks.less_than_or_equal_to
+   pandera.backends.narwhals.builtin_checks.in_range
+   pandera.backends.narwhals.builtin_checks.isin
+   pandera.backends.narwhals.builtin_checks.notin
+   pandera.backends.narwhals.builtin_checks.str_matches
+   pandera.backends.narwhals.builtin_checks.str_contains
+   pandera.backends.narwhals.builtin_checks.str_startswith
+   pandera.backends.narwhals.builtin_checks.str_endswith
+   pandera.backends.narwhals.builtin_checks.str_length

--- a/docs/source/supported_libraries.md
+++ b/docs/source/supported_libraries.md
@@ -27,19 +27,6 @@ Pandera supports validation of the following DataFrame libraries:
   - A data processing library for large-scale data.
 :::
 
-:::{note}
-*new in 0.32.0* &mdash; Pandera ships an optional
-[Narwhals](https://narwhals-dev.github.io/narwhals/)-powered backend that
-unifies the Polars, Ibis, and PySpark SQL validation paths behind a single implementation.
-It is **opt-in**: set the `PANDERA_USE_NARWHALS_BACKEND=True` environment
-variable (or `pandera.config.CONFIG.use_narwhals_backend = True`) and install
-the `narwhals` extra. The user-facing API
-(`import pandera.polars as pa` / `import pandera.ibis as pa`) is unchanged
-regardless of which backend is active. See the
-{ref}`Narwhals-powered backends <narwhals-backends>` section below for
-details.
-:::
-
 ```{toctree}
 :hidden: true
 :maxdepth: 1
@@ -99,6 +86,29 @@ container types specific to these libraries.
 GeoPandas <geopandas>
 ```
 
+## Interoperable Dataframe Backends
+
+*new in 0.32.0*
+
+Pandera provides opt-in support for Narwhals-powered interoperable dataframe backends.
+This allows Pandera to use a single backend to power the validation of different
+dataframe libraries for the library-specific schema definitions, where checks
+are expressed in the native library's API.
+
+:::{list-table}
+:widths: 25 75
+
+* - {ref}`Narwhals <narwhals-backend>`
+  - Use a unified backend to power the validation of different dataframe libraries.
+:::
+
+```{toctree}
+:hidden: true
+:maxdepth: 1
+
+Narwhals-powered backend <narwhals_backend>
+```
+
 ## Alternative Acceleration Frameworks
 
 Pandera works with other dataframe-agnostic libraries that allow for distributed
@@ -117,142 +127,6 @@ dataframe validation:
 
 Fugue <fugue>
 ```
-
-(narwhals-backends)=
-
-## Narwhals-powered backends
-
-As of *0.32.0*, Pandera ships an optional
-[Narwhals](https://narwhals-dev.github.io/narwhals/)-based validation
-backend that powers the {ref}`Polars <polars>`, {ref}`Ibis <ibis>`, and
-{ref}`PySpark SQL <native-pyspark>` integrations behind a single unified code
-path. The Narwhals backend is **opt-in**: by default Pandera continues to use
-the native Polars, Ibis, and PySpark backends. The public API
-(`import pandera.polars as pa`, `import pandera.ibis as pa`,
-`import pandera.pyspark as pa`) is unchanged regardless of which backend is
-active.
-
-### Enabling the Narwhals backend
-
-To switch the Polars, Ibis, and PySpark SQL integrations onto the
-Narwhals-powered backend, install the `narwhals` extra and set the
-`PANDERA_USE_NARWHALS_BACKEND` environment variable to `True` before
-importing `pandera.polars`, `pandera.ibis`, or `pandera.pyspark`:
-
-```bash
-pip install 'pandera[narwhals]'
-export PANDERA_USE_NARWHALS_BACKEND=True
-```
-
-You can also enable it programmatically by setting
-{py:attr}`pandera.config.CONFIG.use_narwhals_backend` to `True` before any
-`pandera.polars` / `pandera.ibis` / `pandera.pyspark` schema is constructed:
-
-```python
-import pandera.config
-
-pandera.config.CONFIG.use_narwhals_backend = True
-
-import pandera.polars as pa  # narwhals backend now registered
-```
-
-The backend choice is locked in the first time a Polars or Ibis schema is
-created (the registration step is `lru_cache`-d). To switch backends in the
-same process, clear the cache and re-register:
-
-```python
-from pandera.backends.polars.register import register_polars_backends
-from pandera.backends.ibis.register import register_ibis_backends
-from pandera.backends.pyspark.register import register_pyspark_backends
-
-register_polars_backends.cache_clear()
-register_ibis_backends.cache_clear()
-register_pyspark_backends.cache_clear()
-```
-
-If `PANDERA_USE_NARWHALS_BACKEND=True` but `narwhals` is not installed,
-schema construction raises an `ImportError` directing you to install
-`pandera[narwhals]`.
-
-### What it is
-
-Narwhals is a lightweight compatibility layer that provides a subset of the
-Polars expression API on top of multiple underlying DataFrame libraries
-(Polars, pandas, PyArrow, Modin, cuDF, Dask, Ibis, DuckDB, PySpark, etc.).
-Pandera uses it to express validation logic &mdash; column selection, type
-coercion, check evaluation, failure-case collection &mdash; once, and have
-it executed natively by each supported engine.
-
-### What it changes for you
-
-* **Unified checks across Polars, Ibis, and PySpark SQL.** Built-in checks
-  (`isin`, `in_range`, `str_matches`, etc.) are implemented as Narwhals
-  expressions and run unchanged on Polars LazyFrames, Ibis tables, and
-  PySpark SQL DataFrames when the Narwhals backend is enabled. PySpark SQL
-  is a SQL-lazy backend: element-wise checks are not supported, and row
-  sampling (`sample=` / `tail=` parameters) is not supported.
-* **Lazy validation stays lazy.** For Polars LazyFrames, Ibis tables, and
-  PySpark SQL DataFrames, Pandera threads validation through the native lazy
-  API: no full-frame `.collect()` / `.execute()` is triggered during
-  validation. Only the bounded `failure_cases` frame is materialized, and
-  only on error.
-* **Custom checks become portable.** A check written against
-  `pandera.polars` typically works against `pandera.ibis` (and vice versa)
-  as long as it uses Narwhals expressions. The `native` parameter on `Check`
-  controls which frame type the check function receives: `native=True`
-  (the **default**) passes the native backend frame (e.g. `pl.DataFrame`,
-  `ibis.Table`) so the check is backend-specific; setting `native=False`
-  passes a Narwhals-wrapped frame so the check can run unchanged across all
-  supported backends using only the Narwhals expression API.
-
-### Opting out
-
-The Narwhals backend is **off by default**, so no action is needed to
-continue using the native Polars and Ibis backends. If you previously
-opted in and want to switch back, unset the environment variable (or set
-it to `False`):
-
-```bash
-unset PANDERA_USE_NARWHALS_BACKEND
-# or
-export PANDERA_USE_NARWHALS_BACKEND=False
-```
-
-The native paths remain fully supported alongside the Narwhals path.
-
-### Known gaps
-
-A small number of features are currently not wired through the Narwhals
-backend. Follow-up milestones track each of the gaps below:
-
-* Under the PySpark Narwhals backend, schema-level ``failure_cases`` produced as
-  scalar Polars frames (e.g. from a wrong-dtype error) are still reported in the
-  ``errors`` dict but their rows are omitted from the aggregated ``failure_cases``
-  frame. This is because scalar Polars frames cannot be converted to PySpark
-  without a live ``SparkSession`` at the error-collection site; this gap is
-  tracked for a future release.
-* Column-level `coerce=True` is currently a no-op for **all** Narwhals backends
-  (Polars, Ibis, PySpark SQL). Pandera emits a one-time ``SchemaWarning`` per
-  column so the subsequent ``WRONG_DATATYPE`` error is understandable rather than
-  silent. Full column-level coercion support is tracked as a follow-up.
-* `coerce` for the Ibis backend (deferred; `Ibis` coerces eagerly today)
-* `add_missing_columns` parser and `set_default` for `Column` fields
-* `group_by`-based checks beyond element-wise and column-wise expressions
-* Element-wise checks for SQL-lazy backends (Ibis and PySpark SQL). As a consequence,
-  the shared built-in check suite in ``tests/common/`` does not run for the PySpark
-  Narwhals backend (all shared checks are element-wise; running them would produce only
-  skips with no useful coverage signal).
-* Schema IO (YAML/JSON) for Narwhals-backed schemas
-* Hypothesis data-synthesis strategies
-* `sample=` / `tail=` row sampling for SQL-lazy backends (Ibis and PySpark SQL)
-* `check_unique` (column-level uniqueness) does not produce a per-row boolean
-  `check_output`, so `drop_invalid_rows=True` cannot filter rows that fail a
-  uniqueness constraint — those rows remain in the output. This gap is tracked
-  for a future release.
-
-See the {ref}`Supported DataFrame Libraries <supported-dataframe-libraries>`
-section above for the user-facing integrations; the Narwhals layer is an
-implementation detail that keeps them consistent.
 
 :::{note}
 Don't see a library that you want supported? Check out the

--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -511,7 +511,7 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
 
         :param cols_to_remove: Columns to be removed from the
             ``DataFrameSchema``
-        :type cols_to_remove: List
+        :type cols_to_remove: list[str]
         :returns: a new :class:`~pandera.api.dataframe.container.DataFrameSchema` without the cols_to_remove
         :raises: :class:`~pandera.errors.SchemaInitError`: if column not in
             schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ all = [
     "polars >= 0.20.0",
     "xarray >= 2024.10.0",
     "numpy >= 1.24.4",
+    "narwhals >= 1.26.0",
 ]
 
 [dependency-groups]

--- a/tests/narwhals/backends/conftest.py
+++ b/tests/narwhals/backends/conftest.py
@@ -66,7 +66,12 @@ class IbisBackend(BackendFixture):
         import ibis
 
         # Infer schema from Python types so ibis doesn't widen int+None to float64.
-        ibis_type = {int: "int64", bool: "boolean", str: "string", float: "float64"}
+        ibis_type = {
+            int: "int64",
+            bool: "boolean",
+            str: "string",
+            float: "float64",
+        }
         fields = [
             (k, ibis_type[type(next(x for x in v if x is not None))])
             for k, v in data.items()

--- a/tests/polars/test_polars_coerce_warning.py
+++ b/tests/polars/test_polars_coerce_warning.py
@@ -27,7 +27,9 @@ def test_coerce_true_dtype_mismatch_emits_schema_warning():
     schema = pa.DataFrameSchema({"a": pa.Column(int, coerce=True)})
     df = pl.DataFrame({"a": ["1", "2", "3"]})
 
-    with pytest.warns(SchemaWarning, match="coerce=True is not applied") as warning_info:
+    with pytest.warns(
+        SchemaWarning, match="coerce=True is not applied"
+    ) as warning_info:
         with pytest.raises((SchemaErrors, Exception)):
             schema.validate(df)
     assert len(warning_info) == 1

--- a/tests/pyspark/test_pyspark_dtypes.py
+++ b/tests/pyspark/test_pyspark_dtypes.py
@@ -14,7 +14,9 @@ from pandera.pyspark import Column, DataFrameSchema
 from pandera.validation_depth import ValidationScope, validate_scope
 from tests.pyspark.conftest import spark_df, validate_collecting_errors
 
-pytestmark = pytest.mark.parametrize("spark_session", ["spark", "spark_connect"])
+pytestmark = pytest.mark.parametrize(
+    "spark_session", ["spark", "spark_connect"]
+)
 
 SKIP_NARWHALS = pytest.mark.skipif(
     CONFIG.use_narwhals_backend,
@@ -481,21 +483,15 @@ def test_pyspark_exact_width_dtype_narwhals(spark_session, request):
     float_df = spark_df(spark, data, float_spark_schema)
 
     # IntegerType column vs IntegerType schema: PASS
-    schema_int = DataFrameSchema(
-        columns={"value": Column(T.IntegerType())}
-    )
+    schema_int = DataFrameSchema(columns={"value": Column(T.IntegerType())})
     schema_int.validate(int_df, lazy=True)
 
     # FloatType column vs FloatType schema: PASS
-    schema_float = DataFrameSchema(
-        columns={"value": Column(T.FloatType())}
-    )
+    schema_float = DataFrameSchema(columns={"value": Column(T.FloatType())})
     schema_float.validate(float_df, lazy=True)
 
     # IntegerType column vs LongType schema: FAIL (WRONG_DATATYPE)
-    schema_long = DataFrameSchema(
-        columns={"value": Column(T.LongType())}
-    )
+    schema_long = DataFrameSchema(columns={"value": Column(T.LongType())})
     with pytest.raises(SchemaErrors) as exc_info:
         schema_long.validate(int_df, lazy=True)
     schema_errors = exc_info.value.schema_errors
@@ -505,9 +501,7 @@ def test_pyspark_exact_width_dtype_narwhals(spark_session, request):
     )
 
     # FloatType column vs DoubleType schema: FAIL (WRONG_DATATYPE)
-    schema_double = DataFrameSchema(
-        columns={"value": Column(T.DoubleType())}
-    )
+    schema_double = DataFrameSchema(columns={"value": Column(T.DoubleType())})
     with pytest.raises(SchemaErrors) as exc_info:
         schema_double.validate(float_df, lazy=True)
     schema_errors = exc_info.value.schema_errors


### PR DESCRIPTION
This pull request updates the documentation to introduce and describe the new Narwhals-powered backend in Pandera 0.32.0. It restructures and clarifies the documentation around backend selection, opt-in workflow, and feature differences, while improving guidance for users on how to enable and use the Narwhals backend for Polars, Ibis, and PySpark SQL integrations.

The most important changes are:

**Narwhals Backend Introduction and Documentation:**
* Added a new dedicated documentation page `narwhals_backend.md` that explains what the Narwhals backend is, how to enable it, its benefits, differences (especially for PySpark), how to opt out, and known limitations.
* Updated the main documentation announcement and summary sections to highlight the Narwhals backend as a key new feature in version 0.32.0.

**How-to and Reference Updates:**
* Updated the configuration, Polars, Ibis, and PySpark SQL documentation to point to the new Narwhals backend page, streamline instructions for opting in, and clarify the installation and activation steps.
* Moved backend-specific behavioral differences (especially for PySpark) to the new Narwhals backend documentation and referenced them from the respective integration pages.

**Documentation Structure and Navigation:**
* Reorganized the "Supported Libraries" and "Alternative Acceleration Frameworks" sections to clearly distinguish Narwhals as an interoperable backend and to link to the new documentation. Removed redundant or outdated explanations.
These changes ensure that users can easily discover, understand, and enable the Narwhals backend, and are aware of its current capabilities and limitations.