### PR TITLE
Harden CI dependency installation

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,17 +51,30 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dependencies
         run: |
-          python -m pip install uv nox prek \
-            mypy==0.982 \
-            types-click \
-            types-pytz \
-            types-pyyaml \
-            types-requests \
-            types-setuptools \
-            setuptools \
-            polars==${{ matrix.polars-version }}
+          for attempt in 1 2 3; do
+            python -m pip install uv nox prek \
+              mypy==0.982 \
+              types-click \
+              types-pytz \
+              types-pyyaml \
+              types-requests \
+              types-setuptools \
+              setuptools \
+              polars==${{ matrix.polars-version }} && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - name: Install pandera
         run: python -m pip install -e .
       - name: Pip info
@@ -124,9 +137,25 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dev deps
         shell: bash
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - run: |
           pip list
           printenv | sort
@@ -170,9 +199,25 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dev deps
         shell: bash
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - run: |
           pip list
           printenv | sort
@@ -221,9 +266,25 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dev deps
         shell: bash
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - run: |
           pip list
           printenv | sort
@@ -306,9 +367,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+
       - name: Install dev deps
         shell: bash
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
 
       - run: |
           pip list
@@ -362,8 +440,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dev deps
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - run: |
           pip list
           printenv | sort
@@ -397,9 +491,25 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/AppData/Local/uv/cache
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dev deps
         shell: bash
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - run: |
           pip list
           printenv | sort
@@ -441,8 +551,22 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'noxfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
       - name: Install dependencies
-        run: pip install 'uv<0.7.0' nox
+        run: |
+          for attempt in 1 2 3; do
+            pip install 'uv<0.7.0' nox && break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
       - name: Pip info
         run: python -m pip list
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -403,6 +403,7 @@ def docs(session: Session) -> None:
 
     _install(session, "-e", ".")
     _install(
+        session,
         *_testing_requirements(
             session, extra="all", pandas=PANDAS_VERSIONS[0]
         ),

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,6 +50,19 @@ PYPROJECT = nox.project.load_toml("pyproject.toml")
 OPTIONAL_DEPENDENCIES = [*PYPROJECT["project"]["optional-dependencies"]]
 
 
+def _install(session: Session, *args: str) -> None:
+    """Install packages, retrying transient installer failures on CI."""
+    attempts = 3 if CI_RUN else 1
+    for attempt in range(1, attempts + 1):
+        try:
+            session.install(*args)
+            return
+        except nox.command.CommandFailed:
+            if attempt == attempts:
+                raise
+            session.log(f"Install failed, retrying ({attempt + 1}/{attempts})")
+
+
 def _pyproject_requirements() -> dict[str, list[str]]:
     """Load requirements from setup.py."""
     return {
@@ -81,7 +94,7 @@ def _generate_pip_deps_from_conda(
 @nox.session(venv_backend="uv", python=PYTHON_VERSIONS)
 def requirements(session: Session) -> None:
     """Check that setup.py requirements match requirements.in"""
-    session.install("pyyaml")
+    _install(session, "pyyaml")
     try:
         _generate_pip_deps_from_conda(session, compare=True)
     except nox.command.CommandFailed as err:
@@ -260,8 +273,8 @@ def tests(
     requirements = _testing_requirements(
         session, extra, pandas, pydantic, polars
     )
-    session.install(*requirements)
-    session.install("-e", ".", "--config-settings", "editable_mode=compat")
+    _install(session, *requirements)
+    _install(session, "-e", ".", "--config-settings", "editable_mode=compat")
     session.run("uv", "pip", "list")
 
     env = {}
@@ -362,8 +375,8 @@ def tests_narwhals_backend(session: Session, extra: str) -> None:
                 f"{r}, < 2" if r.startswith("numpy") else r
                 for r in requirements
             ]
-    session.install(*list(set(requirements)))
-    session.install("-e", ".", "--config-settings", "editable_mode=compat")
+    _install(session, *list(set(requirements)))
+    _install(session, "-e", ".", "--config-settings", "editable_mode=compat")
     session.run("uv", "pip", "list")
 
     path = f"tests/{extra}/"
@@ -388,8 +401,8 @@ def docs(session: Session) -> None:
     """Build the documentation."""
     # this is needed until ray and geopandas are supported on python 3.10
 
-    session.install("-e", ".")
-    session.install(
+    _install(session, "-e", ".")
+    _install(
         *_testing_requirements(
             session, extra="all", pandas=PANDAS_VERSIONS[0]
         ),


### PR DESCRIPTION
## Description:

Issue #2367 reported that large CI matrix jobs can fail before tests run when dependency downloads from PyPI or files.pythonhosted.org are interrupted.

This PR adds uv cache coverage to CI jobs that run nox, and retries dependency installation in CI through a small nox install helper.

The retry is limited to dependency installation. Pytest commands are not retried, so real test failures remain visible.

Closes #2367.

## Checklist:

- [x] I have kept the change limited to CI dependency setup.
- [x] I have run linting and formatting checks in WSL using `prek run --files .github/workflows/ci-tests.yml noxfile.py`.
- [x] I have run focused validation in WSL for YAML parsing and the nox install retry helper.