### PR TITLE
Use Codecov carryforward flags for CI coverage uploads

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -135,6 +135,8 @@ jobs:
           nox -v -db uv --non-interactive --session 'tests-${{ matrix.python-version }}(extra=None, pandas=None, pydantic=None, polars=None)'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-base-${{ runner.os }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
@@ -180,6 +182,8 @@ jobs:
         run: nox -v -db uv --non-interactive --session "tests-${{ matrix.python-version }}(extra='pandas', pandas='${{ matrix.pandas-version }}', pydantic='${{ matrix.pydantic-version }}', polars=None)"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-pandas-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-pydantic${{ matrix.pydantic-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
@@ -231,6 +235,8 @@ jobs:
         run: nox -v -db uv --non-interactive --session "tests-${{ matrix.python-version }}(extra='${{ matrix.extra }}', pandas='${{ matrix.pandas-version }}', pydantic='${{ matrix.pydantic-version }}', polars=None)"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-${{ matrix.extra }}-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-pydantic${{ matrix.pydantic-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
@@ -324,6 +330,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-${{ matrix.extra }}-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-polars${{ matrix.polars-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
@@ -371,6 +379,8 @@ jobs:
         run: nox -v -db uv --non-interactive --session "tests_narwhals_backend-${{ matrix.python-version }}(extra='${{ matrix.extra }}')"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-narwhals-backend-${{ matrix.extra }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 
@@ -407,6 +417,8 @@ jobs:
         run: nox -v -db uv --non-interactive --session "tests-${{ matrix.python-version }}(extra='narwhals', pandas=None, pydantic=None, polars=None)"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          flags: unit-tests-narwhals-${{ runner.os }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Description:

Issue #2368 reported that `codecov/project` can show misleading coverage drops when CI jobs fail before running tests and before uploading coverage.

This PR adds Codecov carryforward flag configuration and tags CI coverage uploads with matrix-specific flags.

This lets Codecov carry forward missing flagged reports from previous runs instead of treating setup-failed jobs as meaningful coverage loss.

Closes #2368.

## Checklist:

- [x] I have kept patch coverage behavior intact.
- [x] I have validated `codecov.yml` with Codecov's validator.
- [x] I have run linting and formatting checks in WSL using `prek run --files .github/workflows/ci-tests.yml codecov.yml`.