### PR TITLE
fix: reload built-in check dispatcher by its own name so a custom name= works (#2042)

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -247,11 +247,15 @@ class Check(BaseCheck):
 
             ``failure_cases``: subset of the check_object that failed.
         """
-        if self.name is not None and self.is_builtin_check(self.name):
-            # we need to reload the function here in case additional
-            # type signatures have been registered for a specific built-in
-            # check.
-            self._check_fn = self.get_builtin_check_fn(self.name)
+        # Reload the function here in case additional type signatures have been registered
+        # for a specific built-in check. Use the check function's own name (the dispatcher
+        # name) rather than ``self.name``, since the latter may have been overridden by a
+        # user-supplied ``name=`` and would otherwise skip this reload (see #2042).
+        builtin_check_name = getattr(self._check_fn, "__name__", None)
+        if builtin_check_name is not None and self.is_builtin_check(
+            builtin_check_name
+        ):
+            self._check_fn = self.get_builtin_check_fn(builtin_check_name)
         backend = self.get_backend(check_obj)(self)
         return backend(check_obj, column)
 

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -207,3 +207,43 @@ class TestBuiltinCheckSignatures:
 
         result = str_length(nw.col("x"), min_value=1, max_value=10)
         assert isinstance(result, nw.Expr)
+
+
+class TestBuiltinCheckCustomName:
+    """Regression tests for #2042: a built-in check given a custom ``name`` must still execute."""
+
+    def test_builtin_check_with_custom_name_validates(self):
+        import pandas as pd
+
+        import pandera.pandas as pa
+
+        schema = pa.DataFrameSchema(
+            columns={
+                "test": pa.Column(
+                    float, checks=[pa.Check.gt(0, name="test_check")]
+                ),
+            }
+        )
+
+        # Previously raised SchemaError wrapping KeyError(<class 'pandas.Series'>)
+        validated = schema.validate(pd.DataFrame({"test": [1.0, 2.0]}))
+        assert validated.shape == (2, 1)
+
+    def test_builtin_check_with_custom_name_still_detects_failures(self):
+        import pandas as pd
+
+        import pandera.pandas as pa
+
+        schema = pa.DataFrameSchema(
+            columns={
+                "test": pa.Column(
+                    float, checks=[pa.Check.gt(0, name="test_check")]
+                ),
+            }
+        )
+
+        with pytest.raises(pa.errors.SchemaError) as exc_info:
+            schema.validate(pd.DataFrame({"test": [-1.0]}))
+
+        # The failure must be a real check failure, not a KeyError from check dispatch
+        assert "KeyError" not in str(exc_info.value)


### PR DESCRIPTION
#### Resolves #2042

**Bug**: a built-in check given a custom `name` raised a `SchemaError` wrapping `KeyError("<class 'pandas.Series'>")` during validation:

```python
import pandera.pandas as pa
import pandas as pd

schema = pa.DataFrameSchema(
    columns={"test": pa.Column(float, checks=[pa.Check.gt(0, name="test_check")])}
)
schema.validate(pd.DataFrame({"test": [1.0]}))  # KeyError, but works without name=
```

**Root cause**: `Check.__call__` reloads the check function from the built-in registry so it picks up type signatures that a backend registers lazily (the pandas backend registers `greater_than(data: Union[pd.Series, pd.DataFrame], ...)`). That reload was gated on `self.is_builtin_check(self.name)`. Passing `name="test_check"` overrides `self.name`, so `is_builtin_check` returned `False`, the reload was skipped, and the dispatcher kept only its generic `Any` entry. The dispatcher does an exact-type lookup (`registry[type(data)]`), so a `pd.Series` then raised `KeyError`.

**Fix**: drive the reload off the check function's own name (the dispatcher `__name__`), which is the built-in name regardless of any custom display name. Custom (non-built-in) check functions still skip the reload because their `__name__` is not a registered built-in.

**Tests**: added `TestBuiltinCheckCustomName` in `tests/core/test_checks.py` validating that a renamed built-in check both validates passing data and still detects failures. The passing-data test fails on `main` (KeyError) and passes with this change.

---
*Disclosure: prepared with AI assistance; I reviewed it and can explain every line.*