### PR TITLE
feat: allow `rename_columns` to work as long as final columns are unique

### DIFF
--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -784,13 +784,18 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         # remove any mapping to itself as this is a no-op
         rename_dict = {k: v for k, v in rename_dict.items() if k != v}
 
-        # ensure all new keys are not present in the current column names
-        already_in_columns: list[str] = [
-            x for x in rename_dict.values() if x in new_schema.columns.keys()
-        ]
-        if already_in_columns:
+        # ensure column names are unique after renaming
+        seen_cols: set[str] = set()
+        duplicate_cols: set[str] = set()
+        for x in new_schema.columns.keys():
+            name = rename_dict.get(x, x)
+            if name in seen_cols:
+                duplicate_cols.add(name)
+            seen_cols.add(name)
+
+        if duplicate_cols:
             raise errors.SchemaInitError(
-                f"Keys {already_in_columns} already found in schema columns!"
+                f"Columns {sorted(duplicate_cols)} would be duplicated after renaming!"
             )
 
         # We iterate over the existing columns dict and replace those keys

--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -788,10 +788,10 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         seen_cols: set[str] = set()
         duplicate_cols: set[str] = set()
         for x in new_schema.columns.keys():
-            name = rename_dict.get(x, x)
-            if name in seen_cols:
-                duplicate_cols.add(name)
-            seen_cols.add(name)
+            new_col = rename_dict.get(x, x)
+            if new_col in seen_cols:
+                duplicate_cols.add(new_col)
+            seen_cols.add(new_col)
 
         if duplicate_cols:
             raise errors.SchemaInitError(

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -1370,10 +1370,17 @@ def test_rename_columns() -> None:
     with pytest.raises(errors.SchemaInitError):
         schema_original.rename_columns({"foo": "bar"})
 
-    # Test raising error if new column name is already in schema
+    # Test raising error if two columns are renamed to the same name
+    with pytest.raises(errors.SchemaInitError):
+        schema_original.rename_columns({"col1": "col_duplicate", "col2": "col_duplicate"})
     for rename_dict in [{"col1": "col2"}, {"col2": "col1"}]:
         with pytest.raises(errors.SchemaInitError):
             schema_original.rename_columns(rename_dict)
+    
+    # Test doesn't raise error if column maps to unique column name
+    schema_circular_renamed = schema_original.rename_columns({"col1": "col2","col2": "col1"})
+    assert schema_circular_renamed.columns["col2"].dtype == schema_original.columns["col1"].dtype
+    assert schema_circular_renamed.columns["col1"].dtype == schema_original.columns["col2"].dtype
 
     # Test doesn't raise error if column maps to itself
     rename_dict = {"col1": "col1", "col2": "col2_new_name"}

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -1372,15 +1372,25 @@ def test_rename_columns() -> None:
 
     # Test raising error if two columns are renamed to the same name
     with pytest.raises(errors.SchemaInitError):
-        schema_original.rename_columns({"col1": "col_duplicate", "col2": "col_duplicate"})
+        schema_original.rename_columns(
+            {"col1": "col_duplicate", "col2": "col_duplicate"}
+        )
     for rename_dict in [{"col1": "col2"}, {"col2": "col1"}]:
         with pytest.raises(errors.SchemaInitError):
             schema_original.rename_columns(rename_dict)
-    
+
     # Test doesn't raise error if column maps to unique column name
-    schema_circular_renamed = schema_original.rename_columns({"col1": "col2","col2": "col1"})
-    assert schema_circular_renamed.columns["col2"].dtype == schema_original.columns["col1"].dtype
-    assert schema_circular_renamed.columns["col1"].dtype == schema_original.columns["col2"].dtype
+    schema_circular_renamed = schema_original.rename_columns(
+        {"col1": "col2", "col2": "col1"}
+    )
+    assert (
+        schema_circular_renamed.columns["col2"].dtype
+        == schema_original.columns["col1"].dtype
+    )
+    assert (
+        schema_circular_renamed.columns["col1"].dtype
+        == schema_original.columns["col2"].dtype
+    )
 
     # Test doesn't raise error if column maps to itself
     rename_dict = {"col1": "col1", "col2": "col2_new_name"}


### PR DESCRIPTION
Closes #2372 

Works as intended:
<img width="917" height="484" alt="圖片" src="https://github.com/user-attachments/assets/f89c92d3-8f43-43a6-b832-3360ad88f80b" />
<img width="1021" height="491" alt="圖片" src="https://github.com/user-attachments/assets/6a8d9836-0380-4cdf-9f52-3376ec0ad33d" />
