### PR TITLE
fix(polars): don't error on optional regex column with no match

### DIFF
--- a/pandera/backends/narwhals/components.py
+++ b/pandera/backends/narwhals/components.py
@@ -79,18 +79,24 @@ class ColumnBackend(NarwhalsSchemaBackend):
                 self.get_regex_columns(schema, check_lf)
             )
             if not column_keys_to_check:
-                raise SchemaError(
-                    schema=schema,
-                    data=_to_native(check_lf),
-                    message=(
-                        f"Column regex name='{schema.selector}' did not match "
-                        "any columns in the dataframe. Update the regex "
-                        "pattern so that it matches at least one column."
-                    ),
-                    failure_cases=check_lf.collect_schema().names(),
-                    check=f"no_regex_column_match('{schema.selector}')",
-                    reason_code=SchemaErrorReason.INVALID_COLUMN_NAME,
-                )
+                if schema.required:
+                    raise SchemaError(
+                        schema=schema,
+                        data=_to_native(check_lf),
+                        message=(
+                            f"Column regex name='{schema.selector}' did not "
+                            "match any columns in the dataframe. Update the "
+                            "regex pattern so that it matches at least one "
+                            "column."
+                        ),
+                        failure_cases=check_lf.collect_schema().names(),
+                        check=f"no_regex_column_match('{schema.selector}')",
+                        reason_code=SchemaErrorReason.INVALID_COLUMN_NAME,
+                    )
+                # An optional (required=False) regex column that matches no
+                # columns has nothing to validate, so skip it instead of
+                # raising, mirroring the pandas backend (see issue #2364).
+                return check_lf
             for column_name in column_keys_to_check:
                 single_col_lf = check_lf.select(nw.col(column_name))
                 col_schema = copy.copy(schema)

--- a/pandera/backends/polars/components.py
+++ b/pandera/backends/polars/components.py
@@ -88,18 +88,24 @@ class ColumnBackend(PolarsSchemaBackend):
                 self.get_regex_columns(schema, check_obj)
             )
             if not column_keys_to_check:
-                raise SchemaError(
-                    schema=schema,
-                    data=check_obj,
-                    message=(
-                        f"Column regex name='{schema.selector}' did not match "
-                        "any columns in the dataframe. Update the regex "
-                        "pattern so that it matches at least one column."
-                    ),
-                    failure_cases=get_lazyframe_column_names(check_obj),
-                    check=f"no_regex_column_match('{schema.selector}')",
-                    reason_code=SchemaErrorReason.INVALID_COLUMN_NAME,
-                )
+                if schema.required:
+                    raise SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=(
+                            f"Column regex name='{schema.selector}' did not "
+                            "match any columns in the dataframe. Update the "
+                            "regex pattern so that it matches at least one "
+                            "column."
+                        ),
+                        failure_cases=get_lazyframe_column_names(check_obj),
+                        check=f"no_regex_column_match('{schema.selector}')",
+                        reason_code=SchemaErrorReason.INVALID_COLUMN_NAME,
+                    )
+                # An optional (required=False) regex column that matches no
+                # columns has nothing to validate, so skip it instead of
+                # raising, mirroring the pandas backend (see issue #2364).
+                return check_obj
             _orig_name = schema.name
             _orig_regex = schema.regex
             for column_name in column_keys_to_check:

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -540,12 +540,43 @@ def test_regex_selector(
                 f"got: {error_text[:500]}"
             )
 
-        # dropping all columns should fail
+        # Dropping all columns is allowed here: these regex columns are
+        # optional (required=False), so a regex that matches no columns simply
+        # has nothing to validate, matching the pandas backend.
+        # See https://github.com/unionai-oss/pandera/issues/2364
         modified_data = ldf_for_regex_match.drop(
             get_lazyframe_column_names(ldf_for_regex_match)
         )
-        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
-            modified_data.pipe(schema.validate).collect()
+        modified_data.pipe(schema.validate).collect()  # should not raise
+
+
+def test_regex_optional_column_no_match():
+    """An optional regex column that matches no columns must not raise.
+
+    Regression test for https://github.com/unionai-oss/pandera/issues/2364:
+    pandera.polars raised on a ``regex=True, required=False`` column when no
+    column matched, while pandera.pandas tolerates it.
+    """
+    df = pl.DataFrame({"data": [1, 2, 3]})
+
+    # required=False + no match: nothing to validate, validation passes.
+    optional_schema = DataFrameSchema(
+        {
+            "data": Column(pl.Int64, required=False),
+            r"^bla_\d+$": Column(pl.Float64, regex=True, required=False),
+        }
+    )
+    assert optional_schema.validate(df).equals(df)
+
+    # required=True + no match: still an error.
+    required_schema = DataFrameSchema(
+        {r"^bla_\d+$": Column(pl.Float64, regex=True, required=True)}
+    )
+    with pytest.raises(
+        (pa.errors.SchemaError, pa.errors.SchemaErrors),
+        match="did not match any columns",
+    ):
+        required_schema.validate(df)
 
 
 def test_regex_column_name_in_error_message():


### PR DESCRIPTION
Fixes #2364.

## Why

With the polars backend, a `Column` declared `regex=True, required=False` raises a `SchemaError` when the pattern matches no columns:

```python
import polars as pl
from pandera.polars import Column, DataFrameSchema

schema = DataFrameSchema({
    "data": Column(int, required=False),
    r"^bla_\d+$": Column(float, regex=True, required=False),
})
schema.validate(pl.DataFrame({"data": [1, 2, 3]}))
# SchemaError: Column regex name='^bla_\d+$' did not match any columns ...
```

The pandas backend tolerates this (an optional column that is absent simply has nothing to validate). The two backends should agree.

I verified the pandas behaviour directly:

| case | pandas | polars (before) |
|------|--------|-----------------|
| `required=False`, no match | OK | **SchemaError** |
| `required=True`, no match | SchemaError | SchemaError |

## What changed

In `ColumnBackend.validate` (`pandera/backends/polars/components.py`), the "regex matched no columns" branch now only raises when the column is `required`; otherwise it returns the (unchanged) data, mirroring the pandas backend. `required=True` still errors exactly as before.

## Note on the existing test (please review)

`tests/polars/test_polars_container.py::test_regex_selector` ended with a "dropping all columns should fail" assertion, but the regex columns in its fixtures are `required=False` — so that assertion was encoding the very bug this PR fixes (it expected an error where pandas raises none). I updated that block to assert the corrected behaviour (validation passes), with a comment pointing at this issue.

I also added `test_regex_optional_column_no_match`, which covers both directions: `required=False` + no match passes, and `required=True` + no match still raises.

## Testing

`tests/polars/test_polars_container.py` and `tests/polars/test_polars_components.py` pass (134 tests). The new test fails without the fix and passes with it. `ruff check`, `ruff format`, and `codespell` are clean.

---
This change was prepared by an AI agent under my direction; I reviewed and verified it.
