### PR TITLE
feat: enable runtime narwhals backend toggling via set_config

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -6,8 +6,9 @@
 
 `pandera` provides a global config `~pandera.config.PanderaConfig`. The
 global configuration is available through `pandera.config.CONFIG`. It can also
-be modified with a configuration context `~pandera.config.config_context` and
-fetched with `~pandera.config.get_config_context` in custom code.
+be modified with {func}`~pandera.set_config`, a configuration context
+`~pandera.config.config_context`, and fetched with
+`~pandera.config.get_config_context` in custom code.
 
 This configuration can also be set using environment variables.
 
@@ -31,31 +32,52 @@ This can be achieved by setting the environment variable
 `PANDERA_VALIDATION_ENABLED=False`. When validation is disabled, any
 `validate` call not actually run any validation checks.
 
-## Narwhals-powered Polars / Ibis backend
+## Narwhals-powered backend
 
 *New in version 0.32.0*
 
 Pandera ships an optional
 [Narwhals](https://narwhals-dev.github.io/narwhals/)-powered backend that
-unifies the Polars and Ibis validation paths. It is **opt-in**; by
-default the native Polars and Ibis backends are used. To switch the
-`pandera.polars` and `pandera.ibis` integrations onto the Narwhals backend,
-install the `narwhals` extra and set:
+unifies the Polars, Ibis, and PySpark SQL validation paths. It is **opt-in**; by
+default the native backends are used.
+
+Install the `narwhals` extra and enable the backend with either:
 
 ```bash
 export PANDERA_USE_NARWHALS_BACKEND=True
 ```
 
-Equivalently, set `pandera.config.CONFIG.use_narwhals_backend = True`
-before any Polars or Ibis schema is constructed. The backend choice is
-locked in at first schema construction (the registration step is
-`lru_cache`-d), so toggle this setting at process start. To switch backends
-in the same process, call `register_polars_backends.cache_clear()`,
-`register_ibis_backends.cache_clear()`, and/or
-`register_pyspark_backends.cache_clear()` before re-registering.
+or:
+
+```python
+import pandera
+
+pandera.set_config(use_narwhals_backend=True)
+```
+
+You can call {func}`~pandera.set_config` before or after importing
+``pandera.polars``, ``pandera.ibis``, or ``pandera.pyspark``.
+
+### Lazy registration
+
+Validation backends are **not** registered at import time. Registration happens
+lazily the first time a schema is constructed or ``validate()`` is called.
+Until then, changing ``CONFIG.use_narwhals_backend`` (via the environment
+variable or {func}`~pandera.set_config`) takes effect on the first registration
+with no extra steps.
+
+### Runtime re-registration
+
+If {func}`~pandera.set_config` changes ``use_narwhals_backend`` after backends
+have already been registered, pandera automatically clears the registration
+caches, swaps the backend classes in the registry, and emits a ``UserWarning``.
+Existing schema objects keep working — backend lookup happens on each
+``validate()`` call.
+
+See {ref}`Backend registration <narwhals-backend-registration>` for worked
+examples and the {ref}`Narwhals backend guide <narwhals-backend>` for
+installation commands, feature comparison, and PySpark-specific differences.
 
 If `PANDERA_USE_NARWHALS_BACKEND=True` but `narwhals` is not installed,
 schema construction raises an `ImportError` pointing you at
-`pandera[narwhals]`. See the
-{ref}`Narwhals-powered backends <narwhals-backend>` page for the full
-feature comparison.
+`pandera[narwhals]`.

--- a/docs/source/ibis.md
+++ b/docs/source/ibis.md
@@ -35,19 +35,22 @@ You can find the command to install the Ibis backend of your choice on the
 *new in 0.32.0*; Pandera ships an optional
 {ref}`Narwhals-powered backend <narwhals-backend>` that runs validation
 against the native Ibis expression graph without materializing tables.
-To opt into the Narwhals backend do the following:
+Install the extra and enable it with either of the following:
 
 ```bash
-# install the narwhals extra
 pip install 'pandera[ibis,narwhals]'
-
-# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
-
-# or set the config option in Python
-import pandera
-pandera.set_config(use_narwhals_backend=True)
 ```
+
+```python
+import pandera.ibis as pa
+
+pa.config.set_config(use_narwhals_backend=True)
+```
+
+You can call {func}`~pandera.set_config` before or after importing
+``pandera.ibis``. See {ref}`Backend registration <narwhals-backend-registration>`
+for details on lazy registration and runtime re-registration.
 :::
 
 Then, you can start validating Ibis tables using Pandera schemas. In the example

--- a/docs/source/ibis.md
+++ b/docs/source/ibis.md
@@ -45,10 +45,10 @@ export PANDERA_USE_NARWHALS_BACKEND=True
 ```python
 import pandera.ibis as pa
 
-pa.config.set_config(use_narwhals_backend=True)
+pa.set_config(use_narwhals_backend=True)
 ```
 
-You can call {func}`~pandera.set_config` before or after importing
+You can call {func}`~pandera.ibis.set_config` before or after importing
 ``pandera.ibis``. See {ref}`Backend registration <narwhals-backend-registration>`
 for details on lazy registration and runtime re-registration.
 :::

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -398,21 +398,26 @@ leverage the pandas validation backend.
 :::{important}
 *new in 0.32.0*; Pandera ships an optional
 {ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
-fully lazy when possible. To opt into the Narwhals backend do the following:
+fully lazy when possible. Install the extra for each backend you use and
+enable it with either of the following:
 
 ```bash
-# install the narwhals extra with the supported dataframe libraries
-pip install 'pandera[narwhals,pyspark]'    # for PySpark SQL
-pip install 'pandera[narwhals,polars]'    # for Polars
-pip install 'pandera[narwhals,ibis]'      # for Ibis
+pip install 'pandera[narwhals,polars]'    # Polars
+pip install 'pandera[narwhals,ibis]'      # Ibis
+pip install 'pandera[narwhals,pyspark]'   # PySpark SQL
 
-# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
+```
 
-# or set the config option in Python
+```python
 import pandera
+
 pandera.set_config(use_narwhals_backend=True)
 ```
+
+You can call {func}`~pandera.set_config` before or after importing a pandera
+backend module. See {ref}`Backend registration <narwhals-backend-registration>`
+for details on lazy registration and runtime re-registration.
 :::
 
 

--- a/docs/source/narwhals_backend.md
+++ b/docs/source/narwhals_backend.md
@@ -14,45 +14,157 @@ active.
 
 ## Enabling the Narwhals backend
 
-To switch the Polars, Ibis, and PySpark SQL integrations onto the
-Narwhals-powered backend, install the `narwhals` extra and set the
-`PANDERA_USE_NARWHALS_BACKEND` environment variable to `True` before
-importing `pandera.polars`, `pandera.ibis`, or `pandera.pyspark`:
+The Narwhals backend is **opt-in**. Install the `narwhals` extra alongside the
+backend(s) you use:
 
 ```bash
-pip install 'pandera[narwhals]'
-export PANDERA_USE_NARWHALS_BACKEND=True
+pip install 'pandera[narwhals,polars]'   # Polars
+pip install 'pandera[narwhals,ibis]'     # Ibis
+pip install 'pandera[narwhals,pyspark]'  # PySpark SQL
 ```
 
-You can also enable it programmatically by setting
-{py:attr}`pandera.config.CONFIG.use_narwhals_backend` to `True` before any
-`pandera.polars` / `pandera.ibis` / `pandera.pyspark` schema is constructed:
+Then enable it using **either** of the following options.
+
+### Environment variable (process start)
+
+Set `PANDERA_USE_NARWHALS_BACKEND` to `True` before starting Python:
+
+```bash
+export PANDERA_USE_NARWHALS_BACKEND=True
+python your_script.py
+```
+
+This value is read when `pandera.config` is first imported.
+
+### Programmatic configuration
+
+Call {func}`~pandera.set_config` at any point — before or after importing
+`pandera.polars`, `pandera.ibis`, or `pandera.pyspark`:
 
 ```python
 import pandera
 
 pandera.set_config(use_narwhals_backend=True)
 
-import pandera.polars as pa  # narwhals backend now registered
+import pandera.polars as pa
 ```
 
-The backend choice is locked in the first time a Polars or Ibis schema is
-created (the registration step is `lru_cache`-d). To switch backends in the
-same process, clear the cache and re-register:
+See {ref}`Backend registration <narwhals-backend-registration>` for details on
+when backends are registered and how runtime toggling works.
+
+### Advanced: manual re-registration
+
+Prefer {func}`~pandera.set_config` to toggle backends within a process. For
+low-level control (for example, in tests), clear the registration caches and
+call the register functions with the desired flag:
 
 ```python
 from pandera.backends.polars.register import register_polars_backends
-from pandera.backends.ibis.register import register_ibis_backends
-from pandera.backends.pyspark.register import register_pyspark_backends
 
 register_polars_backends.cache_clear()
-register_ibis_backends.cache_clear()
-register_pyspark_backends.cache_clear()
+register_polars_backends(use_narwhals_backend=True)
 ```
+
+The same pattern applies to `register_ibis_backends` and
+`register_pyspark_backends`.
 
 If `PANDERA_USE_NARWHALS_BACKEND=True` but `narwhals` is not installed,
 schema construction raises an `ImportError` directing you to install
 `pandera[narwhals]`.
+
+(narwhals-backend-registration)=
+
+## Backend registration
+
+Pandera chooses between the native and Narwhals validation backends through a
+**registration** step that maps each schema class (for example,
+{py:class}`~pandera.api.polars.container.DataFrameSchema`) to a concrete
+backend implementation for a given frame type (for example, `polars.DataFrame`).
+
+Two behaviours govern how that mapping is established and updated at runtime.
+
+### Lazy registration
+
+Validation backends for Polars, Ibis, and PySpark SQL are registered
+**lazily** — not when you import a pandera backend module, but the first time
+a schema needs a backend. Concretely, registration runs when you:
+
+- construct a {py:class}`~pandera.api.polars.container.DataFrameSchema`,
+  {py:class}`~pandera.api.ibis.container.DataFrameSchema`, or
+  {py:class}`~pandera.api.pyspark.container.DataFrameSchema`, or
+- call `validate()` on a column or schema component that triggers backend
+  lookup.
+
+Until one of those happens, importing ``pandera.polars``, ``pandera.ibis``, or
+``pandera.pyspark`` has no effect on which validation backend is active:
+
+```python
+import pandera.polars as pa
+
+# CONFIG.use_narwhals_backend is read here — not at import time above
+pa.config.set_config(use_narwhals_backend=True)
+
+schema = pa.DataFrameSchema({"name": pa.Column(str)})  # narwhals backends registered
+schema.validate(df)
+```
+
+At registration time, pandera reads the current value of
+``CONFIG.use_narwhals_backend`` (from the environment variable or a prior
+{func}`~pandera.set_config` call) and registers either the native or Narwhals
+backend implementations. The register functions are cached with
+``@lru_cache``; the ``use_narwhals_backend`` flag is part of the cache key, so
+native and Narwhals registrations do not collide.
+
+:::{tip}
+Because registration is lazy, you can call {func}`~pandera.set_config` **after**
+importing a backend module and **before** constructing your first schema — no
+manual cache clearing is required in that case.
+:::
+
+### Runtime re-registration
+
+If you change ``use_narwhals_backend`` with {func}`~pandera.set_config` **after**
+backends have already been registered, pandera **re-registers** them
+automatically:
+
+1. The global ``CONFIG.use_narwhals_backend`` value is updated.
+2. Pandera detects which of the Polars / Ibis / PySpark register functions had
+   already run.
+3. Registration caches are cleared and existing registry entries for those
+   backends are removed.
+4. Only the backends that were previously registered are registered again, now
+   using the new flag value.
+5. A ``UserWarning`` is emitted to make the swap visible.
+
+```python
+import pandera.polars as pa
+
+schema = pa.DataFrameSchema({"age": pa.Column(int)})
+schema.validate(df)  # uses native Polars backend (default)
+
+pa.config.set_config(use_narwhals_backend=True)
+# UserWarning: Re-registered pandera backends after use_narwhals_backend changed.
+
+schema.validate(df)  # same schema object, now validated by the Narwhals backend
+```
+
+Existing schema objects **continue to work** after re-registration. Schemas
+do not store a backend reference at construction time; they look up the
+registered backend from the global registry on each ``validate()`` call.
+
+Re-registration applies only to backends that had already been registered in
+the current process. If you call ``set_config(use_narwhals_backend=True)``
+before constructing any Polars/Ibis/PySpark schema, no re-registration occurs
+— the first lazy registration picks up the updated config silently.
+
+:::{note}
+Runtime re-registration is triggered by {func}`~pandera.set_config`, which
+updates the **global** ``CONFIG``. The ``config_context`` manager overrides
+settings for validation behaviour (for example, ``validation_depth``) but does
+**not** change which validation backend is registered. Use
+{func}`~pandera.set_config` (or the environment variable) to switch between
+native and Narwhals backends.
+:::
 
 ## What it is
 
@@ -102,7 +214,7 @@ backend:
   ``coerce=True`` at the `Config` level (row-wise `auto_coerce` dtype) is
   handled and does not warn.
   If you rely on `coerce=True` to convert column dtypes, use the native PySpark
-  backend (`PANDERA_USE_NARWHALS_BACKEND=False`).
+  backend (see {ref}`Opting out <narwhals-opting-out>`).
 - **Custom checks using `PysparkDataframeColumnObject` are incompatible.**
   Custom checks registered via `@register_check_method` that expect a
   `pyspark_obj: PysparkDataframeColumnObject` argument will not work under the
@@ -121,19 +233,29 @@ backend:
   `lazy=False`). This differs from the native PySpark backend, which attaches
   errors to `dataframe.pandera.errors`. If you depend on the
   `dataframe.pandera.errors` accessor, use the native PySpark backend
-  (`PANDERA_USE_NARWHALS_BACKEND=False`).
+  (see {ref}`Opting out <narwhals-opting-out>`).
+
+(narwhals-opting-out)=
 
 ## Opting out
 
 The Narwhals backend is **off by default**, so no action is needed to
-continue using the native Polars and Ibis backends. If you previously
-opted in and want to switch back, unset the environment variable (or set
-it to `False`):
+continue using the native Polars, Ibis, and PySpark backends. If you
+previously opted in and want to switch back, unset the environment variable
+(or set it to `False`):
 
 ```bash
 unset PANDERA_USE_NARWHALS_BACKEND
 # or
 export PANDERA_USE_NARWHALS_BACKEND=False
+```
+
+Or call {func}`~pandera.set_config` programmatically:
+
+```python
+import pandera
+
+pandera.set_config(use_narwhals_backend=False)
 ```
 
 The native paths remain fully supported alongside the Narwhals path.

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -31,19 +31,22 @@ As of `pandera >= 0.21.0`, only `polars >= 1.0.0` is supported.
 :::{note}
 *new in 0.32.0*; Pandera ships an optional
 {ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
-fully lazy. To opt into the Narwhals backend do the following:
+fully lazy. Install the extra and enable it with either of the following:
 
 ```bash
-# install the narwhals extra
 pip install 'pandera[polars,narwhals]'
-
-# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
-
-# or set the config option in Python
-import pandera
-pandera.set_config(use_narwhals_backend=True)
 ```
+
+```python
+import pandera.polars as pa
+
+pa.config.set_config(use_narwhals_backend=True)
+```
+
+You can call {func}`~pandera.set_config` before or after importing
+``pandera.polars``. See {ref}`Backend registration <narwhals-backend-registration>`
+for details on lazy registration and runtime re-registration.
 :::
 
 Then you can use pandera schemas to validate polars dataframes. In the example

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -41,10 +41,10 @@ export PANDERA_USE_NARWHALS_BACKEND=True
 ```python
 import pandera.polars as pa
 
-pa.config.set_config(use_narwhals_backend=True)
+pa.set_config(use_narwhals_backend=True)
 ```
 
-You can call {func}`~pandera.set_config` before or after importing
+You can call {func}`~pandera.polars.set_config` before or after importing
 ``pandera.polars``. See {ref}`Backend registration <narwhals-backend-registration>`
 for details on lazy registration and runtime re-registration.
 :::

--- a/docs/source/pyspark_sql.md
+++ b/docs/source/pyspark_sql.md
@@ -39,10 +39,10 @@ export PANDERA_USE_NARWHALS_BACKEND=True
 ```python
 import pandera.pyspark as pa
 
-pa.config.set_config(use_narwhals_backend=True)
+pa.set_config(use_narwhals_backend=True)
 ```
 
-You can call {func}`~pandera.set_config` before or after importing
+You can call {func}`~pandera.pyspark.set_config` before or after importing
 ``pandera.pyspark``. See {ref}`Backend registration <narwhals-backend-registration>`
 for details on lazy registration and runtime re-registration.
 

--- a/docs/source/pyspark_sql.md
+++ b/docs/source/pyspark_sql.md
@@ -29,19 +29,22 @@ pip install 'pandera[pyspark]'
 :::{note}
 *new in 0.32.0*; Pandera ships an optional
 {ref}`Narwhals-powered backend <narwhals-backend>` that keeps validation
-fully lazy. To opt into the Narwhals backend do the following:
+fully lazy. Install the extra and enable it with either of the following:
 
 ```bash
-# install the narwhals extra
 pip install 'pandera[pyspark,narwhals]'
-
-# set the environment variable
 export PANDERA_USE_NARWHALS_BACKEND=True
-
-# or set the config option in Python
-import pandera
-pandera.set_config(use_narwhals_backend=True)
 ```
+
+```python
+import pandera.pyspark as pa
+
+pa.config.set_config(use_narwhals_backend=True)
+```
+
+You can call {func}`~pandera.set_config` before or after importing
+``pandera.pyspark``. See {ref}`Backend registration <narwhals-backend-registration>`
+for details on lazy registration and runtime re-registration.
 
 Because the Narwhals backend for PySpark shares its check implementations with
 the Polars and Ibis backends, several behaviours differ from the native PySpark

--- a/docs/source/reference/core.rst
+++ b/docs/source/reference/core.rst
@@ -75,3 +75,5 @@ Configuration
    pandera.config.get_config_context
    pandera.config.get_config_global
    pandera.config.reset_config_context
+   pandera.config.set_config
+   pandera.set_config

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -54,6 +54,8 @@
      - Get the current configuration context
    * - :func:`~pandera.config.get_config_global`
      - Get the global configuration
+   * - :func:`~pandera.config.set_config`
+     - Set global configuration options (also available as :func:`~pandera.set_config`)
    * - :func:`~pandera.config.reset_config_context`
      - Reset context configuration to the global default
 ```

--- a/docs/source/reference/narwhals.rst
+++ b/docs/source/reference/narwhals.rst
@@ -8,8 +8,11 @@ Narwhals Backend
 Opt-in `Narwhals <https://narwhals-dev.github.io/narwhals/>`__-powered
 validation backend that powers the Polars, Ibis, and PySpark SQL
 integrations behind a single unified code path. Requires the ``narwhals``
-extra. See :ref:`Narwhals-powered backends <narwhals-backend>` for the
-user-facing guide.
+extra. Enable with ``PANDERA_USE_NARWHALS_BACKEND=True`` or
+:func:`~pandera.set_config`. Backends register lazily on first schema use;
+changing the flag at runtime triggers automatic re-registration. See
+:ref:`Backend registration <narwhals-backend-registration>` and
+:ref:`Narwhals-powered backends <narwhals-backend>` for the user-facing guide.
 
 Data Objects
 ------------

--- a/docs/source/supported_libraries.md
+++ b/docs/source/supported_libraries.md
@@ -99,7 +99,7 @@ are expressed in the native library's API.
 :widths: 25 75
 
 * - {ref}`Narwhals <narwhals-backend>`
-  - Use a unified backend to power the validation of different dataframe libraries.
+  - Unified opt-in backend for Polars, Ibis, and PySpark SQL. Enable with ``PANDERA_USE_NARWHALS_BACKEND=True`` or {func}`~pandera.set_config`.
 :::
 
 ```{toctree}

--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -11,9 +11,11 @@ try:
     from pandera import dtypes, typing
     from pandera._pandas_deprecated import *
     from pandera._pandas_deprecated import __all__ as _pandas_deprecated_all
+    from pandera.config import set_config
 
     __all__ = [
         "__version__",
+        "set_config",
         *_pandas_deprecated_all,
     ]
 
@@ -40,9 +42,11 @@ except (ImportError, ModuleNotFoundError) as err:
         dataframe_parser,
         parser,
     )
+    from pandera.config import set_config
 
     __all__ = [
         "__version__",
+        "set_config",
         "Check",
         "Field",
         "check",

--- a/pandera/_pandas_deprecated.py
+++ b/pandera/_pandas_deprecated.py
@@ -55,6 +55,7 @@ from pandera.api.pandas.components import Column, Index, MultiIndex
 from pandera.api.pandas.container import DataFrameSchema as _DataFrameSchema
 from pandera.api.pandas.model import DataFrameModel as _DataFrameModel
 from pandera.api.parsers import Parser
+from pandera.config import set_config
 from pandera.decorators import check_input, check_io, check_output, check_types
 from pandera.dtypes import (
     Bool,
@@ -201,6 +202,8 @@ __all__ = [
     "UINT64",
     # pandera.engines.pandas_engine
     "pandas_version",
+    # config
+    "set_config",
     # checks
     "Check",
     # parsers

--- a/pandera/api/base/checks.py
+++ b/pandera/api/base/checks.py
@@ -160,8 +160,12 @@ class BaseCheck(metaclass=MetaCheck):
     @classmethod
     def get_backend(cls, check_obj: Any) -> type[BaseCheckBackend]:
         """Get the backend associated with the type of ``check_obj`` ."""
+        from pandera.backends.register_checks import (
+            register_default_check_backends,
+        )
 
         check_obj_cls = type(check_obj)
+        register_default_check_backends(check_obj_cls)
         classes = inspect.getmro(check_obj_cls)
         for _class in classes:
             try:

--- a/pandera/api/base/checks.py
+++ b/pandera/api/base/checks.py
@@ -145,10 +145,17 @@ class BaseCheck(metaclass=MetaCheck):
         )
 
     @classmethod
-    def register_backend(cls, type_: type, backend: type[BaseCheckBackend]):
+    def register_backend(
+        cls,
+        type_: type,
+        backend: type[BaseCheckBackend],
+        *,
+        force: bool = False,
+    ):
         """Register a backend for the specified type."""
-        if (cls, type_) not in cls.BACKEND_REGISTRY:
-            cls.BACKEND_REGISTRY[(cls, type_)] = backend
+        key = (cls, type_)
+        if force or key not in cls.BACKEND_REGISTRY:
+            cls.BACKEND_REGISTRY[key] = backend
 
     @classmethod
     def get_backend(cls, check_obj: Any) -> type[BaseCheckBackend]:

--- a/pandera/api/base/parsers.py
+++ b/pandera/api/base/parsers.py
@@ -27,9 +27,17 @@ class BaseParser(metaclass=MetaParser):
         self.name = name
 
     @classmethod
-    def register_backend(cls, type_: type, backend: type[BaseParserBackend]):
+    def register_backend(
+        cls,
+        type_: type,
+        backend: type[BaseParserBackend],
+        *,
+        force: bool = False,
+    ):
         """Register a backend for the specified type."""
-        cls.BACKEND_REGISTRY[(cls, type_)] = backend
+        key = (cls, type_)
+        if force or key not in cls.BACKEND_REGISTRY:
+            cls.BACKEND_REGISTRY[key] = backend
 
     @classmethod
     def get_backend(cls, parse_obj: Any) -> type[BaseParserBackend]:

--- a/pandera/api/base/schema.py
+++ b/pandera/api/base/schema.py
@@ -93,10 +93,17 @@ class BaseSchema(ABC):
         raise NotImplementedError
 
     @classmethod
-    def register_backend(cls, type_: type, backend: type[BaseSchemaBackend]):
+    def register_backend(
+        cls,
+        type_: type,
+        backend: type[BaseSchemaBackend],
+        *,
+        force: bool = False,
+    ):
         """Register a schema backend for this class."""
-        if (cls, type_) not in cls.BACKEND_REGISTRY:
-            cls.BACKEND_REGISTRY[(cls, type_)] = backend
+        key = (cls, type_)
+        if force or key not in cls.BACKEND_REGISTRY:
+            cls.BACKEND_REGISTRY[key] = backend
 
     @classmethod
     def get_backend(

--- a/pandera/api/ibis/components.py
+++ b/pandera/api/ibis/components.py
@@ -104,7 +104,11 @@ class Column(ComponentSchema[ibis.Table]):
 
     @staticmethod
     def register_default_backends(check_obj_cls: type):
-        register_ibis_backends()
+        from pandera.config import CONFIG
+
+        register_ibis_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     @property
     def dtype(self):

--- a/pandera/api/ibis/container.py
+++ b/pandera/api/ibis/container.py
@@ -22,7 +22,11 @@ class DataFrameSchema(_DataFrameSchema[ibis.Table]):
 
     @staticmethod
     def register_default_backends(check_obj_cls: type):
-        register_ibis_backends()
+        from pandera.config import CONFIG
+
+        register_ibis_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     def validate(
         self,

--- a/pandera/api/pandas/types.py
+++ b/pandera/api/pandas/types.py
@@ -113,7 +113,7 @@ def get_backend_types(check_cls_fqn: str) -> BackendTypes:
         dataframe_datatypes.append(gpd.GeoDataFrame)
         series_datatypes.append(gpd.GeoSeries)
 
-    register_fn = {
+    register_fns = {
         "pandas": register_pandas_backend,
         "dask_expr": register_dask_backend,
         "dask": register_dask_backend,
@@ -121,7 +121,13 @@ def get_backend_types(check_cls_fqn: str) -> BackendTypes:
         "pyspark": register_pyspark_backend,
         "geopandas": register_geopandas_backend,
         "pandera": lambda: None,
-    }[mod_name]
+    }
+    try:
+        register_fn = register_fns[mod_name]
+    except KeyError as exc:
+        raise BackendNotFoundError(
+            f"Unknown backend module name: {mod_name!r}"
+        ) from exc
 
     register_fn()
 

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -109,7 +109,11 @@ class Column(ComponentSchema[PolarsCheckObjects]):
     def register_default_backends(
         check_obj_cls: type,
     ):
-        register_polars_backends()
+        from pandera.config import CONFIG
+
+        register_polars_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     def validate(
         self,

--- a/pandera/api/polars/container.py
+++ b/pandera/api/polars/container.py
@@ -47,7 +47,11 @@ class DataFrameSchema(_DataFrameSchema[PolarsCheckObjects]):
     def register_default_backends(
         check_obj_cls: type,
     ):
-        register_polars_backends()
+        from pandera.config import CONFIG
+
+        register_polars_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     def validate(
         self,

--- a/pandera/api/pyspark/column_schema.py
+++ b/pandera/api/pyspark/column_schema.py
@@ -72,7 +72,11 @@ class ColumnSchema(BaseSchema):
 
     @staticmethod
     def register_default_backends(check_obj_cls: type):
-        register_pyspark_backends()
+        from pandera.config import CONFIG
+
+        register_pyspark_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     @property
     def dtype(self) -> DataType:

--- a/pandera/api/pyspark/components.py
+++ b/pandera/api/pyspark/components.py
@@ -104,7 +104,11 @@ class Column(ComponentSchema[PySparkDataFrameTypes]):
 
     @staticmethod
     def register_default_backends(check_obj_cls: type):
-        register_pyspark_backends()
+        from pandera.config import CONFIG
+
+        register_pyspark_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     @property
     def _allow_groupby(self) -> bool:

--- a/pandera/api/pyspark/container.py
+++ b/pandera/api/pyspark/container.py
@@ -38,7 +38,11 @@ class DataFrameSchema(_DataFrameSchema[PySparkDataFrameTypes]):
 
     @staticmethod
     def register_default_backends(check_obj_cls: type):
-        register_pyspark_backends()
+        from pandera.config import CONFIG
+
+        register_pyspark_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
 
     @property
     def dtype(

--- a/pandera/backends/ibis/register.py
+++ b/pandera/backends/ibis/register.py
@@ -8,27 +8,23 @@ import ibis
 @lru_cache
 def register_ibis_backends(
     check_cls_fqn: str | None = None,
+    use_narwhals_backend: bool = False,
 ):
     """Register backends for Ibis Table types.
 
-    Uses the Narwhals backends when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
-    ``pandera.config.CONFIG.use_narwhals_backend`` is ``True``); otherwise
+    Uses the Narwhals backends when ``use_narwhals_backend`` is ``True`` (from
+    ``PANDERA_USE_NARWHALS_BACKEND`` or ``pandera.config.CONFIG``); otherwise
     registers the native Ibis backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
-    validate() calls. The backend choice is fixed at first call — programmatic
-    changes to ``CONFIG.use_narwhals_backend`` after registration require
-    ``register_ibis_backends.cache_clear()`` to take effect.
+    validate() calls. The backend choice is part of the cache key; programmatic
+    changes to ``CONFIG.use_narwhals_backend`` after registration trigger
+    automatic re-registration via ``pandera.config.set_config``.
 
     This function is called at schema initialization in the _register_*_backends
     method.
     """
-    from pandera.api.checks import Check
-    from pandera.api.ibis.components import Column
-    from pandera.api.ibis.container import DataFrameSchema
-    from pandera.config import CONFIG
-
-    if CONFIG.use_narwhals_backend:
+    if use_narwhals_backend:
         try:
             import narwhals.stable.v1 as nw
         except ImportError as exc:
@@ -39,22 +35,32 @@ def register_ibis_backends(
             ) from exc
 
         import pandera.backends.narwhals.builtin_checks  # noqa: F401
+        from pandera.api.checks import Check
+        from pandera.api.ibis.components import Column
+        from pandera.api.ibis.container import DataFrameSchema
         from pandera.backends.narwhals.checks import NarwhalsCheckBackend
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
 
-        DataFrameSchema.register_backend(ibis.Table, DataFrameSchemaBackend)
-        Column.register_backend(ibis.Table, ColumnBackend)
-        Check.register_backend(ibis.Table, NarwhalsCheckBackend)
-        Check.register_backend(ibis.Column, NarwhalsCheckBackend)
-        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
+        DataFrameSchema.register_backend(
+            ibis.Table, DataFrameSchemaBackend, force=True
+        )
+        Column.register_backend(ibis.Table, ColumnBackend, force=True)
+        Check.register_backend(ibis.Table, NarwhalsCheckBackend, force=True)
+        Check.register_backend(ibis.Column, NarwhalsCheckBackend, force=True)
+        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend, force=True)
     else:
         import pandera.backends.ibis.builtin_checks  # noqa: F401, I001
+        from pandera.api.checks import Check
+        from pandera.api.ibis.components import Column
+        from pandera.api.ibis.container import DataFrameSchema
         from pandera.backends.ibis.checks import IbisCheckBackend
         from pandera.backends.ibis.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.ibis.container import DataFrameSchemaBackend  # type: ignore[assignment]
 
-        DataFrameSchema.register_backend(ibis.Table, DataFrameSchemaBackend)
-        Column.register_backend(ibis.Table, ColumnBackend)
-        Check.register_backend(ibis.Table, IbisCheckBackend)
-        Check.register_backend(ibis.Column, IbisCheckBackend)
+        DataFrameSchema.register_backend(
+            ibis.Table, DataFrameSchemaBackend, force=True
+        )
+        Column.register_backend(ibis.Table, ColumnBackend, force=True)
+        Check.register_backend(ibis.Table, IbisCheckBackend, force=True)
+        Check.register_backend(ibis.Column, IbisCheckBackend, force=True)

--- a/pandera/backends/narwhals/register.py
+++ b/pandera/backends/narwhals/register.py
@@ -127,14 +127,25 @@ def clear_narwhals_compatible_backend_registry() -> None:
 
 
 def _narwhals_compatible_registration_state() -> dict[str, bool]:
-    from pandera.backends.ibis.register import register_ibis_backends
-    from pandera.backends.polars.register import register_polars_backends
-
     state = {
-        "polars": register_polars_backends.cache_info().currsize > 0,
-        "ibis": register_ibis_backends.cache_info().currsize > 0,
+        "polars": False,
+        "ibis": False,
         "pyspark": False,
     }
+
+    try:
+        from pandera.backends.polars.register import register_polars_backends
+
+        state["polars"] = register_polars_backends.cache_info().currsize > 0
+    except ImportError:
+        pass
+
+    try:
+        from pandera.backends.ibis.register import register_ibis_backends
+
+        state["ibis"] = register_ibis_backends.cache_info().currsize > 0
+    except ImportError:
+        pass
 
     try:
         from pandera.backends.pyspark.register import register_pyspark_backends
@@ -147,13 +158,21 @@ def _narwhals_compatible_registration_state() -> dict[str, bool]:
 
 
 def _get_register_functions() -> dict[str, Any]:
-    from pandera.backends.ibis.register import register_ibis_backends
-    from pandera.backends.polars.register import register_polars_backends
+    register_functions: dict[str, Any] = {}
 
-    register_functions: dict[str, Any] = {
-        "polars": register_polars_backends,
-        "ibis": register_ibis_backends,
-    }
+    try:
+        from pandera.backends.polars.register import register_polars_backends
+
+        register_functions["polars"] = register_polars_backends
+    except ImportError:
+        pass
+
+    try:
+        from pandera.backends.ibis.register import register_ibis_backends
+
+        register_functions["ibis"] = register_ibis_backends
+    except ImportError:
+        pass
 
     try:
         from pandera.backends.pyspark.register import register_pyspark_backends

--- a/pandera/backends/narwhals/register.py
+++ b/pandera/backends/narwhals/register.py
@@ -1,8 +1,194 @@
-"""Narwhals backend registration.
+"""Narwhals backend registration utilities.
 
-Registration of Narwhals backends for Polars and Ibis frame types is handled by
-pandera.backends.polars.register.register_polars_backends() and
-pandera.backends.ibis.register.register_ibis_backends() when
-PANDERA_USE_NARWHALS_BACKEND=True (or pandera.config.CONFIG.use_narwhals_backend
-is True).
+Registration of Narwhals backends for Polars, Ibis, and PySpark frame types is
+handled by ``register_polars_backends()``, ``register_ibis_backends()``, and
+``register_pyspark_backends()`` when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
+``pandera.config.CONFIG.use_narwhals_backend`` is ``True``).
 """
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+
+def _pop_registry_key(
+    schema_cls: type[Any],
+    frame_type: type[Any],
+) -> None:
+    schema_cls.BACKEND_REGISTRY.pop((schema_cls, frame_type), None)  # type: ignore[attr-defined]
+
+
+def clear_narwhals_compatible_backend_registry() -> None:
+    """Remove registry entries for narwhals-compatible backends."""
+    from pandera.api.checks import Check
+
+    try:
+        import polars as pl
+
+        from pandera.api.polars.components import Column as PolarsColumn
+        from pandera.api.polars.container import (
+            DataFrameSchema as PolarsDataFrameSchema,
+        )
+
+        polars_keys = [
+            (PolarsDataFrameSchema, pl.LazyFrame),
+            (PolarsDataFrameSchema, pl.DataFrame),
+            (PolarsColumn, pl.LazyFrame),
+            (Check, pl.LazyFrame),
+        ]
+        try:
+            import narwhals.stable.v1 as nw
+
+            polars_keys.extend(
+                [
+                    (Check, nw.LazyFrame),
+                    (Check, nw.DataFrame),
+                ]
+            )
+        except ImportError:
+            pass
+
+        for schema_cls, frame_type in polars_keys:
+            _pop_registry_key(schema_cls, frame_type)
+    except ImportError:
+        pass
+
+    try:
+        import ibis
+
+        from pandera.api.ibis.components import Column as IbisColumn
+        from pandera.api.ibis.container import (
+            DataFrameSchema as IbisDataFrameSchema,
+        )
+
+        ibis_keys = [
+            (IbisDataFrameSchema, ibis.Table),
+            (IbisColumn, ibis.Table),
+            (Check, ibis.Table),
+            (Check, ibis.Column),
+        ]
+        try:
+            import narwhals.stable.v1 as nw
+
+            ibis_keys.append((Check, nw.LazyFrame))
+        except ImportError:
+            pass
+
+        for schema_cls, frame_type in ibis_keys:
+            _pop_registry_key(schema_cls, frame_type)
+    except ImportError:
+        pass
+
+    try:
+        import pyspark.sql as pyspark_sql
+
+        from pandera.api.dataframe.components import ComponentSchema
+        from pandera.api.pyspark.components import Column as PySparkColumn
+        from pandera.api.pyspark.container import (
+            DataFrameSchema as PySparkDataFrameSchema,
+        )
+
+        pyspark_keys = [
+            (PySparkDataFrameSchema, pyspark_sql.DataFrame),
+            (PySparkColumn, pyspark_sql.DataFrame),
+            (Check, pyspark_sql.DataFrame),
+            (ComponentSchema, pyspark_sql.DataFrame),
+        ]
+
+        try:
+            import narwhals.stable.v1 as nw
+
+            pyspark_keys.append((Check, nw.LazyFrame))
+        except ImportError:
+            pass
+
+        try:
+            from pyspark.sql.connect import dataframe as pyspark_connect
+
+            pyspark_keys.extend(
+                [
+                    (
+                        PySparkDataFrameSchema,
+                        pyspark_connect.DataFrame,
+                    ),
+                    (PySparkColumn, pyspark_connect.DataFrame),
+                    (Check, pyspark_connect.DataFrame),
+                    (ComponentSchema, pyspark_connect.DataFrame),
+                ]
+            )
+        except ImportError:
+            pass
+
+        for schema_cls, frame_type in pyspark_keys:
+            _pop_registry_key(schema_cls, frame_type)
+    except ImportError:
+        pass
+
+
+def _narwhals_compatible_registration_state() -> dict[str, bool]:
+    from pandera.backends.ibis.register import register_ibis_backends
+    from pandera.backends.polars.register import register_polars_backends
+
+    state = {
+        "polars": register_polars_backends.cache_info().currsize > 0,
+        "ibis": register_ibis_backends.cache_info().currsize > 0,
+        "pyspark": False,
+    }
+
+    try:
+        from pandera.backends.pyspark.register import register_pyspark_backends
+
+        state["pyspark"] = register_pyspark_backends.cache_info().currsize > 0
+    except ImportError:
+        pass
+
+    return state
+
+
+def _get_register_functions() -> dict[str, Any]:
+    from pandera.backends.ibis.register import register_ibis_backends
+    from pandera.backends.polars.register import register_polars_backends
+
+    register_functions: dict[str, Any] = {
+        "polars": register_polars_backends,
+        "ibis": register_ibis_backends,
+    }
+
+    try:
+        from pandera.backends.pyspark.register import register_pyspark_backends
+
+        register_functions["pyspark"] = register_pyspark_backends
+    except ImportError:
+        pass
+
+    return register_functions
+
+
+def reregister_narwhals_compatible_backends(
+    *,
+    use_narwhals_backend: bool,
+) -> None:
+    """Re-register narwhals-compatible backends after toggling the config flag."""
+    register_functions = _get_register_functions()
+    previously_registered = _narwhals_compatible_registration_state()
+
+    for register_fn in register_functions.values():
+        register_fn.cache_clear()
+
+    if not any(previously_registered.values()):
+        return
+
+    clear_narwhals_compatible_backend_registry()
+
+    warnings.warn(
+        "Re-registered pandera backends after use_narwhals_backend changed. "
+        "Existing schema objects continue to work; backend classes were "
+        "swapped in the registry.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+    for name, register_fn in register_functions.items():
+        if previously_registered.get(name):
+            register_fn(use_narwhals_backend=use_narwhals_backend)

--- a/pandera/backends/polars/register.py
+++ b/pandera/backends/polars/register.py
@@ -8,24 +8,20 @@ import polars as pl
 @lru_cache
 def register_polars_backends(
     check_cls_fqn: str | None = None,
+    use_narwhals_backend: bool = False,
 ):
     """Register backends for Polars frame types.
 
-    Uses the Narwhals backends when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
-    ``pandera.config.CONFIG.use_narwhals_backend`` is ``True``); otherwise
+    Uses the Narwhals backends when ``use_narwhals_backend`` is ``True`` (from
+    ``PANDERA_USE_NARWHALS_BACKEND`` or ``pandera.config.CONFIG``); otherwise
     registers the native Polars backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
-    validate() calls. The backend choice is fixed at first call — programmatic
-    changes to ``CONFIG.use_narwhals_backend`` after registration require
-    ``register_polars_backends.cache_clear()`` to take effect.
+    validate() calls. The backend choice is part of the cache key; programmatic
+    changes to ``CONFIG.use_narwhals_backend`` after registration trigger
+    automatic re-registration via ``pandera.config.set_config``.
     """
-    from pandera.api.checks import Check
-    from pandera.api.polars.components import Column
-    from pandera.api.polars.container import DataFrameSchema
-    from pandera.config import CONFIG
-
-    if CONFIG.use_narwhals_backend:
+    if use_narwhals_backend:
         try:
             import narwhals.stable.v1 as nw
         except ImportError as exc:
@@ -36,23 +32,37 @@ def register_polars_backends(
             ) from exc
 
         import pandera.backends.narwhals.builtin_checks  # noqa: F401
+        from pandera.api.checks import Check
+        from pandera.api.polars.components import Column
+        from pandera.api.polars.container import DataFrameSchema
         from pandera.backends.narwhals.checks import NarwhalsCheckBackend
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
 
-        DataFrameSchema.register_backend(pl.LazyFrame, DataFrameSchemaBackend)
-        DataFrameSchema.register_backend(pl.DataFrame, DataFrameSchemaBackend)
-        Column.register_backend(pl.LazyFrame, ColumnBackend)
-        Check.register_backend(pl.LazyFrame, NarwhalsCheckBackend)
-        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
-        Check.register_backend(nw.DataFrame, NarwhalsCheckBackend)
+        DataFrameSchema.register_backend(
+            pl.LazyFrame, DataFrameSchemaBackend, force=True
+        )
+        DataFrameSchema.register_backend(
+            pl.DataFrame, DataFrameSchemaBackend, force=True
+        )
+        Column.register_backend(pl.LazyFrame, ColumnBackend, force=True)
+        Check.register_backend(pl.LazyFrame, NarwhalsCheckBackend, force=True)
+        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend, force=True)
+        Check.register_backend(nw.DataFrame, NarwhalsCheckBackend, force=True)
     else:
         import pandera.backends.polars.builtin_checks  # noqa: F401, I001
+        from pandera.api.checks import Check
+        from pandera.api.polars.components import Column
+        from pandera.api.polars.container import DataFrameSchema
         from pandera.backends.polars.checks import PolarsCheckBackend
         from pandera.backends.polars.components import ColumnBackend  # type: ignore[assignment]
         from pandera.backends.polars.container import DataFrameSchemaBackend  # type: ignore[assignment]
 
-        DataFrameSchema.register_backend(pl.LazyFrame, DataFrameSchemaBackend)
-        DataFrameSchema.register_backend(pl.DataFrame, DataFrameSchemaBackend)
-        Column.register_backend(pl.LazyFrame, ColumnBackend)
-        Check.register_backend(pl.LazyFrame, PolarsCheckBackend)
+        DataFrameSchema.register_backend(
+            pl.LazyFrame, DataFrameSchemaBackend, force=True
+        )
+        DataFrameSchema.register_backend(
+            pl.DataFrame, DataFrameSchemaBackend, force=True
+        )
+        Column.register_backend(pl.LazyFrame, ColumnBackend, force=True)
+        Check.register_backend(pl.LazyFrame, PolarsCheckBackend, force=True)

--- a/pandera/backends/pyspark/register.py
+++ b/pandera/backends/pyspark/register.py
@@ -1,7 +1,6 @@
 """Register pyspark backends."""
 
 from functools import lru_cache
-from typing import Optional
 
 import pyspark
 import pyspark.sql as pyspark_sql
@@ -21,27 +20,23 @@ if PYSPARK_CONNECT_AVAILABLE:
 @lru_cache
 def register_pyspark_backends(
     check_cls_fqn: str | None = None,
+    use_narwhals_backend: bool = False,
 ):
     """Register backends for PySpark DataFrame types.
 
-    Uses the Narwhals backends when ``PANDERA_USE_NARWHALS_BACKEND=True`` (or
-    ``pandera.config.CONFIG.use_narwhals_backend`` is ``True``); otherwise
+    Uses the Narwhals backends when ``use_narwhals_backend`` is ``True`` (from
+    ``PANDERA_USE_NARWHALS_BACKEND`` or ``pandera.config.CONFIG``); otherwise
     registers the native PySpark backends.
 
     Decorated with @lru_cache to prevent duplicate registrations across repeated
-    validate() calls. The backend choice is fixed at first call — programmatic
-    changes to ``CONFIG.use_narwhals_backend`` after registration require
-    ``register_pyspark_backends.cache_clear()`` to take effect.
+    validate() calls. The backend choice is part of the cache key; programmatic
+    changes to ``CONFIG.use_narwhals_backend`` after registration trigger
+    automatic re-registration via ``pandera.config.set_config``.
 
     This function is called at schema initialization in the _register_*_backends
     method.
     """
-    from pandera.api.checks import Check
-    from pandera.api.pyspark.components import Column
-    from pandera.api.pyspark.container import DataFrameSchema
-    from pandera.config import CONFIG
-
-    if CONFIG.use_narwhals_backend:
+    if use_narwhals_backend:
         try:
             import narwhals.stable.v1 as nw
         except ImportError as exc:  # pragma: no cover
@@ -52,35 +47,47 @@ def register_pyspark_backends(
             ) from exc
 
         import pandera.backends.narwhals.builtin_checks  # noqa: F401
+        from pandera.api.checks import Check
+        from pandera.api.pyspark.components import Column
+        from pandera.api.pyspark.container import DataFrameSchema
         from pandera.backends.narwhals.checks import NarwhalsCheckBackend
         from pandera.backends.narwhals.components import ColumnBackend
         from pandera.backends.narwhals.container import DataFrameSchemaBackend
 
         DataFrameSchema.register_backend(
-            pyspark_sql.DataFrame, DataFrameSchemaBackend
+            pyspark_sql.DataFrame, DataFrameSchemaBackend, force=True
         )
-        Column.register_backend(pyspark_sql.DataFrame, ColumnBackend)
-        Check.register_backend(pyspark_sql.DataFrame, NarwhalsCheckBackend)
+        Column.register_backend(
+            pyspark_sql.DataFrame, ColumnBackend, force=True
+        )
+        Check.register_backend(
+            pyspark_sql.DataFrame, NarwhalsCheckBackend, force=True
+        )
         # nw.DataFrame is intentionally NOT registered: PySpark SQL frames are always
         # SQL-lazy under narwhals (exposed as nw.LazyFrame, never nw.DataFrame). This
         # mirrors pandera/backends/ibis/register.py; contrast with polars, which also
         # registers nw.DataFrame because polars frames can be eager.
-        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend)
+        Check.register_backend(nw.LazyFrame, NarwhalsCheckBackend, force=True)
 
         if PYSPARK_CONNECT_AVAILABLE:
             DataFrameSchema.register_backend(
-                pyspark_connect.DataFrame, DataFrameSchemaBackend
+                pyspark_connect.DataFrame, DataFrameSchemaBackend, force=True
             )
-            Column.register_backend(pyspark_connect.DataFrame, ColumnBackend)
+            Column.register_backend(
+                pyspark_connect.DataFrame, ColumnBackend, force=True
+            )
             Check.register_backend(
-                pyspark_connect.DataFrame, NarwhalsCheckBackend
+                pyspark_connect.DataFrame, NarwhalsCheckBackend, force=True
             )
     else:
         from pandera._patch_numpy2 import _patch_numpy2
 
         _patch_numpy2()
 
+        from pandera.api.checks import Check
         from pandera.api.dataframe.components import ComponentSchema
+        from pandera.api.pyspark.components import Column
+        from pandera.api.pyspark.container import DataFrameSchema
         from pandera.backends.pyspark import builtin_checks  # noqa: F401
         from pandera.backends.pyspark.checks import PySparkCheckBackend
         from pandera.backends.pyspark.column import ColumnSchemaBackend
@@ -92,13 +99,17 @@ def register_pyspark_backends(
         )
 
         # Register PySpark SQL DataFrame
-        Check.register_backend(pyspark_sql.DataFrame, PySparkCheckBackend)
-        ComponentSchema.register_backend(
-            pyspark_sql.DataFrame, ColumnSchemaBackend
+        Check.register_backend(
+            pyspark_sql.DataFrame, PySparkCheckBackend, force=True
         )
-        Column.register_backend(pyspark_sql.DataFrame, PySparkColumnBackend)
+        ComponentSchema.register_backend(
+            pyspark_sql.DataFrame, ColumnSchemaBackend, force=True
+        )
+        Column.register_backend(
+            pyspark_sql.DataFrame, PySparkColumnBackend, force=True
+        )
         DataFrameSchema.register_backend(
-            pyspark_sql.DataFrame, PySparkDataFrameSchemaBackend
+            pyspark_sql.DataFrame, PySparkDataFrameSchemaBackend, force=True
         )
 
         # Note: pyspark.pandas DataFrames use pandas-like API and should use
@@ -107,14 +118,16 @@ def register_pyspark_backends(
         # Register Spark Connect DataFrame, if available
         if PYSPARK_CONNECT_AVAILABLE:
             Check.register_backend(
-                pyspark_connect.DataFrame, PySparkCheckBackend
+                pyspark_connect.DataFrame, PySparkCheckBackend, force=True
             )
             ComponentSchema.register_backend(
-                pyspark_connect.DataFrame, ColumnSchemaBackend
+                pyspark_connect.DataFrame, ColumnSchemaBackend, force=True
             )
             Column.register_backend(
-                pyspark_connect.DataFrame, PySparkColumnBackend
+                pyspark_connect.DataFrame, PySparkColumnBackend, force=True
             )
             DataFrameSchema.register_backend(
-                pyspark_connect.DataFrame, PySparkDataFrameSchemaBackend
+                pyspark_connect.DataFrame,
+                PySparkDataFrameSchemaBackend,
+                force=True,
             )

--- a/pandera/backends/register_checks.py
+++ b/pandera/backends/register_checks.py
@@ -1,0 +1,81 @@
+"""Lazy registration of check backends."""
+
+from __future__ import annotations
+
+
+def register_default_check_backends(check_obj_cls: type) -> None:
+    """Register check backends for ``check_obj_cls`` at validation time."""
+    from pandera.api.pandas.types import get_backend_types_from_mro
+
+    if get_backend_types_from_mro(check_obj_cls) is not None:
+        from pandera.api.pandas.container import (
+            DataFrameSchema as PandasDataFrameSchema,
+        )
+
+        PandasDataFrameSchema.register_default_backends(check_obj_cls)
+        return
+
+    module = getattr(check_obj_cls, "__module__", "")
+
+    if module.startswith("polars."):
+        from pandera.backends.polars.register import register_polars_backends
+        from pandera.config import CONFIG
+
+        register_polars_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
+        return
+
+    if module.startswith("ibis."):
+        from pandera.backends.ibis.register import register_ibis_backends
+        from pandera.config import CONFIG
+
+        register_ibis_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
+        return
+
+    if module.startswith("pyspark"):
+        from pandera.backends.pyspark.register import (
+            register_pyspark_backends,
+        )
+        from pandera.config import CONFIG
+
+        register_pyspark_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
+        return
+
+    if module.startswith("narwhals."):
+        from pandera.config import CONFIG
+
+        use_nw = CONFIG.use_narwhals_backend
+        try:
+            from pandera.backends.polars.register import (
+                register_polars_backends,
+            )
+
+            register_polars_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        try:
+            from pandera.backends.ibis.register import register_ibis_backends
+
+            register_ibis_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        try:
+            from pandera.backends.pyspark.register import (
+                register_pyspark_backends,
+            )
+
+            register_pyspark_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        return
+
+    if module.startswith("xarray."):
+        from pandera.backends.xarray.register import register_xarray_backends
+
+        register_xarray_backends()
+        return

--- a/pandera/backends/register_checks.py
+++ b/pandera/backends/register_checks.py
@@ -5,6 +5,38 @@ from __future__ import annotations
 
 def register_default_check_backends(check_obj_cls: type) -> None:
     """Register check backends for ``check_obj_cls`` at validation time."""
+    module = getattr(check_obj_cls, "__module__", "")
+
+    # Narwhals wrapper types share pandas-like class names (e.g. DataFrame)
+    # but must not route through the pandas backend registry.
+    if module.startswith("narwhals."):
+        from pandera.config import CONFIG
+
+        use_nw = CONFIG.use_narwhals_backend
+        try:
+            from pandera.backends.polars.register import (
+                register_polars_backends,
+            )
+
+            register_polars_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        try:
+            from pandera.backends.ibis.register import register_ibis_backends
+
+            register_ibis_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        try:
+            from pandera.backends.pyspark.register import (
+                register_pyspark_backends,
+            )
+
+            register_pyspark_backends(use_narwhals_backend=use_nw)
+        except ImportError:
+            pass
+        return
+
     from pandera.api.pandas.types import get_backend_types_from_mro
 
     if get_backend_types_from_mro(check_obj_cls) is not None:
@@ -14,8 +46,6 @@ def register_default_check_backends(check_obj_cls: type) -> None:
 
         PandasDataFrameSchema.register_default_backends(check_obj_cls)
         return
-
-    module = getattr(check_obj_cls, "__module__", "")
 
     if module.startswith("polars."):
         from pandera.backends.polars.register import register_polars_backends
@@ -44,34 +74,6 @@ def register_default_check_backends(check_obj_cls: type) -> None:
         register_pyspark_backends(
             use_narwhals_backend=CONFIG.use_narwhals_backend
         )
-        return
-
-    if module.startswith("narwhals."):
-        from pandera.config import CONFIG
-
-        use_nw = CONFIG.use_narwhals_backend
-        try:
-            from pandera.backends.polars.register import (
-                register_polars_backends,
-            )
-
-            register_polars_backends(use_narwhals_backend=use_nw)
-        except ImportError:
-            pass
-        try:
-            from pandera.backends.ibis.register import register_ibis_backends
-
-            register_ibis_backends(use_narwhals_backend=use_nw)
-        except ImportError:
-            pass
-        try:
-            from pandera.backends.pyspark.register import (
-                register_pyspark_backends,
-            )
-
-            register_pyspark_backends(use_narwhals_backend=use_nw)
-        except ImportError:
-            pass
         return
 
     if module.startswith("xarray."):

--- a/pandera/config.py
+++ b/pandera/config.py
@@ -37,6 +37,11 @@ class PanderaConfig:
     export PANDERA_KEEP_CACHED_DATAFRAME=True
     export PANDERA_USE_NARWHALS_BACKEND=True
     export SILENCE_WARNING_PYDANTIC_MODEL=true
+
+    ``use_narwhals_backend``: when ``True``, Polars, Ibis, and PySpark SQL use
+    the Narwhals-powered validation backend. Backends register lazily on first
+    schema use; changing this flag via :func:`~pandera.config.set_config`
+    re-registers backends that were already registered in the current process.
     """
 
     validation_enabled: bool = True
@@ -121,7 +126,15 @@ def set_config(
         keep_cached_dataframe: Whether to keep cached dataframes after validation (default: None)
         use_narwhals_backend: Enable Narwhals-powered backend for compatible backends (default: None)
         silenced_warnings: List of warning names to silence (default: None)
+
+    Note:
+        Changing ``use_narwhals_backend`` re-registers Polars, Ibis, and PySpark
+        validation backends that were already registered in the current process.
+        Backends that have not yet been registered pick up the new value on first
+        schema use. See the Narwhals backend documentation for details.
     """
+    previous_use_narwhals_backend = CONFIG.use_narwhals_backend
+
     if validation_enabled is not None:
         CONFIG.validation_enabled = validation_enabled
     if validation_depth is not None:
@@ -134,6 +147,18 @@ def set_config(
         CONFIG.use_narwhals_backend = use_narwhals_backend
     if silenced_warnings is not None:
         CONFIG.silenced_warnings = silenced_warnings
+
+    if (
+        use_narwhals_backend is not None
+        and use_narwhals_backend != previous_use_narwhals_backend
+    ):
+        from pandera.backends.narwhals.register import (
+            reregister_narwhals_compatible_backends,
+        )
+
+        reregister_narwhals_compatible_backends(
+            use_narwhals_backend=use_narwhals_backend
+        )
 
 
 @contextmanager

--- a/pandera/geopandas.py
+++ b/pandera/geopandas.py
@@ -138,7 +138,7 @@ __all__ = [
     "typing",
     "errors",
     "dtypes",
-    "config",
+    "set_config",
 ]
 
 if platform.system() != "Windows":

--- a/pandera/ibis.py
+++ b/pandera/ibis.py
@@ -32,5 +32,5 @@ __all__ = [
     "infer_dataframe_schema",
     "infer_schema",
     "IbisData",
-    "config",
+    "set_config",
 ]

--- a/pandera/pandas.py
+++ b/pandera/pandas.py
@@ -172,7 +172,7 @@ __all__ = [
     # dtypes
     "dtypes",
     # config
-    "config",
+    "set_config",
 ]
 
 

--- a/pandera/polars.py
+++ b/pandera/polars.py
@@ -34,5 +34,5 @@ __all__ = [
     "infer_dataframe_schema",
     "infer_schema",
     "PolarsData",
-    "config",
+    "set_config",
 ]

--- a/pandera/polars.py
+++ b/pandera/polars.py
@@ -11,16 +11,12 @@ from pandera.api.polars.components import Column
 from pandera.api.polars.container import DataFrameSchema
 from pandera.api.polars.model import DataFrameModel
 from pandera.api.polars.types import PolarsData
-from pandera.backends.polars.register import register_polars_backends
 from pandera.decorators import check_input, check_io, check_output, check_types
 from pandera.schema_inference.polars import (
     infer_dataframe_schema,
     infer_schema,
 )
 from pandera.typing import polars as typing
-
-register_polars_backends()
-
 
 __all__ = [
     "check_input",

--- a/pandera/pyspark.py
+++ b/pandera/pyspark.py
@@ -107,5 +107,5 @@ __all__ = [
     # version
     "__version__",
     # config
-    "config",
+    "set_config",
 ]

--- a/tests/ibis/test_ibis_check.py
+++ b/tests/ibis/test_ibis_check.py
@@ -17,7 +17,7 @@ from pandera.constants import CHECK_OUTPUT_KEY
 
 @pytest.fixture(autouse=True, scope="module")
 def _register_ibis_backends():
-    register_ibis_backends()
+    register_ibis_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
 
 
 @pytest.fixture

--- a/tests/ibis/test_ibis_narwhals_register.py
+++ b/tests/ibis/test_ibis_narwhals_register.py
@@ -24,7 +24,7 @@ def test_ibis_narwhals_activated_when_opted_in(monkeypatch, request):
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
     request.addfinalizer(register_ibis_backends.cache_clear)
     register_ibis_backends.cache_clear()
-    register_ibis_backends()
+    register_ibis_backends(use_narwhals_backend=True)
     t = ibis.memtable({"a": [1, 2, 3]})
     backend = IbisDataFrameSchema.get_backend(t)
     assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
@@ -37,8 +37,9 @@ def test_ibis_backend_is_narwhals():
     )
     from pandera.backends.ibis.register import register_ibis_backends
     from pandera.backends.narwhals.container import DataFrameSchemaBackend
+    from pandera.config import CONFIG
 
-    register_ibis_backends()
+    register_ibis_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
     t = ibis.memtable({"a": [1, 2, 3]})
     backend = IbisDataFrameSchema.get_backend(t)
     assert isinstance(backend, DataFrameSchemaBackend)

--- a/tests/narwhals/conftest.py
+++ b/tests/narwhals/conftest.py
@@ -47,11 +47,12 @@ def _ensure_narwhals_backends_registered():
     """
     from pandera.backends.ibis.register import register_ibis_backends
     from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG
 
     register_polars_backends.cache_clear()
     register_ibis_backends.cache_clear()
-    register_polars_backends()
-    register_ibis_backends()
+    register_polars_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
+    register_ibis_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
 
     try:
         import pyspark.sql  # noqa: F401
@@ -59,7 +60,9 @@ def _ensure_narwhals_backends_registered():
         from pandera.backends.pyspark.register import register_pyspark_backends
 
         register_pyspark_backends.cache_clear()
-        register_pyspark_backends()
+        register_pyspark_backends(
+            use_narwhals_backend=CONFIG.use_narwhals_backend
+        )
     except ImportError:
         pass
 

--- a/tests/narwhals/test_container.py
+++ b/tests/narwhals/test_container.py
@@ -131,9 +131,10 @@ def test_register_is_idempotent():
     lru_cache ensures the second call is a no-op — registry state is preserved.
     """
     from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG
 
-    register_polars_backends()
-    register_polars_backends()
+    register_polars_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
+    register_polars_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
     # No exception should be raised; lru_cache makes second call a no-op
 
 
@@ -166,7 +167,7 @@ def test_polars_narwhals_activated_when_opted_in(monkeypatch, request):
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
     request.addfinalizer(register_polars_backends.cache_clear)
     register_polars_backends.cache_clear()
-    register_polars_backends()
+    register_polars_backends(use_narwhals_backend=True)
     backend = DataFrameSchema.get_backend(pl.DataFrame({}))
     assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
 

--- a/tests/polars/test_polars_narwhals_register.py
+++ b/tests/polars/test_polars_narwhals_register.py
@@ -1,0 +1,125 @@
+"""Tests for programmatic narwhals backend activation via set_config."""
+
+import pytest
+
+pl = pytest.importorskip("polars")
+pytest.importorskip("narwhals")
+
+
+def test_import_polars_does_not_register_backends():
+    """import pandera.polars must not eagerly register validation backends."""
+    import importlib
+
+    from pandera.backends.polars.register import register_polars_backends
+
+    register_polars_backends.cache_clear()
+    importlib.reload(importlib.import_module("pandera.polars"))
+    assert register_polars_backends.cache_info().currsize == 0
+
+
+def test_set_config_before_import_uses_narwhals_backend():
+    """set_config before first schema use registers narwhals backends."""
+    from pandera.api.polars.container import DataFrameSchema
+    from pandera.backends.narwhals.container import (
+        DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
+    )
+    from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG, set_config
+
+    original = CONFIG.use_narwhals_backend
+    try:
+        set_config(use_narwhals_backend=True)
+        register_polars_backends.cache_clear()
+        DataFrameSchema.BACKEND_REGISTRY.clear()
+
+        backend = DataFrameSchema.get_backend(pl.DataFrame({"a": [1]}))
+        assert isinstance(backend, NarwhalsDataFrameSchemaBackend)
+    finally:
+        register_polars_backends.cache_clear()
+        DataFrameSchema.BACKEND_REGISTRY.clear()
+        set_config(use_narwhals_backend=original)
+        DataFrameSchema.get_backend(pl.DataFrame({"a": [1]}))
+
+
+def test_set_config_after_import_switches_to_narwhals_backend():
+    """set_config after import re-registers backends (test.py scenario)."""
+    import pandera.polars as pa
+    from pandera.backends.narwhals.container import (
+        DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
+    )
+    from pandera.backends.polars.container import (
+        DataFrameSchemaBackend as NativeDataFrameSchemaBackend,
+    )
+    from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG, set_config
+
+    original = CONFIG.use_narwhals_backend
+    try:
+        set_config(use_narwhals_backend=False)
+        register_polars_backends.cache_clear()
+        pa.DataFrameSchema.BACKEND_REGISTRY.clear()
+
+        schema = pa.DataFrameSchema({"name": pa.Column(str)})
+        native_backend = pa.DataFrameSchema.get_backend(
+            pl.DataFrame({"name": ["a"]})
+        )
+        assert isinstance(native_backend, NativeDataFrameSchemaBackend)
+
+        with pytest.warns(UserWarning, match="Re-registered pandera backends"):
+            pa.config.set_config(use_narwhals_backend=True)
+
+        narwhals_backend = pa.DataFrameSchema.get_backend(
+            pl.DataFrame({"name": ["a"]})
+        )
+        assert isinstance(narwhals_backend, NarwhalsDataFrameSchemaBackend)
+        assert schema.validate(pl.DataFrame({"name": ["John"]})).equals(
+            pl.DataFrame({"name": ["John"]})
+        )
+    finally:
+        register_polars_backends.cache_clear()
+        pa.DataFrameSchema.BACKEND_REGISTRY.clear()
+        set_config(use_narwhals_backend=original)
+        pa.DataFrameSchema.get_backend(pl.DataFrame({"name": ["a"]}))
+
+
+def test_set_config_toggles_native_and_narwhals():
+    """set_config can switch between native and narwhals backends in-process."""
+    from pandera.api.polars.container import DataFrameSchema
+    from pandera.backends.narwhals.container import (
+        DataFrameSchemaBackend as NarwhalsDataFrameSchemaBackend,
+    )
+    from pandera.backends.polars.container import (
+        DataFrameSchemaBackend as NativeDataFrameSchemaBackend,
+    )
+    from pandera.backends.polars.register import register_polars_backends
+    from pandera.config import CONFIG, set_config
+
+    original = CONFIG.use_narwhals_backend
+    try:
+        set_config(use_narwhals_backend=False)
+        register_polars_backends.cache_clear()
+        DataFrameSchema.BACKEND_REGISTRY.clear()
+        DataFrameSchema.get_backend(pl.DataFrame({"a": [1]}))
+        assert isinstance(
+            DataFrameSchema.get_backend(pl.DataFrame({"a": [1]})),
+            NativeDataFrameSchemaBackend,
+        )
+
+        with pytest.warns(UserWarning, match="Re-registered pandera backends"):
+            set_config(use_narwhals_backend=True)
+        assert isinstance(
+            DataFrameSchema.get_backend(pl.DataFrame({"a": [1]})),
+            NarwhalsDataFrameSchemaBackend,
+        )
+
+        with pytest.warns(UserWarning, match="Re-registered pandera backends"):
+            set_config(use_narwhals_backend=False)
+        assert isinstance(
+            DataFrameSchema.get_backend(pl.DataFrame({"a": [1]})),
+            NativeDataFrameSchemaBackend,
+        )
+    finally:
+        register_polars_backends.cache_clear()
+        DataFrameSchema.BACKEND_REGISTRY.clear()
+        set_config(use_narwhals_backend=original)
+        DataFrameSchema.get_backend(pl.DataFrame({"a": [1]}))

--- a/tests/pyspark/test_pyspark_narwhals_register.py
+++ b/tests/pyspark/test_pyspark_narwhals_register.py
@@ -63,7 +63,7 @@ def test_pyspark_narwhals_activated_when_opted_in(monkeypatch, request):
 
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
     register_pyspark_backends.cache_clear()
-    register_pyspark_backends()
+    register_pyspark_backends(use_narwhals_backend=True)
 
     # Assert all three backends are registered with their narwhals implementations
     backend = PySparkDataFrameSchema.get_backend(
@@ -105,7 +105,7 @@ def test_pyspark_native_unchanged_when_flag_off(monkeypatch, request):
 
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", False)
     register_pyspark_backends.cache_clear()
-    register_pyspark_backends()
+    register_pyspark_backends(use_narwhals_backend=False)
     backend = PySparkDataFrameSchema.get_backend(
         check_type=pyspark_sql.DataFrame
     )
@@ -150,7 +150,7 @@ def test_pyspark_connect_narwhals_activated_when_opted_in(
 
     monkeypatch.setattr(CONFIG, "use_narwhals_backend", True)
     register_pyspark_backends.cache_clear()
-    register_pyspark_backends()
+    register_pyspark_backends(use_narwhals_backend=True)
     backend = PySparkDataFrameSchema.get_backend(
         check_type=pyspark_connect.DataFrame
     )
@@ -160,6 +160,7 @@ def test_pyspark_connect_narwhals_activated_when_opted_in(
 def test_pyspark_register_is_idempotent():
     """Calling register_pyspark_backends() twice does not raise or corrupt state."""
     from pandera.backends.pyspark.register import register_pyspark_backends
+    from pandera.config import CONFIG
 
-    register_pyspark_backends()
-    register_pyspark_backends()
+    register_pyspark_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)
+    register_pyspark_backends(use_narwhals_backend=CONFIG.use_narwhals_backend)


### PR DESCRIPTION
## Summary
- Defer Polars backend registration to first schema use so `set_config(use_narwhals_backend=True)` works after `import pandera.polars`
- Re-register native/narwhals backends automatically when `use_narwhals_backend` changes at runtime, with a `UserWarning` if backends were already registered
- Export `pandera.set_config` and document lazy registration and runtime re-registration across the Narwhals/configuration docs

## Test plan
- [x] `pytest tests/polars/test_polars_narwhals_register.py`
- [x] `pytest tests/polars/test_polars_container.py`
- [x] `pytest tests/base/test_config.py`
- [x] Manual smoke test: `import pandera.polars as pa; pa.config.set_config(use_narwhals_backend=True); schema.validate(...)`


Made with [Cursor](https://cursor.com)