### PR TITLE
fix(polars): report concrete column name in regex coercion errors (#2363)

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -520,9 +520,22 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                         continue
 
                     if schema.coerce or col_schema.coerce:
-                        obj = getattr(col_schema.dtype, coerce_fn)(
-                            PolarsData(obj, col_schema.selector)
-                        )
+                        if getattr(col_schema, "regex", False):
+                            # Coerce each regex-matched column individually so
+                            # a coercion failure reports the concrete column
+                            # name instead of the regex pattern (issue #2363,
+                            # mirroring the check path fixed in #2221).
+                            matched_columns = get_lazyframe_column_names(
+                                obj.select(pl.col(col_schema.selector))
+                            )
+                            for matched_column in matched_columns:
+                                obj = getattr(col_schema.dtype, coerce_fn)(
+                                    PolarsData(obj, matched_column)
+                                )
+                        else:
+                            obj = getattr(col_schema.dtype, coerce_fn)(
+                                PolarsData(obj, col_schema.selector)
+                            )
         except ParserError as exc:
             error_handler.collect_error(
                 get_error_category(SchemaErrorReason.DATATYPE_COERCION),

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -617,6 +617,39 @@ def test_regex_column_name_in_error_message():
         )
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="narwhals backend does not coerce regex columns",
+    strict=True,
+)
+def test_regex_coerce_column_name_in_error_message():
+    """Regex column coercion errors must report the actual column name,
+    not the pattern (#2363, mirroring the check path fixed in #2221)."""
+    dataframe = pl.DataFrame(
+        {
+            "var_1": [0.4, 0.3, 0.9],
+            "var_2": ["0.5", "0.7", "0.8"],
+            "var_3": ["1.2", "bla", "0.2"],  # 'bla' cannot coerce to float
+        }
+    )
+    schema = pa.DataFrameSchema(
+        {
+            "var_.+": pa.Column(float, regex=True, coerce=True),
+        }
+    )
+    with pytest.raises(
+        (pa.errors.SchemaError, pa.errors.SchemaErrors)
+    ) as exc_info:
+        schema.validate(dataframe)
+    error_text = str(exc_info.value)
+    assert "var_3" in error_text, (
+        f"Expected error to name actual column 'var_3', got: {error_text}"
+    )
+    assert "^var_.+$" not in error_text, (
+        f"Error should not report the regex pattern, got: {error_text}"
+    )
+
+
 def test_regex_coerce(
     ldf_for_regex_match: pl.LazyFrame,
     ldf_schema_with_regex_name: DataFrameSchema,


### PR DESCRIPTION
Fixes #2363.

When a polars regex column with `coerce=True` fails to coerce one of its matched columns, the error reports the regex pattern and the whole schema instead of the offending column name:

```python
import pandera.polars as pa
import polars as pl

df = pl.DataFrame(
    {"var_1": [0.4, 0.3, 0.9], "var_2": ["0.5", "0.7", "0.8"], "var_3": ["1.2", "bla", "0.2"]}
)
schema = pa.DataFrameSchema({"var_.+": pa.Column(float, regex=True, coerce=True)})
schema.validate(df)
# SchemaError: Could not coerce '^var_.+$' in LazyFrame with schema Schema(...) into type Float64
```

The pandas backend names the failing column, and the polars *check* path was already fixed to do so in #2221; the *coercion* path was missed.

## Fix

In the polars container backend, coerce each regex-matched column individually (resolving the matched names with `pl.col(selector)`) instead of coercing once with the pattern as the key. A coercion failure then reports the concrete column:

```
SchemaError: Could not coerce 'var_3' in LazyFrame with schema Schema(...) into type Float64
```

Non-regex columns are unchanged.

## Tests

Added `test_regex_coerce_column_name_in_error_message`, a coercion sibling to the existing `test_regex_column_name_in_error_message` (#2221 check path). The narwhals backend does not coerce regex columns (it emits a `SchemaWarning` and reports a dtype mismatch instead), so the new test is marked `xfail(strict=True)` under `CONFIG.use_narwhals_backend`, matching the convention used throughout this test file. The native polars container suite passes (61 passed), and the test is RED on the unpatched backend (reports the pattern) and GREEN with the fix.

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
