### PR TITLE
docs: note regex engine differences between pandas and polars backends (#2349)

### DIFF
--- a/docs/source/dataframe_schemas.md
+++ b/docs/source/dataframe_schemas.md
@@ -257,6 +257,18 @@ In the case that your dataframe has multiple columns that share common
 statistical properties, you might want to specify a regex pattern that matches
 a set of meaningfully grouped columns that have `str` names.
 
+:::{note}
+The pandas and polars validation backends use different regular expression
+engines to match column names, so the same pattern may behave differently
+depending on the backend. The pandas backend uses Python's built-in
+[`re`](https://docs.python.org/3/library/re.html) module, while the polars
+backend uses polars' native regex engine (the Rust
+[`regex`](https://docs.rs/regex/latest/regex/) crate). Patterns that rely on
+features unsupported by the Rust `regex` crate—such as look-around assertions
+and backreferences—work with the pandas backend but not with the polars
+backend. See {ref}`polars` for more details.
+:::
+
 ```{code-cell} python
 import numpy as np
 import pandas as pd

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -876,3 +876,13 @@ not yet supported with polars DataFrames.
 Here is a list of supported and unsupported features. You can
 refer to the {ref}`supported features matrix <supported-features>` to see
 which features are implemented in the polars validation backend.
+
+:::{note}
+{ref}`Column name regex matching <column-name-regex>` uses polars' native regex
+engine (the Rust [`regex`](https://docs.rs/regex/latest/regex/) crate), which
+differs from the pandas validation backend's use of Python's built-in
+[`re`](https://docs.python.org/3/library/re.html) module. Patterns relying on
+features that the Rust `regex` crate does not support—such as look-around
+assertions and backreferences—are not available when validating polars
+DataFrames.
+:::


### PR DESCRIPTION
Closes #2349.

Adds a short caveat in both the dataframe schemas guide ("Column Regex Pattern Matching") and the polars guide ("Supported and Unsupported Functionality"): the pandas backend matches column names with Python's `re`, while the polars backend uses polars' native regex engine (the Rust `regex` crate), so patterns relying on look-around or backreferences work under pandas but not polars. The two notes cross-link each other.

This follows the suggested fix in the issue. Docs-only, no code changes.