### PR TITLE
fix: isolate config context per execution context

### DIFF
--- a/pandera/config.py
+++ b/pandera/config.py
@@ -2,6 +2,7 @@
 
 import os
 from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -106,7 +107,41 @@ def _config_from_env_vars():
 
 # this config variable should be accessible globally
 CONFIG = _config_from_env_vars()
-_CONTEXT_CONFIG = copy(CONFIG)
+
+
+def _copy_config(config: PanderaConfig) -> PanderaConfig:
+    config_copy = copy(config)
+    config_copy.silenced_warnings = config.silenced_warnings.copy()
+    return config_copy
+
+
+class _ContextConfig:
+    """Context-local config proxy."""
+
+    def __init__(self, config: PanderaConfig) -> None:
+        object.__setattr__(
+            self,
+            "_config",
+            ContextVar("pandera_context_config", default=config),
+        )
+
+    def get(self) -> PanderaConfig:
+        return self._config.get()
+
+    def set(self, config: PanderaConfig):
+        return self._config.set(config)
+
+    def reset(self, token) -> None:
+        self._config.reset(token)
+
+    def __getattr__(self, name: str):
+        return getattr(self.get(), name)
+
+    def __setattr__(self, name: str, value) -> None:
+        setattr(self.get(), name, value)
+
+
+_CONTEXT_CONFIG = _ContextConfig(_copy_config(CONFIG))
 
 
 def set_config(
@@ -171,45 +206,33 @@ def config_context(
     silenced_warnings: list[str] | None = None,
 ):
     """Temporarily set pandera config options to custom settings."""
-    # Save the current state of _CONTEXT_CONFIG
-    original_validation_enabled = _CONTEXT_CONFIG.validation_enabled
-    original_validation_depth = _CONTEXT_CONFIG.validation_depth
-    original_cache_dataframe = _CONTEXT_CONFIG.cache_dataframe
-    original_keep_cached_dataframe = _CONTEXT_CONFIG.keep_cached_dataframe
-    original_use_narwhals_backend = _CONTEXT_CONFIG.use_narwhals_backend
-    original_silenced_warnings = _CONTEXT_CONFIG.silenced_warnings.copy()
+    context_config = _copy_config(_CONTEXT_CONFIG.get())
 
+    # Apply new values
+    if validation_enabled is not None:
+        context_config.validation_enabled = validation_enabled
+    if validation_depth is not None:
+        context_config.validation_depth = validation_depth
+    if cache_dataframe is not None:
+        context_config.cache_dataframe = cache_dataframe
+    if keep_cached_dataframe is not None:
+        context_config.keep_cached_dataframe = keep_cached_dataframe
+    if use_narwhals_backend is not None:
+        context_config.use_narwhals_backend = use_narwhals_backend
+    if silenced_warnings is not None:
+        context_config.silenced_warnings = silenced_warnings.copy()
+
+    token = _CONTEXT_CONFIG.set(context_config)
     try:
-        # Apply new values
-        if validation_enabled is not None:
-            _CONTEXT_CONFIG.validation_enabled = validation_enabled
-        if validation_depth is not None:
-            _CONTEXT_CONFIG.validation_depth = validation_depth
-        if cache_dataframe is not None:
-            _CONTEXT_CONFIG.cache_dataframe = cache_dataframe
-        if keep_cached_dataframe is not None:
-            _CONTEXT_CONFIG.keep_cached_dataframe = keep_cached_dataframe
-        if use_narwhals_backend is not None:
-            _CONTEXT_CONFIG.use_narwhals_backend = use_narwhals_backend
-        if silenced_warnings is not None:
-            _CONTEXT_CONFIG.silenced_warnings = silenced_warnings.copy()
-
         yield
     finally:
-        # Restore original state of _CONTEXT_CONFIG
-        _CONTEXT_CONFIG.validation_enabled = original_validation_enabled
-        _CONTEXT_CONFIG.validation_depth = original_validation_depth
-        _CONTEXT_CONFIG.cache_dataframe = original_cache_dataframe
-        _CONTEXT_CONFIG.keep_cached_dataframe = original_keep_cached_dataframe
-        _CONTEXT_CONFIG.use_narwhals_backend = original_use_narwhals_backend
-        _CONTEXT_CONFIG.silenced_warnings = original_silenced_warnings
+        _CONTEXT_CONFIG.reset(token)
 
 
 def reset_config_context(conf: PanderaConfig | None = None):
     """Reset the context configuration to the global configuration."""
 
-    global _CONTEXT_CONFIG
-    _CONTEXT_CONFIG = copy(conf or CONFIG)
+    _CONTEXT_CONFIG.set(_copy_config(conf or CONFIG))
 
 
 def get_config_global() -> PanderaConfig:
@@ -222,7 +245,7 @@ def get_config_context(
     | None = ValidationDepth.SCHEMA_AND_DATA,
 ) -> PanderaConfig:
     """Gets the configuration context."""
-    config = copy(_CONTEXT_CONFIG)
+    config = _copy_config(_CONTEXT_CONFIG.get())
 
     if config.validation_depth is None and validation_depth_default:
         config.validation_depth = validation_depth_default

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -1,8 +1,19 @@
 """Unit tests for pandera/config.py."""
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+
 import pytest
 
-from pandera.config import _CONTEXT_CONFIG, CONFIG, config_context, set_config
+from pandera.config import (
+    _CONTEXT_CONFIG,
+    CONFIG,
+    ValidationDepth,
+    config_context,
+    get_config_context,
+    reset_config_context,
+    set_config,
+)
 
 
 def test_set_config_updates_attributes():
@@ -35,6 +46,8 @@ def test_set_config_updates_attributes():
     finally:
         # Restore original values
         set_config(**original_values)
+        CONFIG.validation_depth = original_values["validation_depth"]
+        reset_config_context()
 
 
 def test_set_config_invalid_key():
@@ -146,3 +159,34 @@ def test_config_context_silenced_warnings():
     finally:
         # Restore to ensure test isolation (this shouldn't change anything)
         pass
+
+
+def test_config_context_is_thread_isolated():
+    """Concurrent config contexts should not restore another thread's state."""
+    thread_a_entered = Event()
+    thread_b_entered = Event()
+    release_thread_b = Event()
+
+    def worker_a():
+        with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+            thread_a_entered.set()
+            assert thread_b_entered.wait(timeout=5)
+        release_thread_b.set()
+
+    def worker_b():
+        assert thread_a_entered.wait(timeout=5)
+        with config_context(validation_depth=ValidationDepth.DATA_ONLY):
+            thread_b_entered.set()
+            assert release_thread_b.wait(timeout=5)
+
+    reset_config_context()
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(worker_a), pool.submit(worker_b)]
+            for future in futures:
+                future.result()
+
+        config = get_config_context(validation_depth_default=None)
+        assert config.validation_depth is None
+    finally:
+        reset_config_context()


### PR DESCRIPTION
## Summary
- store `_CONTEXT_CONFIG` in a context-local proxy backed by `ContextVar`
- make `config_context()` work on a copied config for the current execution context instead of mutating one shared global object
- add a deterministic regression test for the interleaving where one thread restores another thread's validation depth

## Testing
- `uv run python -m pytest tests/base/test_config.py tests/pandas/test_config.py tests/pandas/test_pandas_config.py tests/polars/test_polars_config.py -q`
- `uv run python -m pytest tests/polars -q`
- `uv run python -m pytest tests/base -q`
- `uv run ruff check pandera/config.py tests/base/test_config.py`
- `uv run ruff format --check pandera/config.py tests/base/test_config.py`
- `uv run python -m compileall -q pandera/config.py tests/base/test_config.py`
- `git diff --check`

Fixes #2358
