### PR TITLE
Support pydantic aliases in dataframe schemas

### DIFF
--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -24,6 +24,59 @@ from pandera.import_utils import strategy_import_error
 class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
     """A lightweight pandas DataFrame validator."""
 
+    def __init__(
+        self,
+        columns=None,
+        checks=None,
+        parsers=None,
+        index=None,
+        dtype=None,
+        coerce: bool = False,
+        strict=False,
+        name=None,
+        ordered: bool = False,
+        unique=None,
+        report_duplicates="all",
+        unique_column_names: bool = False,
+        add_missing_columns: bool = False,
+        title=None,
+        description=None,
+        metadata=None,
+        drop_invalid_rows: bool = False,
+    ) -> None:
+        super().__init__(
+            columns=columns,
+            checks=checks,
+            parsers=parsers,
+            index=index,
+            dtype=dtype,
+            coerce=coerce,
+            strict=strict,
+            name=name,
+            ordered=ordered,
+            unique=unique,
+            report_duplicates=report_duplicates,
+            unique_column_names=unique_column_names,
+            add_missing_columns=add_missing_columns,
+            title=title,
+            description=description,
+            metadata=metadata,
+            drop_invalid_rows=drop_invalid_rows,
+        )
+        if not self.columns and isinstance(
+            self.dtype, pandas_engine.PydanticModel
+        ):
+            self.columns = {
+                name: self._build_pydantic_column(name)
+                for name in self.dtype.column_names
+            }
+
+    @staticmethod
+    def _build_pydantic_column(name: str):
+        from pandera.api.pandas.components import Column
+
+        return Column(None, name=name)
+
     @_DataFrameSchema.dtype.setter  # type: ignore[attr-defined]
     def dtype(self, value: PandasDtypeInputTypes) -> None:
         """Set the dtype property."""

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -227,7 +227,9 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             _orig_coerce = schema_component.coerce
 
             try:
-                if schema.dtype is not None:
+                if schema.dtype is not None and not isinstance(
+                    schema.dtype, pandas_engine.PydanticModel
+                ):
                     # override column dtype with dataframe dtype
                     schema_component.dtype = schema.dtype  # type: ignore
 

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1410,6 +1410,19 @@ class PydanticModel(DataType):
     def __init__(self, model: builtins.type[BaseModel]) -> None:
         object.__setattr__(self, "type", model)
 
+    @property
+    def column_names(self) -> list[str]:
+        """Return pydantic field aliases, falling back to field names."""
+        if PYDANTIC_V2:
+            return [
+                field.alias or name
+                for name, field in self.type.model_fields.items()  # type: ignore[attr-defined]
+            ]
+        return [
+            field.alias or name
+            for name, field in self.type.__fields__.items()  # type: ignore[attr-defined]
+        ]
+
     def _check_column_names(
         self,
         data_container: PandasObject,
@@ -1440,11 +1453,7 @@ class PydanticModel(DataType):
                 UserWarning,
             )
 
-            if PYDANTIC_V2:
-                column_names = list(self.type.model_fields.keys())  # type: ignore[attr-defined]
-            else:
-                column_names = list(self.type.__fields__.keys())  # type: ignore[attr-defined]
-            self._check_column_names(data_container, column_names)
+            self._check_column_names(data_container, self.column_names)
             return data_container
 
         from pandera.config import (
@@ -1467,9 +1476,11 @@ class PydanticModel(DataType):
         def _coerce_row(row):
             try:
                 if PYDANTIC_V2:
-                    row = self.type.model_validate(row).model_dump()
+                    row = self.type.model_validate(row).model_dump(
+                        by_alias=True
+                    )
                 else:
-                    row = self.type.parse_obj(row).dict()
+                    row = self.type.parse_obj(row).dict(by_alias=True)
                 row["failure_cases"] = np.nan
             except ValidationError as exc:
                 row["failure_cases"] = {

--- a/tests/pandas/test_pydantic_dtype.py
+++ b/tests/pandas/test_pydantic_dtype.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import pandera.pandas as pa
 from pandera.api.pandas.array import ArraySchema
@@ -125,3 +125,47 @@ def test_pydantic_model_coerce_numbers_to_str():
         "age": [25, 30, 22],
         "city": ["New York", "London", "Paris"],
     }
+
+
+def test_pydantic_model_preserves_field_aliases_with_strict_schema():
+    """Strict schemas should accept and preserve pydantic field aliases."""
+
+    class Row(BaseModel):
+        name: str = Field(alias="Name")
+        amount: float = Field(alias="Amount in local currency")
+
+    schema = pa.DataFrameSchema(
+        dtype=PydanticModel(Row),
+        coerce=True,
+        strict=True,
+    )
+    data = pd.DataFrame(
+        {
+            "Name": ["foo", "bar"],
+            "Amount in local currency": [1.32, 3.34],
+        }
+    )
+
+    validated = schema.validate(data)
+    assert validated.columns.tolist() == [
+        "Name",
+        "Amount in local currency",
+    ]
+    pd.testing.assert_frame_equal(validated, data)
+
+
+def test_pydantic_model_validates_empty_dataframe_with_aliases():
+    """Empty dataframes should validate against aliased pydantic fields."""
+
+    class Row(BaseModel):
+        name: str = Field(alias="Name")
+        amount: float = Field(alias="Amount in local currency")
+
+    schema = pa.DataFrameSchema(dtype=PydanticModel(Row), coerce=True, strict=True)
+    data = pd.DataFrame(columns=["Name", "Amount in local currency"])
+    validated = schema.validate(data)
+    assert validated.columns.tolist() == [
+        "Name",
+        "Amount in local currency",
+    ]
+    assert validated.empty


### PR DESCRIPTION
## Summary
- preserve pydantic field aliases when row-wise dataframe validation coerces records back into a pandas dataframe
- infer placeholder schema columns for `PydanticModel` dataframe schemas so `strict=True` works with aliased inputs
- skip overriding inferred placeholder columns with the dataframe-level pydantic dtype during component validation, and add regression tests for strict + empty alias cases

## Testing
- pytest tests/pandas/test_pydantic_dtype.py -q

Fixes #1388
