### PR TITLE
fix(strategies): avoid strategy truthiness checks

### DIFF
--- a/pandera/strategies/pandas_strategies.py
+++ b/pandera/strategies/pandas_strategies.py
@@ -1241,7 +1241,7 @@ def field_element_strategy(
         constrain the values of the data in the column/index.
     :returns: ``hypothesis`` strategy.
     """
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The series strategy is a base strategy. You cannot specify the "
             "strategy argument to chain it to a parent strategy."
@@ -1568,7 +1568,7 @@ def dataframe_strategy(
             "`n_regex_columns` must be a positive integer, found: "
             f"{n_regex_columns}"
         )
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The dataframe strategy is a base strategy. You cannot specify "
             "the strategy argument to chain it to a parent strategy."
@@ -1840,7 +1840,7 @@ def multiindex_strategy(
     :returns: ``hypothesis`` strategy.
     """
 
-    if strategy:
+    if strategy is not None:
         raise BaseStrategyOnlyError(
             "The dataframe strategy is a base strategy. You cannot specify "
             "the strategy argument to chain it to a parent strategy."

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -24,10 +24,12 @@ try:
     import hypothesis
     import hypothesis.extra.numpy as npst
     import hypothesis.strategies as st
+    from hypothesis.errors import HypothesisWarning
 except ImportError:
     HAS_HYPOTHESIS = False
     hypothesis = MagicMock()
     st = MagicMock()
+    HypothesisWarning = Warning
 else:
     HAS_HYPOTHESIS = True
 
@@ -693,6 +695,25 @@ def test_multiindex_strategy(data) -> None:
         strategies.multiindex_strategy(
             data_type, strategies.pandas_dtype_strategy(data_type)
         )
+
+
+def test_base_strategy_guards_do_not_emit_hypothesis_warning() -> None:
+    data_type = cast(Any, pandas_engine.Engine.dtype(np.dtype("float64")))
+    strategy = strategies.pandas_dtype_strategy(data_type)
+
+    with catch_warnings(record=True) as warnings:
+        with pytest.raises(pa.errors.BaseStrategyOnlyError):
+            strategies.series_strategy(data_type, strategy)
+
+        with pytest.raises(pa.errors.BaseStrategyOnlyError):
+            strategies.dataframe_strategy(data_type, strategy)
+
+        with pytest.raises(pa.errors.BaseStrategyOnlyError):
+            strategies.multiindex_strategy(data_type, strategy)
+
+    assert not any(
+        issubclass(warning.category, HypothesisWarning) for warning in warnings
+    )
 
 
 def test_multiindex_example() -> None:


### PR DESCRIPTION
## Description:

Issue #2307 reported that pandas strategy entry-points still used truthiness checks on Hypothesis strategy objects, which emits `HypothesisWarning` messages when a chained strategy is supplied.

This PR replaces the three remaining `if strategy:` guards in `pandera/strategies/pandas_strategies.py` with explicit `is not None` checks.

It also adds a regression test that verifies the base strategy guards still raise `BaseStrategyOnlyError` without emitting `HypothesisWarning`.

Closes #2307.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files pandera/strategies/pandas_strategies.py tests/strategies/test_strategies.py`.
- [x] I have run focused tests in WSL using `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/strategies/test_strategies.py -k "strategy"`.

### The validation screenshots of the tests run, locally:

<img width="1269" height="131" alt="image" src="https://github.com/user-attachments/assets/f5575d25-6423-460c-aa52-1c6f28c6205b" />

<img width="1257" height="276" alt="image" src="https://github.com/user-attachments/assets/4a703d03-a369-4238-94d3-01d332276a8d" />
