### PR TITLE
ci: make codecov upload failures non-blocking

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-base-${{ runner.os }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
@@ -228,6 +229,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-pandas-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-pydantic${{ matrix.pydantic-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
@@ -297,6 +299,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-${{ matrix.extra }}-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-pydantic${{ matrix.pydantic-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
@@ -409,6 +412,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-${{ matrix.extra }}-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-polars${{ matrix.polars-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
@@ -474,6 +478,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-narwhals-backend-${{ matrix.extra }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}
@@ -528,6 +533,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: false
           flags: unit-tests-narwhals-${{ runner.os }}-py${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.PANDERA_CODECOV_TOKEN }}


### PR DESCRIPTION
## Description:

Issue #2384 reported that CI matrix jobs can fail after tests pass when the Codecov upload step hits a transient network or DNS error.

This PR sets `fail_ci_if_error: false` on the `codecov/codecov-action@v4` steps in `ci-tests.yml`.

This keeps successful test jobs green when Codecov upload fails transiently, while preserving `codecov/patch` and `codecov/project` as the actual coverage signals and keeping the existing carryforward flag behavior intact.

Closes #2384.

## Checklist:

- [x] I have kept the change limited to CI coverage upload handling.
- [x] I have run linting and formatting checks in WSL using `prek run --files .github/workflows/ci-tests.yml codecov.yml`.
- [x] I have run focused validation in WSL by parsing `.github/workflows/ci-tests.yml` and `codecov.yml` with `python -c`.