### PR TITLE
fix: register builtin checks in polars-only install (#2387)

### DIFF
--- a/pandera/__init__.py
+++ b/pandera/__init__.py
@@ -33,6 +33,12 @@ except (ImportError, ModuleNotFoundError) as err:
     else:
         raise  # Re-raise any other `ImportError` exceptions
 
+    # Register the builtin check functions (e.g. greater_than_or_equal_to,
+    # isin). Without pandas/numpy the pandas import above fails before
+    # ``_pandas_deprecated`` (which normally triggers this) is imported, so
+    # register them here too. Otherwise builtin checks raise KeyError when
+    # constructed in a polars-only install. See GH #2387.
+    import pandera.backends.base.builtin_checks  # noqa: F401
     from pandera import dtypes, typing
     from pandera.api.checks import Check
     from pandera.api.dataframe.model_components import (

--- a/pandera/backends/register_checks.py
+++ b/pandera/backends/register_checks.py
@@ -2,6 +2,36 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _load_get_backend_types_from_mro() -> Callable | None:
+    """Imports ``get_backend_types_from_mro`` once, tolerating missing pandas.
+
+    ``pandera.api.pandas.types`` imports numpy and pandas at module load, which
+    raises in environments that only install one of the disjoint extras (e.g.
+    ``pandera[polars]`` without numpy/pandas). The result is cached so the
+    import (and any failure) is attempted once rather than on every check, since
+    ``register_default_check_backends`` runs on the validation hot path and
+    Python does not cache failed imports in ``sys.modules``.
+
+    A non-pandas-absence ``ImportError`` here (e.g. a broken transitive
+    dependency or a circular-import regression) is also swallowed. If a real
+    pandas frame later surfaces a confusing "Backend not found" error, suspect
+    this import. See GH #2387.
+
+    Returns:
+        The ``get_backend_types_from_mro`` callable, or ``None`` when pandas is
+        not importable.
+    """
+    try:
+        from pandera.api.pandas.types import get_backend_types_from_mro
+    except ImportError:
+        return None
+    return get_backend_types_from_mro
+
 
 def register_default_check_backends(check_obj_cls: type) -> None:
     """Register check backends for ``check_obj_cls`` at validation time."""
@@ -37,9 +67,16 @@ def register_default_check_backends(check_obj_cls: type) -> None:
             pass
         return
 
-    from pandera.api.pandas.types import get_backend_types_from_mro
+    # Consult the pandas-like backend types first so pandas-like backends
+    # (notably ``pyspark.pandas``, whose module name starts with ``pyspark`` but
+    # uses the pandas backends) keep routing correctly. The import is guarded so
+    # pandas-free installs fall through to the native dispatch below. See #2387.
+    get_backend_types_from_mro = _load_get_backend_types_from_mro()
 
-    if get_backend_types_from_mro(check_obj_cls) is not None:
+    if (
+        get_backend_types_from_mro is not None
+        and get_backend_types_from_mro(check_obj_cls) is not None
+    ):
         from pandera.api.pandas.container import (
             DataFrameSchema as PandasDataFrameSchema,
         )

--- a/pandera/backends/register_checks.py
+++ b/pandera/backends/register_checks.py
@@ -102,7 +102,12 @@ def register_default_check_backends(check_obj_cls: type) -> None:
         )
         return
 
-    if module.startswith("pyspark"):
+    # Match ``pyspark.sql`` rather than bare ``pyspark`` so that
+    # ``pyspark.pandas`` frames (module prefix ``pyspark.pandas``) are not
+    # captured here. They route through the pandas-MRO check above when pandas
+    # is importable; narrowing keeps them from misrouting to the pyspark-sql
+    # backend in a pandas-free install where that check returns None. See #2387.
+    if module.startswith("pyspark.sql"):
         from pandera.backends.pyspark.register import (
             register_pyspark_backends,
         )

--- a/tests/core/test_register_checks.py
+++ b/tests/core/test_register_checks.py
@@ -1,0 +1,49 @@
+"""Unit tests for ``pandera.backends.register_checks``.
+
+These cover the import-guard fallback added in GH #2387 without needing a
+numpy/pandas-free environment, so they run (and report coverage) in the
+default pandas test matrix. The polars-only regression lives in
+``tests/polars/test_polars_no_pandas.py``.
+"""
+
+import builtins
+
+import pytest
+
+from pandera.backends import register_checks
+
+
+@pytest.fixture
+def clear_loader_cache():
+    """Reset the ``lru_cache`` before and after so the import is re-attempted."""
+    register_checks._load_get_backend_types_from_mro.cache_clear()
+    try:
+        yield
+    finally:
+        register_checks._load_get_backend_types_from_mro.cache_clear()
+
+
+@pytest.mark.usefixtures("clear_loader_cache")
+def test_loader_returns_callable_when_pandas_importable():
+    """With pandas present the loader returns the real callable."""
+    loader = register_checks._load_get_backend_types_from_mro()
+    assert callable(loader)
+
+
+@pytest.mark.usefixtures("clear_loader_cache")
+def test_loader_returns_none_on_import_error(monkeypatch):
+    """An ImportError importing the pandas types makes the loader return None.
+
+    Simulates the ``pandera[polars]``-only install where
+    ``pandera.api.pandas.types`` cannot be imported (GH #2387).
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pandera.api.pandas.types":
+            raise ImportError("No module named 'numpy'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert register_checks._load_get_backend_types_from_mro() is None

--- a/tests/core/test_register_checks.py
+++ b/tests/core/test_register_checks.py
@@ -47,3 +47,32 @@ def test_loader_returns_none_on_import_error(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     assert register_checks._load_get_backend_types_from_mro() is None
+
+
+def test_pyspark_pandas_does_not_route_to_pyspark_sql(monkeypatch):
+    """``pyspark.pandas`` frames must not hit the ``pyspark.sql`` dispatch.
+
+    With pandas absent the pandas-MRO check returns None, so dispatch falls
+    through to the native prefix checks. The pyspark branch matches
+    ``pyspark.sql`` (not bare ``pyspark``) so a ``pyspark.pandas`` frame falls
+    through instead of misrouting to the pyspark-sql backend. See #2387.
+    """
+    monkeypatch.setattr(
+        register_checks,
+        "_load_get_backend_types_from_mro",
+        lambda: None,
+    )
+
+    called = []
+    monkeypatch.setattr(
+        "pandera.backends.pyspark.register.register_pyspark_backends",
+        lambda *a, **k: called.append(True),
+    )
+
+    class FakePysparkPandasFrame:
+        pass
+
+    FakePysparkPandasFrame.__module__ = "pyspark.pandas.frame"
+
+    register_checks.register_default_check_backends(FakePysparkPandasFrame)
+    assert called == []

--- a/tests/polars/test_polars_no_pandas.py
+++ b/tests/polars/test_polars_no_pandas.py
@@ -1,0 +1,92 @@
+"""Regression tests for using ``pandera[polars]`` without numpy/pandas.
+
+The polars extra is disjoint from the pandas extra in ``pyproject.toml``, so the
+documented ``pip install 'pandera[polars]'`` may run where neither numpy nor
+pandas is importable. Builtin check registration must not depend on importing
+``pandera.api.pandas.types`` (which imports numpy/pandas at module load). See
+GH #2387.
+
+Like ``tests/dask/test_dask_not_installed.py`` this blocks the missing modules
+in-process and re-imports pandera under the block. A meta-path finder is used
+rather than the ``sys.modules[name] = None`` sentinel because
+``pandera/__init__.py`` only swallows an ImportError whose message starts with
+``No module named 'numpy'``; the sentinel raises a differently-worded message
+that would be re-raised.
+"""
+
+import importlib
+import importlib.abc
+import sys
+
+import pytest
+
+pytest.importorskip("polars")
+
+import polars as pl
+
+from pandera.backends.register_checks import _load_get_backend_types_from_mro
+
+
+class _BlockNumpyPandas(importlib.abc.MetaPathFinder):
+    """Meta-path finder that makes numpy and pandas look uninstalled."""
+
+    def find_spec(self, fullname, path, target=None):
+        root = fullname.split(".", 1)[0]
+        if root in ("numpy", "pandas"):
+            raise ModuleNotFoundError(f"No module named {root!r}")
+        return None
+
+
+def _drop_cached():
+    for name in list(sys.modules):
+        if name.split(".", 1)[0] in ("pandera", "numpy", "pandas"):
+            del sys.modules[name]
+
+
+@pytest.fixture
+def without_numpy_pandas():
+    """Make numpy/pandas unimportable and re-import pandera under the block.
+
+    Restores the module table and the backend-loader cache afterwards so the
+    block does not leak into the rest of the session, which has pandas.
+    """
+    saved = dict(sys.modules)
+    finder = _BlockNumpyPandas()
+    sys.meta_path.insert(0, finder)
+    _drop_cached()
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        _drop_cached()
+        sys.modules.update(saved)
+        # The loader caches None while pandas is blocked; reset it so later
+        # tests re-import the pandas backend types.
+        _load_get_backend_types_from_mro.cache_clear()
+
+
+@pytest.mark.usefixtures("without_numpy_pandas")
+def test_builtin_checks_register_without_numpy_pandas():
+    """Builtin polars checks register when numpy/pandas are not importable."""
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("pandas")
+
+    import pandera.polars as pa
+    from pandera.polars import Column, DataFrameSchema
+
+    # Constructing builtin checks must not raise KeyError (GH #2387).
+    DataFrameSchema({"a": Column(pl.Int64, pa.Check.ge(0))})
+    DataFrameSchema({"a": Column(pl.Utf8, pa.Check.isin(["x", "y"]))})
+
+
+@pytest.mark.usefixtures("without_numpy_pandas")
+def test_failing_check_reports_value_without_numpy_pandas():
+    """A failing builtin check reports the value, not a swallowed import error."""
+    import pandera.polars as pa
+    from pandera.polars import Column, DataFrameSchema
+
+    schema = DataFrameSchema({"a": Column(pl.Int64, pa.Check.ge(0))})
+    with pytest.raises(
+        pa.errors.SchemaError, match="greater_than_or_equal_to"
+    ):
+        schema.validate(pl.DataFrame({"a": [-1]}))


### PR DESCRIPTION
Fixes #2387.

## Problem

Installing pandera with only the `polars` extra (no numpy/pandas, i.e. the documented `pip install 'pandera[polars]'`) broke on 0.32.0. Constructing any builtin check now raises `KeyError` before you've validated anything:

```python
import pandera.polars as pa
import polars as pl
from pandera.polars import Column, DataFrameSchema

DataFrameSchema({"a": Column(pl.Int64, pa.Check.ge(0))})   # KeyError: 'greater_than_or_equal_to'
DataFrameSchema({"a": Column(pl.Utf8, pa.Check.isin(["x", "y"]))})  # KeyError: 'isin'
```

A custom check (a plain lambda) works, so the problem is the builtin check registry not getting populated. 0.31.1 shipped a fix titled "Fix `pandera[polars]` import without pandas", so this is the same bug coming back.

## Root cause

Builtin check functions (`greater_than_or_equal_to`, `isin`, etc.) get registered into `Check.CHECK_FUNCTION_REGISTRY` as a side effect of importing `pandera.backends.base.builtin_checks`. On a full install that happens via `pandera._pandas_deprecated`, in the pandas branch of `pandera/__init__.py`. Without numpy/pandas the `import pandas` at the top of that branch fails, the `except` fallback runs instead, and the fallback never imported `base.builtin_checks`. The registry stays empty, so `Check.ge(...)` raises `KeyError` at construction.

There's a second, related issue in `register_default_check_backends`. It imports `pandera.api.pandas.types` (which imports numpy and pandas at module load) before dispatching to the native polars/ibis/pyspark/xarray backends, so in a polars-only env that import raises before the polars branch can run.

## Fix

`pandera/__init__.py`: import `pandera.backends.base.builtin_checks` in the no-pandas fallback branch so the builtin checks register there too. That module only pulls in `re`, `typing` and `pandera.api.checks`, none of which import numpy/pandas, so it's safe without the pandas extra.

`pandera/backends/register_checks.py`: wrap the `pandera.api.pandas.types` import in `try/except ImportError`. If it fails (polars-only env) we fall through to the native polars/ibis/pyspark/xarray dispatch; if it succeeds the dispatch order is unchanged, so pandas-like backends keep routing correctly. That last point matters for `pyspark.pandas`, whose module name starts with `pyspark` but which uses the pandas backends. (My first attempt reordered the dispatch instead, which broke `pyspark.pandas` routing, hence guarding the import rather than reordering.) The import is memoized with `lru_cache` so a failing import is attempted once rather than on every check, since `register_default_check_backends` is on the validation hot path and Python doesn't cache failed imports in `sys.modules`.

## Tests

`tests/polars/test_polars_no_pandas.py` follows the same approach as `tests/dask/test_dask_not_installed.py`: it blocks numpy/pandas in-process and re-imports pandera under the block, then checks that:

- builtin checks (`ge`, `isin`) register and a schema can be built, and
- a failing builtin check reports the offending value via `SchemaError` instead of a swallowed import error.

It uses a meta-path finder rather than the `sys.modules[name] = None` sentinel, because `pandera/__init__.py` only swallows an ImportError whose message starts with `No module named 'numpy'`, and the sentinel raises a differently-worded message that would be re-raised. A fixture restores the module table and the backend-loader cache afterwards so the block doesn't leak into the rest of the session, which has pandas installed.

## Verification

- New tests pass; `tests/polars/` is green (629 passed, 4 skipped), with no leakage into the pandas suite when run together.
- `pyspark.pandas` routing is unaffected. `tests/pyspark/test_schemas_on_pyspark_pandas.py` behaves the same as on `main` (the 3 dtype-coercion / `test_schema_model` failures I saw locally also fail on a clean `main`, so they're a pyspark/pandas version issue in my env, not from this change).
- `prek run` clean (ruff, ruff-format, mypy).

## Why polars and not ibis

The package-level registration would help any pandas-free entrypoint, but in practice this only affects polars. `pandera.engines.ibis_engine` hard-imports numpy at module load, so `import pandera.ibis` can't run without numpy regardless of this fix, and an ibis-only-without-numpy test would just fail at import. The polars engine has no such import, so it's the reachable case and the one the test covers.
