### PR TITLE
fix(pandas): report differing categories in dtype mismatch error

### DIFF
--- a/pandera/backends/pandas/array.py
+++ b/pandera/backends/pandas/array.py
@@ -11,7 +11,10 @@ from pandera.backends.pandas.base import (
     PandasSchemaBackend,
     _parsed_column_values,
 )
-from pandera.backends.pandas.error_formatters import reshape_failure_cases
+from pandera.backends.pandas.error_formatters import (
+    describe_dtype_mismatch,
+    reshape_failure_cases,
+)
 from pandera.backends.utils import convert_uniquesettings
 from pandera.config import ValidationScope
 from pandera.engines.pandas_engine import Engine
@@ -454,9 +457,18 @@ class ArraySchemaBackend(PandasSchemaBackend):
                             failure_cases = str(check_obj.dtype)
                 elif not passed:
                     failure_cases = str(check_obj.dtype)
+                if not passed:
+                    # Surface differing categories when both sides collide on
+                    # the bare "category" string (issue #2051).
+                    expected_type, actual_type = describe_dtype_mismatch(
+                        schema.dtype, check_obj.dtype
+                    )
+                else:
+                    expected_type = str(schema.dtype)
+                    actual_type = str(check_obj.dtype)
                 msg = (
                     f"expected series '{check_obj.name}' to have type "
-                    f"{schema.dtype}, got {check_obj.dtype}"
+                    f"{expected_type}, got {actual_type}"
                 )
             else:
                 passed = dtype_check_results.all()

--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -7,6 +7,55 @@ import pandas as pd
 
 from pandera.errors import SchemaError
 
+# Cap how many categories are listed in a dtype-mismatch message; mirrors the
+# default ``n_failure_cases`` limit so high-cardinality categoricals don't
+# produce multi-KB error strings.
+_MAX_CATEGORIES_IN_MESSAGE = 10
+
+
+def describe_dtype_mismatch(expected_dtype, actual_dtype) -> tuple[str, str]:
+    """Describe an expected/actual dtype pair for a dtype-mismatch message.
+
+    Categorical dtypes all stringify to the bare word ``category``, so a
+    mismatch between two categoricals reads ``category, got category`` and names
+    nothing (see issue #2051). When both sides stringify identically and expose
+    ``.categories``, surface the categories on each side; when those match too,
+    surface the differing ``ordered`` flag instead. Non-colliding mismatches are
+    returned unchanged.
+    """
+    expected_str, actual_str = str(expected_dtype), str(actual_dtype)
+    if expected_str != actual_str:
+        return expected_str, actual_str
+
+    expected_categories = getattr(expected_dtype, "categories", None)
+    actual_categories = getattr(actual_dtype, "categories", None)
+    if expected_categories is None or actual_categories is None:
+        return expected_str, actual_str
+
+    def _describe(dtype, categories) -> str:
+        categories = tuple(categories)
+        if len(categories) > _MAX_CATEGORIES_IN_MESSAGE:
+            shown = ", ".join(
+                repr(c) for c in categories[:_MAX_CATEGORIES_IN_MESSAGE]
+            )
+            remaining = len(categories) - _MAX_CATEGORIES_IN_MESSAGE
+            return (
+                f"{dtype} with {len(categories)} categories "
+                f"({shown}, ... +{remaining} more)"
+            )
+        return f"{dtype} with categories {categories}"
+
+    expected_desc = _describe(expected_dtype, expected_categories)
+    actual_desc = _describe(actual_dtype, actual_categories)
+    if tuple(expected_categories) == tuple(actual_categories):
+        # Categories match on both sides, so the mismatch is the ``ordered``
+        # flag; surface it so the two descriptions differ.
+        expected_desc += (
+            f", ordered={getattr(expected_dtype, 'ordered', None)}"
+        )
+        actual_desc += f", ordered={getattr(actual_dtype, 'ordered', None)}"
+    return expected_desc, actual_desc
+
 
 def format_generic_error_message(
     parent_schema,

--- a/tests/pandas/test_errors.py
+++ b/tests/pandas/test_errors.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from pandera.backends.pandas.error_formatters import describe_dtype_mismatch
 from pandera.config import ValidationDepth, config_context
 from pandera.engines import numpy_engine, pandas_engine
 from pandera.errors import (
@@ -509,3 +510,15 @@ def test_category_dtype_error_truncates_many_categories():
     assert "category with 40 categories" in msg
     assert "+40 more" in msg
     assert "'c49'" not in msg and "'c39'" not in msg
+
+
+def test_describe_dtype_mismatch_falls_back_without_categories():
+    """Colliding dtype strings fall back to ``str()`` when categories are absent.
+
+    ``Category()`` with no categories pinned stringifies to ``category`` but
+    exposes ``categories=None``, so there is nothing to enrich the message with.
+    """
+    expected, actual = describe_dtype_mismatch(
+        Category(["a", "b"]), Category()
+    )
+    assert (expected, actual) == ("category", "category")

--- a/tests/pandas/test_errors.py
+++ b/tests/pandas/test_errors.py
@@ -26,7 +26,7 @@ from pandera.errors import (
     SchemaError,
     SchemaErrors,
 )
-from pandera.pandas import Check, Column, DataFrameSchema
+from pandera.pandas import Category, Check, Column, DataFrameSchema
 
 
 class MyError(ReducedPickleExceptionBase):
@@ -438,3 +438,74 @@ def test_validation_depth(validation_depth, expected_error):
             schema.validate(df, lazy=True)
 
     assert e.value.message == expected_error
+
+
+def test_category_dtype_error_reports_differing_categories():
+    """A categorical dtype mismatch should report the differing categories.
+
+    Both the expected and actual dtypes stringify to the bare word ``category``,
+    so the message must surface the categories on each side (see issue #2051).
+    """
+    schema = DataFrameSchema({"status": Column(Category(["a", "b", "c"]))})
+    df = pd.DataFrame(
+        {
+            "status": pd.Series(
+                ["a", "b"], dtype=pd.CategoricalDtype(["a", "b"])
+            )
+        }
+    )
+
+    with pytest.raises(SchemaError) as exc:
+        schema.validate(df)
+
+    msg = str(exc.value)
+    # The categories must appear on both sides, not the bare "category, got category".
+    assert "to have type category, got category" not in msg
+    assert "to have type category with categories ('a', 'b', 'c')" in msg
+    assert "got category with categories ('a', 'b')" in msg
+
+
+def test_category_dtype_error_reports_differing_ordered():
+    """When only ``ordered`` differs, the message should surface it.
+
+    The categories are identical, so without reporting ``ordered`` both sides
+    of the message would be byte-for-byte identical and uninformative.
+    """
+    schema = DataFrameSchema(
+        {"status": Column(Category(["a", "b"], ordered=True))}
+    )
+    df = pd.DataFrame(
+        {
+            "status": pd.Series(
+                ["a", "b"],
+                dtype=pd.CategoricalDtype(["a", "b"], ordered=False),
+            )
+        }
+    )
+
+    with pytest.raises(SchemaError) as exc:
+        schema.validate(df)
+
+    msg = str(exc.value)
+    assert "ordered=True" in msg
+    assert "ordered=False" in msg
+
+
+def test_category_dtype_error_truncates_many_categories():
+    """High-cardinality category lists are truncated to keep the message small."""
+    expected = [f"c{i}" for i in range(50)]
+    actual = [f"c{i}" for i in range(40)]
+    schema = DataFrameSchema({"status": Column(Category(expected))})
+    df = pd.DataFrame(
+        {"status": pd.Series(actual, dtype=pd.CategoricalDtype(actual))}
+    )
+
+    with pytest.raises(SchemaError) as exc:
+        schema.validate(df)
+
+    msg = str(exc.value)
+    # Counts are reported and the list is truncated rather than fully dumped.
+    assert "category with 50 categories" in msg
+    assert "category with 40 categories" in msg
+    assert "+40 more" in msg
+    assert "'c49'" not in msg and "'c39'" not in msg


### PR DESCRIPTION
Fixes #2051.

## Problem

When a categorical column fails dtype validation because its categories differ from (e.g. are a subset of) the schema's `Category(categories=...)`, the error names neither side's categories, since both stringify to the bare word `category`:

```python
import pandas as pd
from pandera.pandas import Category, Column, DataFrameSchema

schema = DataFrameSchema({"status": Column(Category(["a", "b", "c"]))})
df = pd.DataFrame({"status": pd.Series(["a", "b"], dtype=pd.CategoricalDtype(["a", "b"]))})
schema.validate(df)
# pandera.errors.SchemaError: expected series 'status' to have type category, got category
```

## Fix

Adds a `describe_dtype_mismatch` helper in `pandera/backends/pandas/error_formatters.py` (alongside the other message constructors); `ArraySchemaBackend.check_dtype` uses it on the mismatch path. When both sides stringify identically and expose `.categories`, the categories are surfaced on each side; when the categories match but `ordered` differs, the `ordered` flag is surfaced instead (otherwise both halves would read identically). High-cardinality category lists are truncated to keep messages readable. Non-categorical mismatches (e.g. `int64, got float64`) are unchanged.

After:

```
pandera.errors.SchemaError: expected series 'status' to have type category with categories ('a', 'b', 'c'), got category with categories ('a', 'b')
```

## Checklist:

- [x] I have added relevant regression test cases (`tests/pandas/test_errors.py`: differing categories, ordered-only mismatch, high-cardinality truncation).
- [x] I have run linting/formatting via `prek run --files pandera/backends/pandas/array.py pandera/backends/pandas/error_formatters.py tests/pandas/test_errors.py` (all hooks pass, including mypy).
- [x] I have run `pytest tests/pandas/test_errors.py tests/pandas/test_dtypes.py` plus the full `tests/pandas/` suite (2346 passed).

(Supersedes the stale, unmerged #2377.)
