### PR TITLE
docs: document multiple inheritance of DataFrameModel mixins (#986)

### DIFF
--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -516,6 +516,41 @@ def transform(df: DataFrame[BaseSchema]) -> DataFrame[FinalSchema]:
 transform(df)
 ```
 
+### Multiple Inheritance
+
+Multiple inheritance is also supported, making it easy to compose schemas from
+reusable "mixin" models without repeating yourself. For this to work, each of
+the base classes **must** inherit from
+{class}`~pandera.api.pandas.model.DataFrameModel`, otherwise their fields are not
+collected:
+
+```{code-cell} python
+class A(pa.DataFrameModel):
+    a: Series[int]
+
+class B(pa.DataFrameModel):
+    b: Series[int]
+
+class C(A, B):
+    c: Series[int]
+
+C.to_schema()
+```
+
+If a base class does not inherit from `DataFrameModel`, its fields are not
+recognized and a `KeyError` is raised when calling
+{func}`~pandera.api.pandas.model.DataFrameModel.to_schema`:
+
+```python
+class A:  # not a DataFrameModel!
+    a: Series[int]
+
+class C(pa.DataFrameModel, A):
+    c: Series[int]
+
+C.to_schema()  # raises KeyError: 'a'
+```
+
 (schema-model-config)=
 
 ## Config

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -600,6 +600,43 @@ def test_inherit_dataframemodel_fields() -> None:
     assert expected == Child.to_schema()
 
 
+def test_inherit_dataframemodel_fields_multiple() -> None:
+    """Test that fields are inherited via multiple inheritance of mixins.
+
+    Each base class must inherit from ``DataFrameModel`` for its fields to be
+    collected (see the "Multiple Inheritance" docs section). Mixing in a plain
+    class whose fields are not collected raises a ``KeyError``.
+    """
+
+    class A(pa.DataFrameModel):
+        a: Series[int]
+
+    class B(pa.DataFrameModel):
+        b: Series[int]
+
+    class C(A, B):
+        c: Series[int]
+
+    expected = pa.DataFrameSchema(
+        name="C",
+        columns={
+            "a": pa.Column(int),
+            "b": pa.Column(int),
+            "c": pa.Column(int),
+        },
+    )
+    assert expected == C.to_schema()
+
+    class PlainMixin:  # does not inherit from DataFrameModel
+        d: Series[int]
+
+    class D(pa.DataFrameModel, PlainMixin):
+        e: Series[int]
+
+    with pytest.raises(KeyError):
+        D.to_schema()
+
+
 def test_inherit_dataframemodel_fields_alias() -> None:
     """Test that columns and index aliases are inherited."""
 


### PR DESCRIPTION
Closes #986.

Adds a "Multiple Inheritance" section to the dataframe models guide showing how to compose a schema from several `DataFrameModel` mixins, with a runnable example. It also notes that every base class has to inherit from `DataFrameModel`, since fields on a plain (non-model) base aren't collected and `to_schema()` then raises a `KeyError`.

Added a regression test in `tests/pandas/test_model.py` covering both the multi-mixin case and the plain-base case. The new test passes and the executed doc example runs cleanly.