### PR TITLE
fix: preserve xarray regex DataVar schemas across validation

### DIFF
--- a/pandera/api/base/schema.py
+++ b/pandera/api/base/schema.py
@@ -147,6 +147,12 @@ class BaseSchema(ABC):
     def __setstate__(self, state):
         self.__dict__ = state
 
+    def __copy__(self):
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        obj.__dict__ = self.__dict__.copy()
+        return obj
+
     def set_name(self, name: str) -> Self:
         """Used to set or modify the name of a base model object.
 

--- a/tests/xarray/test_dataset_schema.py
+++ b/tests/xarray/test_dataset_schema.py
@@ -666,6 +666,23 @@ class TestDatasetCheckMethods:
 class TestRegexDataVars:
     """Tests for regex-based data variable matching."""
 
+    def test_regex_schema_reuse_does_not_mutate_pattern(self):
+        pattern = r"^(t2m|temperature|temp)$"
+        schema = DatasetSchema(
+            data_vars={
+                pattern: DataVar(
+                    dtype=np.float32,
+                    dims=("x",),
+                    regex=True,
+                ),
+            },
+        )
+
+        for name in ("t2m", "temperature", "temp"):
+            ds = xr.Dataset({name: (["x"], np.arange(3, dtype=np.float32))})
+            schema.validate(ds)
+            assert list(schema.data_vars) == [pattern]
+
     def test_regex_matches_multiple_vars(self):
         ds = xr.Dataset(
             {


### PR DESCRIPTION
## Description:

Issue #2390 reports that `DataVar(regex=True)` works on the first xarray `DatasetSchema.validate()` call, but mutates the schema to the first concrete match. After that, later validations treat the first matched variable name as a literal required data variable.

This PR adds `BaseSchema.__copy__` so schema copies do not share the same `__dict__`, which keeps xarray regex `DataVar` schemas stable across validation.

It also adds a regression test that reuses the same `DatasetSchema` across multiple validations and verifies that the regex key is preserved.

Closes #2390.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `prek run --files pandera/api/base/schema.py tests/xarray/test_dataset_schema.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/xarray/test_dataset_schema.py -k "regex"`.
- [x] I have run broader xarray validation in WSL using `pytest -q tests/xarray`.

### The validation screenshots of the tests run, locally on WSL:

<img width="1272" height="731" alt="image" src="https://github.com/user-attachments/assets/3fb6194d-cb46-44bb-a899-d5f2f8eddef3" />

<img width="1262" height="727" alt="image" src="https://github.com/user-attachments/assets/5401428c-cae0-48a5-9f32-67100848755c" />

<img width="1270" height="302" alt="image" src="https://github.com/user-attachments/assets/a5ae717e-5014-4450-b23b-14702c7faa3d" />
