### PR TITLE
Raise a clear TypeError for non-DataFrame validate arguments

### DIFF
--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -111,6 +111,7 @@ class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
 
         :raises SchemaError: when ``DataFrame`` violates built-in or custom
             checks.
+        :raises TypeError: when ``check_obj`` is not a pandas DataFrame.
 
         :example:
 
@@ -195,7 +196,14 @@ class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
         lazy: bool = False,
         inplace: bool = False,
     ) -> pd.DataFrame:
-        return self.get_backend(check_obj).validate(
+        try:
+            backend = self.get_backend(check_obj)
+        except BackendNotFoundError as exc:
+            raise TypeError(
+                f"Expected a pandas DataFrame to validate, but got a value of "
+                f"type {type(check_obj).__name__!r}."
+            ) from exc
+        return backend.validate(
             check_obj,
             schema=self,
             head=head,

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -119,6 +119,18 @@ def test_dataframe_schema() -> None:
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
 
+@pytest.mark.parametrize(
+    "non_dataframe",
+    [int, 42, "hello", [1, 2, 3], (1, 2), pd.Series([1.0, 2.0]), {"a": [1.0]}],
+)
+def test_validate_non_dataframe_raises_typeerror(non_dataframe) -> None:
+    """Validating a non-DataFrame argument raises an informative TypeError
+    instead of an obscure backend-lookup error (see GH#467)."""
+    schema = DataFrameSchema({"a": Column(float)})
+    with pytest.raises(TypeError, match=r"Expected a pandas DataFrame.*type"):
+        schema.validate(non_dataframe)
+
+
 def test_dataframe_single_element_coerce() -> None:
     """Test that coercing a single element dataframe works correctly."""
     schema = DataFrameSchema({"x": Column(int, coerce=True)})


### PR DESCRIPTION
## Summary

`DataFrameSchema(...).validate(x)` with a non-DataFrame `x` previously failed with `BackendNotFoundError: Backend not found for backend, class: (DataFrameSchema, int)`, which gives the caller no useful signal about what went wrong. This raises a `TypeError` that names the offending type instead. Closes #467.

Example:

```
TypeError: Expected a pandas DataFrame to validate, but got a value of type 'int'.
```

## What changed

- `DataFrameSchema._validate`: wrap the `get_backend(check_obj)` lookup and convert `BackendNotFoundError` into a `TypeError` that names the received type.
- Documented the new `:raises TypeError:` on `DataFrameSchema.validate`.
- Added a parametrized regression test `test_validate_non_dataframe_raises_typeerror` covering `int`, `42`, `"hello"`, `[1, 2, 3]`, `(1, 2)`, a `pd.Series`, and a `dict`.

## Why TypeError, and why in `_validate`

`TypeError` is the Pythonic signal for a wrong-argument type, and pandera already raises it elsewhere; a `SchemaError` would wrongly imply the data was validated and failed. The issue explicitly allowed either.

The guard lives in `_validate` rather than `get_backend` because `BackendNotFoundError` is reused as internal control flow (caught in `register_default_backends`) and registered non-pandas backends (dask, modin) must still resolve normally. The dask path in `validate()` runs before `_validate`, so its real-DataFrame partitions are unaffected. Scope is limited to the pandas `DataFrameSchema` per the issue.

## Verification

The new test passes with the fix and fails without it. `tests/pandas/test_schemas.py` is 199 passed, 1 xfailed. `ruff check` and `ruff format` are clean.
