### PR TITLE
Report all missing required columns in lazy validation

### DIFF
--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -84,7 +84,7 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
         column_info = self.collect_column_info(check_obj, schema)
 
         core_parsers: list[tuple[Callable[..., Any], tuple[Any, ...]]] = [
-            (self.add_missing_columns, (schema, column_info)),
+            (self.add_missing_columns, (schema, column_info, lazy)),
             (self.strict_filter_columns, (schema, column_info)),
             (self.set_defaults, (schema,)),
             (self.coerce_dtype, (schema,)),
@@ -416,7 +416,11 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
     ###########
 
     def add_missing_columns(
-        self, check_obj: pd.DataFrame, schema, column_info: ColumnInfo
+        self,
+        check_obj: pd.DataFrame,
+        schema,
+        column_info: ColumnInfo,
+        lazy: bool = False,
     ):
         """Add columns that aren't in the dataframe."""
         # Add missing columns to dataframe based on 'add_missing_columns'
@@ -429,10 +433,11 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
 
         # Absent columns are required to have a default
         # value or be nullable
+        absent_column_errors = []
         for col_name in column_info.absent_column_names:
             col_schema = schema.columns[col_name]
             if pd.isna(col_schema.default) and not col_schema.nullable:
-                raise SchemaError(
+                error = SchemaError(
                     schema=schema,
                     data=check_obj,
                     message=(
@@ -444,6 +449,19 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                     check="add_missing_has_default",
                     reason_code=SchemaErrorReason.ADD_MISSING_COLUMN_NO_DEFAULT,
                 )
+                # In non-lazy mode preserve the fail-fast behavior, otherwise
+                # collect every offending column so lazy validation reports
+                # all missing required columns rather than only the first.
+                if not lazy:
+                    raise error
+                absent_column_errors.append(error)
+
+        if absent_column_errors:
+            raise SchemaErrors(
+                schema=schema,
+                schema_errors=absent_column_errors,
+                data=check_obj,
+            )
 
         # Ascertain order in which missing columns should be inserted into
         # dataframe. Be careful not to modify order of existing dataframe

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -563,6 +563,32 @@ def test_add_missing_columns_dtype():
     pd.testing.assert_frame_equal(ref_df, test_df)
 
 
+def test_add_missing_columns_reports_all_in_lazy_validation():
+    """Lazy validation should report every missing non-nullable column without
+    a default value, not only the first one.
+
+    https://github.com/unionai-oss/pandera/issues/1993
+    """
+    schema = DataFrameSchema(
+        columns={i: Column(int, nullable=False) for i in ["a", "b", "c"]},
+        strict=True,
+        add_missing_columns=True,
+    )
+    frame = pd.DataFrame(data=[[3]], columns=["b"])
+
+    with pytest.raises(errors.SchemaErrors) as exc_info:
+        schema.validate(frame, lazy=True)
+
+    failure_cases = exc_info.value.failure_cases
+    missing_columns = set(
+        failure_cases.loc[
+            failure_cases["check"] == "add_missing_has_default",
+            "failure_case",
+        ]
+    )
+    assert missing_columns == {"a", "c"}
+
+
 def test_series_schema() -> None:
     """Tests that a SeriesSchema Check behaves as expected for integers and
     strings. Tests error cases for types, duplicates, name errors, and issues


### PR DESCRIPTION
## What

Fixes #1993.

With `add_missing_columns=True`, lazy validation reports only the **first** missing required column, not all of them. Given a schema with two missing non-nullable columns without defaults (`a` and `c`), `lazy=True` surfaces only `a`:

```python
class TestSchema(pa.DataFrameModel):
    a: int = pa.Field(ge=2)
    b: str = pa.Field(isin=["x", "y"])
    c: bool = pa.Field()
    class Config:
        strict = True
        coerce = True
        add_missing_columns = True

TestSchema.validate(pd.DataFrame({"b": ["x", "y", "z"]}), lazy=True)
# reports the missing 'a' (and the 'b' isin failure) but never 'c'
```

## Root cause

`DataFrameSchemaBackend.add_missing_columns` raises a `SchemaError` on the first absent non-nullable column that has no default, so the loop stops before checking the remaining columns. The `validate` pipeline already knows how to collect a plural `SchemaErrors` in lazy mode (it does so for the other core parsers), but `add_missing_columns` only ever raised a single error.

## Fix

Collect a `SchemaError` per offending column. In lazy mode, raise them together as `SchemaErrors`, which the existing pipeline expands into the report; in non-lazy mode, raise the first error immediately so the fail-fast behavior (and its single-error message) is unchanged.

## Test

Added `test_add_missing_columns_reports_all_in_lazy_validation` in `tests/pandas/test_schemas.py`, asserting that both missing columns appear in the lazy failure cases. It fails before the change (only `a` is reported) and passes after. The existing `test_add_missing_columns_order` and `test_add_missing_columns_dtype` (including the non-lazy single-error case) still pass.