### PR TITLE
fix(pandas-engine): treat an Enum annotation as a categorical dtype (#2052)

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -7,6 +7,7 @@ import builtins
 import dataclasses
 import datetime
 import decimal
+import enum
 import inspect
 import logging
 import sys
@@ -226,6 +227,10 @@ class Engine(
         try:
             return engine.Engine.dtype(cls, data_type)
         except TypeError:
+            if inspect.isclass(data_type) and issubclass(data_type, enum.Enum):
+                # treat an Enum class as a categorical type whose categories
+                # are the enum members.
+                return Category(categories=data_type)
             if is_geopandas_dtype(data_type):
                 # register geopandas datatypes
                 import pandera.engines.geopandas_engine

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -187,6 +187,36 @@ def test_invalid_annotations() -> None:
         InvalidDtype.to_schema()
 
 
+def test_enum_annotation_as_category() -> None:
+    """Test that using an Enum directly as a column annotation is treated as a
+    categorical column with categories equal to the enum members (issue #2052).
+    """
+
+    class Status(str, Enum):
+        B = "b"
+        A = "a"
+
+    class DfSchema(pa.DataFrameModel):
+        name: str
+        status: Status = pa.Field()
+
+    schema = DfSchema.to_schema()
+    column = schema.columns["status"]
+    assert str(column.dtype) == "category"
+    assert tuple(column.dtype.categories) == tuple(Status)
+
+    df = pd.DataFrame(
+        {"name": ["foo", "bar", "baz"], "status": ["a", "b", "a"]}
+    )
+    df["status"] = df["status"].astype("category")
+    DfSchema.validate(df)
+
+    invalid = pd.DataFrame({"name": ["foo"], "status": ["c"]})
+    invalid["status"] = invalid["status"].astype("category")
+    with pytest.raises(pa.errors.SchemaError):
+        DfSchema.validate(invalid)
+
+
 def test_optional_column() -> None:
     """Test that optional columns are not required."""
 


### PR DESCRIPTION
Using an `Enum` class directly as a column annotation raised `TypeError: dtype '<enum 'Status'>' not understood`:

```python
import pandera.pandas as pa
from enum import Enum

class Status(str, Enum):
    A = "a"
    B = "b"

class DfSchema(pa.DataFrameModel):
    status: Status = pa.Field()

DfSchema.to_schema()  # TypeError: dtype '<enum 'Status'>' not understood
```

The root cause is that `Engine.dtype` doesn't recognize an enum class, so the pandas engine falls through to `pd.api.types.pandas_dtype(Status)`, which raises. The fix goes in the existing `except TypeError` fallback of `Engine.dtype`: an `Enum` class is now treated as a categorical type whose categories are the enum members, so `status: Status` becomes equivalent to `pa.Category(categories=Status)`.

Added `test_enum_annotation_as_category`, which checks the resolved dtype is `category` with categories equal to the enum members, validates the repro DataFrame, and asserts an out-of-enum value raises `SchemaError`. It fails without the change and passes with it; `tests/pandas/test_model.py`, `test_dtypes.py`, and `test_model_components.py` pass.

Closes #2052.