### PR TITLE
fix(pandas): run column parsers before dataframe-level coercion

### DIFF
--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -126,7 +126,9 @@ class ColumnBackend(ArraySchemaBackend):
                 check_obj[column_name] = self._try_convert_dtype_after_fillna(
                     check_obj[column_name], schema.dtype, schema.default
                 )
-            if schema.coerce:
+            # if the column has parsers, defer coercion to the array backend,
+            # which runs parsers before coercing
+            if schema.coerce and not schema.parsers:
                 try:
                     check_obj[column_name] = self.coerce_dtype(
                         check_obj[column_name],

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -231,9 +231,17 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                     # override column dtype with dataframe dtype
                     schema_component.dtype = schema.dtype  # type: ignore
 
-                # disable coercion at the schema component level since the
-                # dataframe-level schema already coerced it.
-                schema_component.coerce = False  # type: ignore
+                if getattr(schema_component, "parsers", None):
+                    # coercion of components with parsers is deferred to
+                    # component-level validation so that parsers run before
+                    # coercion: propagate dataframe-level coercion.
+                    schema_component.coerce = (  # type: ignore
+                        schema_component.coerce or schema.coerce
+                    )
+                else:
+                    # disable coercion at the schema component level since the
+                    # dataframe-level schema already coerced it.
+                    schema_component.coerce = False  # type: ignore
 
                 result = schema_component.validate(
                     check_obj, lazy=lazy, inplace=True
@@ -405,13 +413,6 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             ) and col_name not in column_info.absent_column_names:
                 if col.name != col_name:
                     col.name = col_name
-                if col.parsers and schema.coerce and not col.coerce:
-                    # dataframe-level coercion of columns with parsers is
-                    # deferred to column-level validation so that parsers run
-                    # before coercion: propagate schema-level coercion to a
-                    # copy of the column component.
-                    col = copy.deepcopy(col)
-                    col.coerce = True
                 schema_components.append(col)
 
         if schema.index is not None:

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -227,7 +227,7 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 schema_component.__dict__ = schema_component.__dict__.copy()
                 if schema.dtype is not None and not isinstance(
                     schema.dtype, pandas_engine.PydanticModel
-                  ):
+                ):
                     # override column dtype with dataframe dtype
                     schema_component.dtype = schema.dtype  # type: ignore
 
@@ -405,6 +405,13 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             ) and col_name not in column_info.absent_column_names:
                 if col.name != col_name:
                     col.name = col_name
+                if col.parsers and schema.coerce and not col.coerce:
+                    # dataframe-level coercion of columns with parsers is
+                    # deferred to column-level validation so that parsers run
+                    # before coercion: propagate schema-level coercion to a
+                    # copy of the column component.
+                    col = copy.deepcopy(col)
+                    col.coerce = True
                 schema_components.append(col)
 
         if schema.index is not None:
@@ -750,8 +757,13 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
 
                 for matched_colname in matched_columns:
                     if (
-                        col_schema.coerce or schema.coerce
-                    ) and schema.dtype is None:
+                        (col_schema.coerce or schema.coerce)
+                        and schema.dtype is None
+                        # coercion of columns with parsers is deferred to
+                        # column-level validation so that parsers run before
+                        # coercion
+                        and not col_schema.parsers
+                    ):
                         _col_schema = copy.deepcopy(col_schema)
                         _col_schema.coerce = True
                         obj[matched_colname] = _try_coercion(
@@ -761,6 +773,9 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
                 (col_schema.coerce or schema.coerce)
                 and schema.dtype is None
                 and colname in obj
+                # coercion of columns with parsers is deferred to column-level
+                # validation so that parsers run before coercion
+                and not col_schema.parsers
             ):
                 _col_schema = copy.deepcopy(col_schema)
                 _col_schema.coerce = True

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -206,3 +206,57 @@ def test_parser_with_add_missing_columns():
 
     with pytest.raises(pa.errors.SchemaError, match="No `b` or `c` in"):
         Schema.validate(pd.DataFrame({"a": ["xxx"]}))
+
+
+def _clean_to_float(series: pd.Series) -> pd.Series:
+    stripped = series.astype(str).str.strip()
+    return pd.to_numeric(stripped, errors="coerce").astype(float)
+
+
+@pytest.mark.parametrize(
+    "schema_coerce,column_coerce",
+    [(True, False), (False, True), (True, True)],
+)
+def test_column_parser_with_coercion(schema_coerce, column_coerce):
+    """Column-level parsers should be applied before dtype coercion.
+
+    Regression test for
+    https://github.com/unionai-oss/pandera/issues/2047
+    """
+    df = pd.DataFrame({"col1": ["-0013123", "-0000012", "        "]})
+    schema = DataFrameSchema(
+        {
+            "col1": pa.Column(
+                float,
+                parsers=Parser(_clean_to_float),
+                nullable=True,
+                coerce=column_coerce,
+            )
+        },
+        coerce=schema_coerce,
+    )
+    validated = schema.validate(df)
+    expected = pd.Series(
+        [-13123.0, -12.0, np.nan], name="col1", dtype="float64"
+    )
+    pd.testing.assert_series_equal(validated["col1"], expected)
+
+
+def test_column_parser_with_inferred_schema_coercion():
+    """Updating an inferred schema with a parser column should validate the
+    same way as a manually defined schema (issue #2047)."""
+    df = pd.DataFrame({"col1": ["-0013123", "-0000012", "        "]})
+    schema = pa.infer_schema(df).update_columns(
+        {
+            "col1": {
+                "dtype": float,
+                "parsers": Parser(_clean_to_float),
+                "nullable": True,
+            }
+        }
+    )
+    validated = schema.validate(df)
+    expected = pd.Series(
+        [-13123.0, -12.0, np.nan], name="col1", dtype="float64"
+    )
+    pd.testing.assert_series_equal(validated["col1"], expected)

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -242,6 +242,29 @@ def test_column_parser_with_coercion(schema_coerce, column_coerce):
     pd.testing.assert_series_equal(validated["col1"], expected)
 
 
+@pytest.mark.parametrize(
+    "schema_coerce,column_coerce",
+    [(True, False), (False, True), (True, True)],
+)
+def test_column_parser_output_needs_coercion(schema_coerce, column_coerce):
+    """Coercion should still be applied to the output of column-level
+    parsers whose output does not yet have the expected dtype."""
+    df = pd.DataFrame({"col1": ["1,5", "2,5"]})
+    schema = DataFrameSchema(
+        {
+            "col1": pa.Column(
+                float,
+                parsers=Parser(lambda s: s.str.replace(",", ".")),
+                coerce=column_coerce,
+            )
+        },
+        coerce=schema_coerce,
+    )
+    validated = schema.validate(df)
+    expected = pd.Series([1.5, 2.5], name="col1", dtype="float64")
+    pd.testing.assert_series_equal(validated["col1"], expected)
+
+
 def test_column_parser_with_inferred_schema_coercion():
     """Updating an inferred schema with a parser column should validate the
     same way as a manually defined schema (issue #2047)."""


### PR DESCRIPTION
Fixes #2047

## Problem

A column parser that cleans raw data into a coercible form works when coercion is off, but fails with a `DATATYPE_COERCION` error whenever schema-level or column-level coercion is enabled. This makes schemas built via `infer_schema().update_columns(...)` (which sets `coerce=True` at the schema level) behave differently from manually defined schemas with the same columns:

```python
import pandera.pandas as pa
import pandas as pd

def clean_to_float(series: pd.Series) -> pd.Series:
    s = series.astype(str).str.strip()
    return pd.to_numeric(s, errors="coerce").astype(float)

df = pd.DataFrame({"col1": ["-0013123", "-0000012", "        "]})

# Method 1: works
schema = pa.DataFrameSchema({
    "col1": pa.Column(pa.Float, parsers=pa.Parser(clean_to_float), nullable=True),
})
schema.validate(df)

# Method 2: raises SchemaError: Error while coercing 'col1' to type float64
schema = pa.infer_schema(df).update_columns({
    "col1": {"dtype": pa.Float, "parsers": pa.Parser(clean_to_float), "nullable": True},
})
schema.validate(df)
```

Root cause: dataframe-level `coerce_dtype` runs as a core parser step in `DataFrameSchemaBackend.validate`, before column components are validated, while column-level parsers only run inside column validation. So the raw strings hit `float64` coercion before the parser can clean them. This contradicts the documented order in the parsers docs (parsing happens before checks) and the intent of the existing `test_parser_with_coercion`, which only covers dataframe-level parsers.

The bug is broader than the issue's repro: `pa.Column(float, parsers=..., coerce=True)` and `pa.DataFrameSchema({...}, coerce=True)` fail the same way.

## Fix

In `pandera/backends/pandas/container.py`:

- `_coerce_dtype_helper`: skip dataframe-level coercion for columns that have parsers (both the regex and plain branches), deferring it to column-level validation, which already applies parsers before coercing.
- `collect_schema_components`: when a deferred column is only covered by schema-level coercion (`schema.coerce=True`, `col.coerce=False`), append a copy of the component with `coerce=True` so the deferred coercion still happens after parsing.

Whole-dataframe dtype coercion (`schema.dtype is not None`) and index coercion are unchanged.

## Checklist:

- [x] Regression tests added in `tests/pandas/test_parsers.py` covering schema-level coercion, column-level coercion, both, and the `infer_schema().update_columns(...)` path from the issue (all fail before the fix, pass after)
- [x] Original issue repro verified: method 1 and method 2 now return identical results
- [x] `pytest tests/pandas` passes (2357 passed, 16 skipped, 4 xfailed)
- [x] `prek run --files pandera/backends/pandas/container.py tests/pandas/test_parsers.py` passes (ruff check, ruff format, mypy, codespell)
