### PR TITLE
Add PyTorch TensorDict validation backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude
 pandera/_version.py
 uv.lock
 *.db

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -491,6 +491,7 @@ configuration
 
 supported_libraries
 xarray_guide/index
+pytorch_guide/index
 integrations
 ```
 

--- a/docs/source/pytorch_guide/error_reporting.md
+++ b/docs/source/pytorch_guide/error_reporting.md
@@ -1,0 +1,64 @@
+---
+file_format: mystnb
+---
+
+(pytorch-error-reporting)=
+
+# Error Reporting
+
+Pandera raises {class}`~pandera.errors.SchemaError` for individual validation failures
+and {class}`~pandera.errors.SchemaErrors` when `lazy=True`.
+
+## Non-lazy validation (fail-fast)
+
+By default, validation stops on the first error:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={"x": pa.Tensor(dtype=torch.float32, shape=(None, 10))},
+    batch_size=(32,),
+)
+
+td = TensorDict({"x": torch.randn(16, 10)}, batch_size=[16])
+
+try:
+    schema.validate(td)
+except pa.errors.SchemaError as exc:
+    print(f"Error: {exc}")
+    print(f"Reason: {exc.reason_code}")
+```
+
+## Lazy validation
+
+Set `lazy=True` to collect all errors:
+
+```{code-cell} python
+td_invalid = TensorDict(
+    {"x": torch.randn(16, 10), "y": torch.randn(16, 10)},
+    batch_size=[16],
+)
+
+try:
+    schema.validate(td_invalid, lazy=True)
+except pa.errors.SchemaErrors as exc:
+    print(f"Found {len(exc.schema_errors)} errors")
+    for err in exc.schema_errors:
+        print(f"  - {str(err)}")
+    print(f"\nError counts: {exc.error_counts}")
+```
+
+## Error reason codes
+
+- `WRONG_DATATYPE` — tensor dtype mismatch
+- `COLUMN_NOT_IN_DATAFRAME` — missing key
+- `CHECK_ERROR` — value check failure
+
+## See also
+
+- {ref}`checks` — Check API
+- {ref}`pytorch-tensordict-schema` — TensorDictSchema
+- {ref}`lazy-validation` — general lazy validation guide

--- a/docs/source/pytorch_guide/index.md
+++ b/docs/source/pytorch_guide/index.md
@@ -1,0 +1,155 @@
+---
+file_format: mystnb
+---
+
+(pytorch-guide)=
+
+# PyTorch Tensor Data Validation
+
+[PyTorch](https://pytorch.org/) provides {class}`~torch.Tensor` objects,
+{class}`~tensordict.TensorDict` for managing collections of tensors,
+and [tensorclass][tensorclass] for typed tensor collections.
+
+Pandera validates them with the same patterns as the other dataframe backends:
+schema objects, optional {class}`~pandera.api.checks.Check` instances, and
+global {ref}`configuration <configuration>`.
+
+## Installation
+
+```bash
+pip install 'pandera[torch]'
+pip install tensordict
+```
+
+## Quick start
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.float32, shape=(None, 5)),
+    },
+    batch_size=(32,),
+)
+
+td = TensorDict(
+    {"observation": torch.randn(32, 10), "action": torch.randn(32, 5)},
+    batch_size=[32],
+)
+schema.validate(td)
+```
+
+## Supported objects
+
+{class}`~pandera.api.tensordict.container.TensorDictSchema` validates any
+tensordict tensor collection:
+
+- {class}`~tensordict.TensorDict` and any other
+  {class}`~tensordict.TensorDictBase` subclass, including lazily stacked
+  tensordicts created with {meth}`~tensordict.TensorDict.lazy_stack`.
+- [tensorclass][tensorclass] instances created with the
+  {func}`~tensordict.tensorclass` decorator.
+
+```{code-cell} python
+stacked = TensorDict.lazy_stack(
+    [
+        TensorDict({"observation": torch.randn(16, 10), "action": torch.randn(16, 5)}, batch_size=[16]),
+        TensorDict({"observation": torch.randn(16, 10), "action": torch.randn(16, 5)}, batch_size=[16]),
+    ],
+    dim=0,
+)
+
+stacked_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32),
+        "action": pa.Tensor(dtype=torch.float32),
+    },
+    batch_size=(2, 16),
+)
+stacked_schema.validate(stacked)
+```
+
+## Type Coercion
+
+Set `coerce=True` to automatically convert tensor dtypes:
+
+```{code-cell} python
+schema_coerce = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+    coerce=True,
+)
+
+# Input with wrong dtype (float64)
+td_wrong_dtype = TensorDict(
+    {"observation": torch.randn(32, 10).to(torch.float64)},
+    batch_size=[32],
+)
+
+# Dtype is automatically coerced to float32
+validated = schema_coerce.validate(td_wrong_dtype)
+assert validated["observation"].dtype == torch.float32
+```
+
+## Define a schema with a class-based model
+
+```{code-cell} python
+class RL(pa.TensorDictModel):
+    """Schema for reinforcement learning data."""
+
+    # Use PyTorch dtypes in type annotations
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+    action: torch.int64 = pa.Field(shape=(None,))
+    reward: torch.float32 = pa.Field()
+
+    class Config:
+        batch_size = (32,)
+
+# Validate using the model - schema is built automatically
+td = TensorDict(
+    {"observation": torch.randn(32, 10), "action": torch.randint(0, 4, (32,)), "reward": torch.randn(32)},
+    batch_size=[32],
+)
+RL.validate(td)
+```
+
+**Note:** Type annotations specify the dtype (e.g., `torch.float32`, `torch.int64`).
+Use {func}`~pandera.tensordict.Field` to define additional constraints like shape and checks.
+
+## Guide contents
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+tensordict_schema
+tensordict_model
+tensordict_checks
+tensordict_schema_inference
+tensordict_io
+tensordict_strategies
+error_reporting
+```
+
+- {ref}`pytorch-tensordict-schema` — validating a {class}`~tensordict.TensorDict` with `Tensor` components
+- {ref}`pytorch-tensordict-model` — class-based `TensorDictModel`
+- {ref}`pytorch-checks` — checks, parsers, and lazy validation
+- {ref}`pytorch-tensordict-inference` — infer schemas from data automatically
+- {ref}`pytorch-tensordict-io` — save/load schemas with YAML/JSON
+- {ref}`pytorch-tensordict-strategies` — generate synthetic data with Hypothesis
+- {ref}`pytorch-error-reporting` — `SchemaError` / `SchemaErrors`, lazy validation, and failure cases
+
+## See also
+
+- {ref}`supported-dataframe-libraries` — other backends
+- {ref}`checks` — general `Check` behaviour
+- {ref}`lazy-validation` — `lazy=True` and `SchemaErrors`
+- {ref}`configuration` — `ValidationDepth` and environment variables
+
+[tensorclass]: https://docs.pytorch.org/tensordict/stable/reference/tensorclass.html

--- a/docs/source/pytorch_guide/tensordict_checks.md
+++ b/docs/source/pytorch_guide/tensordict_checks.md
@@ -1,0 +1,73 @@
+---
+file_format: mystnb
+---
+
+(pytorch-checks)=
+
+# Checks and Lazy Validation
+
+Use {class}`~pandera.api.checks.Check` to validate tensor values.
+
+## Apply checks to Tensor components
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+from pandera import Check
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "values": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=[Check.greater_than(0.0), Check.less_than(1.0)],
+        ),
+    },
+    batch_size=(10,),
+)
+
+td = TensorDict(
+    {"values": torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95])},
+    batch_size=[10],
+)
+validated = schema.validate(td)
+```
+
+## Lazy validation
+
+Set `lazy=True` to collect all errors:
+
+```{code-cell} python
+td_invalid = TensorDict(
+    {"values": torch.tensor([-0.1, 0.2, 0.3, 10.0, 0.5])},
+    batch_size=[5],
+)
+
+try:
+    schema.validate(td_invalid, lazy=True)
+except pa.errors.SchemaErrors as exc:
+    print(f"Found {len(exc.schema_errors)} errors")
+    print(exc)
+```
+
+## Available checks
+
+Standard pandera checks work with tensor data:
+
+- {func}`~pandera.api.checks.Check.greater_than`
+- {func}`~pandera.api.checks.Check.less_than`
+- {func}`~pandera.api.checks.Check.greater_than_or_equal_to`
+- {func}`~pandera.api.checks.Check.less_than_or_equal_to`
+- {func}`~pandera.api.checks.Check.in_range`
+- {func}`~pandera.api.checks.Check.isin`
+- {func}`~pandera.api.checks.Check.notin`
+- {func}`~pandera.api.checks.Check.str_matches`
+- {func}`~pandera.api.checks.Check.str_contains`
+- {func}`~pandera.api.checks.Check.str_startswith`
+- {func}`~pandera.api.checks.Check.str_endswith`
+
+## See also
+
+- {ref}`checks` — full Check API reference
+- {ref}`pytorch-error-reporting` — error handling

--- a/docs/source/pytorch_guide/tensordict_io.md
+++ b/docs/source/pytorch_guide/tensordict_io.md
@@ -1,0 +1,211 @@
+---
+file_format: mystnb
+---
+
+(pytorch-tensordict-io)=
+
+# Serialization and Deserialization
+
+Save and load TensorDict schemas using YAML or JSON, or save TensorDicts with embedded schema metadata.
+
+## Schema Serialization
+
+### YAML Format
+
+```{code-cell} python
+import torch
+from pandera import Check
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,), checks=Check.greater_than(0.0)),
+    },
+    batch_size=(32,),
+)
+
+# Save schema to YAML
+schema_yaml = pa.to_yaml(schema)
+print("YAML output preview:", schema_yaml[:150] + "...")
+
+# Load schema from YAML
+loaded_schema = pa.from_yaml(schema_yaml)
+assert loaded_schema.batch_size == schema.batch_size
+```
+
+### JSON Format
+
+```{code-cell} python
+import json
+import torch
+from pandera import Check
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+)
+
+# Serialize to JSON string
+json_str = pa.to_json(schema)
+print("JSON output preview:", json_str[:150] + "...")
+
+# Deserialize from JSON string
+loaded_schema = pa.from_json(json_str)
+```
+
+## File I/O
+
+Save schemas to and load from files:
+
+```{code-cell} python
+import tempfile
+from pathlib import Path
+import torch
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+)
+
+# Save to file
+with tempfile.TemporaryDirectory() as tmpdir:
+    schema_path = Path(tmpdir) / "schema.yaml"
+    pa.to_yaml(schema, schema_path)
+
+    # Load from file
+    loaded_schema = pa.from_yaml(schema_path)
+    print("Successfully saved and loaded schema")
+```
+
+## TensorDict Saving/Loading
+
+Save TensorDicts with embedded schema metadata for data integrity:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(32,),
+)
+
+td = TensorDict({
+    "observation": torch.randn(32, 10),
+    "action": torch.randint(0, 5, (32,)),
+}, batch_size=[32])
+
+# Save with schema metadata
+import tempfile
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path = f"{tmpdir}/rl_batch.pt"
+    pa.save(schema, td, save_path)
+
+    # Load and validate automatically
+    loaded_td = pa.load(save_path)
+    print(f"Loaded batch size: {loaded_td.batch_size}")
+```
+
+## Use Cases
+
+### 1. Data Pipeline Validation
+
+Save trained model inputs/outputs with schema:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+import tempfile
+
+# At training time
+training_data = TensorDict({
+    "input": torch.randn(100, 64),
+    "target": torch.randint(0, 10, (100,)),
+}, batch_size=[100])
+
+schema = pa.TensorDictSchema(
+    keys={
+        "input": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "target": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(100,),
+)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    pa.save(schema, training_data, f"{tmpdir}/training.pt")
+
+    # Later: validate before inference
+    loaded = pa.load(f"{tmpdir}/training.pt")
+    print("Successfully validated and loaded training data")
+```
+
+### 2. Configuration Management
+
+Define schemas in YAML for version control and collaboration:
+
+```{code-cell} python
+import tempfile
+from pathlib import Path
+import pandera.tensordict as pa
+import torch
+
+# Define schema programmatically
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(32,),
+)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    # Save to config file
+    config_path = Path(tmpdir) / "rl_schema.yaml"
+    pa.to_yaml(schema, config_path)
+
+    # Load from config file (e.g., in a different process)
+    loaded_schema = pa.from_yaml(config_path)
+    print("Successfully loaded schema from config")
+```
+
+### 3. Distributed Training
+
+Share schemas across workers via serialization:
+
+```{code-cell} python
+import torch
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+)
+
+# Worker 1: Serialize and send
+serialized = pa.to_json(schema)
+print("Serialized schema (JSON):", serialized[:150] + "...")
+
+# Worker 2: Deserialize and use (simulated here)
+loaded_schema = pa.from_json(serialized)
+print(f"Loaded batch_size: {loaded_schema.batch_size}")
+```
+
+## See also
+
+- {ref}`pytorch-tensordict-inference` — infer schemas from data
+- {ref}`pytorch-tensordict-schema` — manual schema definition

--- a/docs/source/pytorch_guide/tensordict_model.md
+++ b/docs/source/pytorch_guide/tensordict_model.md
@@ -1,0 +1,154 @@
+---
+file_format: mystnb
+---
+
+(pytorch-tensordict-model)=
+
+# TensorDictModel
+
+Use {class}`~pandera.api.tensordict.model.TensorDictModel` to define a class-based
+schema that maps directly to a {class}`~tensordict.TensorDict`.
+
+## Define a model
+
+```{code-cell} python
+import torch
+import pandera.tensordict as pa
+
+class RL(pa.TensorDictModel):
+    """Schema for reinforcement learning data."""
+
+    # Type annotation specifies the dtype (torch.float32, torch.int64, etc.)
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+    action: torch.int64 = pa.Field(shape=(None,))
+    reward: torch.float32 = pa.Field()
+```
+
+Use PyTorch dtypes in type annotations (e.g., `torch.float32`, `torch.int64`)
+to specify the expected data type. Use {func}`~pandera.tensordict.Field` to
+define additional constraints.
+
+## Validate with a model
+
+```{code-cell} python
+from tensordict import TensorDict
+
+td = TensorDict(
+    {"observation": torch.randn(32, 10), "action": torch.randint(0, 4, (32,)), "reward": torch.randn(32)},
+    batch_size=[32],
+)
+validated = RL.validate(td)
+```
+
+## Field configuration
+
+Use {func}`~pandera.tensordict.Field` to customize field options:
+
+- `shape`: Expected shape tuple (use `None` for variable dimensions)
+- `checks`: List of Check instances or check arguments
+- `nullable`: Whether the key can be missing
+- `default`: Default value if missing
+
+```{code-cell} python
+class RLWithConfig(pa.TensorDictModel):
+    """RL schema with field-level checks."""
+
+    observation: torch.float32 = pa.Field(
+        shape=(None, 10),
+        ge=-1.0,
+        le=1.0,
+    )
+    action: torch.int64 = pa.Field(
+        shape=(None,),
+        isin=[0, 1, 2, 3],
+    )
+    reward: torch.float32 = pa.Field(
+        gt=0.0,
+    )
+
+    class Config:
+        batch_size = (32,)
+```
+
+## Configuring the model
+
+Use a nested `Config` class to configure schema-level options:
+
+- `batch_size`: Expected batch size tuple (use `None` for variable dimensions)
+
+```{code-cell} python
+class RLWithBatchSize(pa.TensorDictModel):
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+    action: torch.int64 = pa.Field(shape=(None,))
+
+    class Config:
+        batch_size = (64,)
+```
+
+## Lazy validation
+
+Use `lazy=True` to collect all validation errors:
+
+```{code-cell} python
+from tensordict import TensorDict
+
+# Create invalid data with wrong dtypes
+td_wrong_dtype = TensorDict(
+    {"observation": torch.randn(32, 10).to(torch.float64), "action": torch.randint(0, 4, (32,)), "reward": torch.randn(32)},
+    batch_size=[32],
+)
+
+try:
+    RL.validate(td_wrong_dtype, lazy=True)
+except pa.SchemaErrors as e:
+    print(f"Found {len(e.schema_errors)} validation errors:")
+    for err in e.schema_errors:
+        print(f"  - {err.reason_code}")
+```
+
+## Type Coercion
+
+Model schemas support dtype coercion with the `coerce=True` option:
+
+```{code-cell} python
+class RLWithCoercion(pa.TensorDictModel):
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+
+    class Config:
+        batch_size = (32,)
+        coerce = True
+
+# Input with wrong dtype
+td = TensorDict(
+    {"observation": torch.randn(32, 10).to(torch.float64)},
+    batch_size=[32],
+)
+
+# Dtype is automatically coerced during validation
+validated = RLWithCoercion.validate(td)
+assert validated["observation"].dtype == torch.float32
+```
+
+## Model inheritance
+
+Models can be inherited to create more specific schemas:
+
+```{code-cell} python
+class BaseRL(pa.TensorDictModel):
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+
+    class Config:
+        batch_size = (32,)
+
+class ExtendedRL(BaseRL):
+    action: torch.int64 = pa.Field(shape=(None,))
+
+# ExtendedRL has both 'observation' and 'action'
+schema = ExtendedRL.to_schema()
+```
+
+## See also
+
+- {ref}`pytorch-tensordict-schema` — dictionary-based schema
+- {ref}`pytorch-checks` — value checks
+- {ref}`configuration` — validation configuration

--- a/docs/source/pytorch_guide/tensordict_schema.md
+++ b/docs/source/pytorch_guide/tensordict_schema.md
@@ -1,0 +1,177 @@
+---
+file_format: mystnb
+---
+
+(pytorch-tensordict-schema)=
+
+# TensorDictSchema
+
+Use {class}`~pandera.api.tensordict.container.TensorDictSchema` to validate
+{class}`~tensordict.TensorDict` objects.
+
+## Define a schema
+
+Define a dictionary-based schema with {class}`~pandera.api.tensordict.components.Tensor`
+components:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.float32, shape=(None, 5)),
+    },
+    batch_size=(32,),
+)
+```
+
+- `keys`: A dictionary mapping key names to {class}`~pandera.api.tensordict.components.Tensor` objects
+- `batch_size`: Required batch dimension sizes. Use `None` for flexible dimensions.
+
+## Validate a TensorDict
+
+```{code-cell} python
+td = TensorDict(
+    {"observation": torch.randn(32, 10), "action": torch.randn(32, 5)},
+    batch_size=[32],
+)
+validated = schema.validate(td)
+```
+
+## Lazy validation
+
+Set `lazy=True` to collect all errors instead of fail-fast. Note that TensorDict
+validates batch dimensions on creation, so we need to use matching dimensions:
+
+```{code-cell} python
+td_wrong_dtype = TensorDict(
+    {"observation": torch.randn(32, 10), "action": torch.randint(0, 5, (32,))},
+    batch_size=[32],
+)
+
+try:
+    schema.validate(td_wrong_dtype, lazy=True)
+except pa.errors.SchemaErrors as exc:
+    print(f"Total errors: {len(exc.schema_errors)}")
+    for err in exc.schema_errors:
+        print(f"  - {str(err)}")
+```
+
+## Tensor component
+
+The {class}`~pandera.api.tensordict.components.Tensor` component validates individual tensor keys.
+
+### Parameters
+
+- `dtype`: Torch dtype (e.g., `torch.float32`, `torch.int64`)
+- `shape`: Expected shape tuple. Use `None` for flexible dimensions.
+- `checks`: Optional list of {class}`~pandera.api.checks.Check` instances
+
+### Example
+
+```{code-cell} python
+from pandera import Check
+
+schema = pa.TensorDictSchema(
+    keys={
+        "values": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=[Check.greater_than(0.0), Check.less_than(1.0)],
+        ),
+    },
+    batch_size=(10,),
+)
+```
+
+## Type Coercion
+
+Set `coerce=True` to automatically convert tensor dtypes during validation:
+
+```{code-cell} python
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64),
+    },
+    batch_size=(32,),
+    coerce=True,
+)
+
+# Input has wrong dtypes (float64, int32)
+td = TensorDict(
+    {
+        "observation": torch.randn(32, 10).to(torch.float64),
+        "action": torch.randint(0, 5, (32,)).to(torch.int32),
+    },
+    batch_size=[32],
+)
+
+# Dtypes are automatically coerced to float32 and int64
+validated = schema.validate(td)
+assert validated["observation"].dtype == torch.float32
+assert validated["action"].dtype == torch.int64
+```
+
+Type coercion is applied **before** validation checks, so any dtype or shape
+constraints will be evaluated on the coerced data.
+
+## Schema Inference
+
+Automatically infer a schema from existing data using `pa.infer_schema()`:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Existing TensorDict with sample data
+sample_td = TensorDict({
+    "observation": torch.randn(100, 64),
+    "action": torch.randint(0, 4, (100,)),
+}, batch_size=[100])
+
+# Infer schema from data
+inferred_schema = pa.infer_schema(sample_td)
+```
+
+See {ref}`pytorch-tensordict-inference` for more details on schema inference.
+
+## Serialization
+
+Save and load schemas using YAML or JSON:
+
+```{code-cell} python
+import tempfile
+from pathlib import Path
+import torch
+import pandera.tensordict as pa
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    # Save to YAML
+    yaml_path = Path(tmpdir) / "schema.yaml"
+    pa.to_yaml(schema, yaml_path)
+
+    # Load from YAML
+    loaded_schema = pa.from_yaml(yaml_path)
+```
+
+See {ref}`pytorch-tensordict-io` for more details on serialization.
+
+## See also
+
+- {ref}`pytorch-tensordict-model` — class-based schema definition
+- {ref}`pytorch-checks` — checks for value validation
+- {ref}`pytorch-error-reporting` — error handling
+- {ref}`pytorch-tensordict-inference` — infer schemas from data
+- {ref}`pytorch-tensordict-io` — save/load schemas

--- a/docs/source/pytorch_guide/tensordict_schema_inference.md
+++ b/docs/source/pytorch_guide/tensordict_schema_inference.md
@@ -1,0 +1,141 @@
+---
+file_format: mystnb
+---
+
+(pytorch-tensordict-inference)=
+
+# Schema Inference
+
+Use `pa.infer_schema()` to automatically infer a schema from existing TensorDict data.
+
+```{note}
+Schema inference is useful when you have existing data and want to create a validation schema without manually specifying all the dtypes, shapes, and value ranges.
+```
+
+## Basic Usage
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Existing data with batch_size (100,)
+td = TensorDict({
+    "observation": torch.randn(100, 64),
+    "action": torch.randint(0, 4, (100,)),
+    "reward": torch.randn(100),
+}, batch_size=[100])
+
+# Infer schema from data
+schema = pa.infer_schema(td)
+print(f"Keys: {list(schema.keys.keys())}")
+print(f"Batch size: {schema.batch_size}")
+
+# Output includes inferred dtypes and shapes:
+# TensorDictSchema(keys={'observation', 'action', 'reward'}, batch_size=(100,))
+```
+
+## What Gets Inferred
+
+- **Dtypes**: Automatically detected (e.g., `torch.float32`, `torch.int64`)
+- **Shapes**: Full tensor shapes including batch dimensions
+- **Value ranges**: Min/max bounds for numeric tensors (used in range checks)
+
+## TensorClass Support
+
+Works with both `TensorDict` and `tensorclass`:
+
+```{code-cell} python
+from tensordict import tensorclass
+
+@tensorclass
+class RLData:
+    observation: torch.Tensor
+    action: torch.Tensor
+    reward: torch.Tensor
+
+tc = RLData(
+    observation=torch.randn(100, 32),
+    action=torch.randint(0, 4, (100,)),
+    reward=torch.randn(100),
+    batch_size=[100]
+)
+
+# Infer schema from tensorclass
+schema = pa.infer_schema(tc)
+print(f"Keys: {list(schema.keys.keys())}")
+```
+
+## Use Cases
+
+### 1. Quick Schema Development
+
+Start with sample data and infer the schema, then refine it:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera import Check
+
+# Step 1: Infer from sample data (batch_size=32)
+sample_td = TensorDict({
+    "observation": torch.randn(32, 10),
+    "action": torch.randint(0, 4, (32,)),
+}, batch_size=[32])
+schema = pa.infer_schema(sample_td)
+
+# Step 2: Refine the inferred schema for your needs
+schema.keys["observation"].checks.append(Check.greater_than_or_equal_to(-1.0))
+```
+
+### 2. Data Quality Validation
+
+Infer a baseline schema from healthy data, then validate new data against it:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Infer from known-good dataset (batch_size=100)
+healthy_data = TensorDict({
+    "observation": torch.randn(100, 64),
+}, batch_size=[100])
+baseline_schema = pa.infer_schema(healthy_data)
+
+# The inferred schema includes value-range checks derived from the
+# observed data, so incoming batches must stay within those bounds.
+obs_min = healthy_data["observation"].min()
+obs_max = healthy_data["observation"].max()
+new_batch = TensorDict(
+    {"observation": torch.randn(100, 64).clamp(obs_min, obs_max)},
+    batch_size=[100],
+)
+validated_batch = baseline_schema.validate(new_batch)
+```
+
+### 3. Schema Evolution
+
+Track how schemas change over time by inferring and comparing:
+
+```{code-cell} python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Infer from different dataset versions (both with batch_size=10)
+data_v1 = TensorDict({"x": torch.randn(10)}, batch_size=[10])
+schema_v1 = pa.infer_schema(data_v1)
+
+data_v2 = TensorDict({"x": torch.randn(10), "y": torch.randn(10)}, batch_size=[10])
+schema_v2 = pa.infer_schema(data_v2)
+
+# Compare key sets
+assert set(schema_v2.keys.keys()) == {"x", "y"}
+```
+
+## See also
+
+- {ref}`pytorch-tensordict-schema` — manual schema definition
+- {ref}`pytorch-tensordict-io` — saving and loading schemas

--- a/docs/source/pytorch_guide/tensordict_strategies.md
+++ b/docs/source/pytorch_guide/tensordict_strategies.md
@@ -1,0 +1,306 @@
+---
+file_format: mystnb
+---
+
+(pytorch-tensordict-strategies)=
+
+# Hypothesis Strategies
+
+Generate synthetic TensorDict data for property-based testing using
+[Hypothesis](https://hypothesis.readthedocs.io/).
+
+## Installation
+
+```bash
+pip install pandera[strategies]
+```
+
+## Basic Usage
+
+Generate valid TensorDicts from a schema:
+
+```{code-cell} python
+from hypothesis import given, settings
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera.strategies import tensordict_strategy
+
+# Define schema
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(32,),
+)
+
+# Generate and validate TensorDicts
+@given(tensordict_strategy(schema))
+@settings(max_examples=10)
+def test_policy_output(td):
+    """Property-based test for policy network."""
+    # Schema validates automatically
+    assert td["observation"].shape == (32, 10)
+    assert td["action"].dtype == torch.int64
+
+# Run the test
+test_policy_output()
+```
+
+## TensorClass Generation
+
+Generate tensorclass instances:
+
+```{code-cell} python
+from tensordict import tensorclass
+from pandera.strategies import tensorclass_strategy
+
+@tensorclass
+class RLData:
+    observation: torch.Tensor
+    action: torch.Tensor
+    reward: torch.Tensor
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+    },
+    batch_size=(128,),
+)
+
+@given(tensorclass_strategy(RLData, schema))
+@settings(max_examples=10)
+def test_tensorclass(tc):
+    assert tc.batch_size == torch.Size([128])
+    assert hasattr(tc, "observation")
+
+test_tensorclass()
+```
+
+## Custom Data Generation
+
+Combine with Hypothesis strategies for more control:
+
+```{code-cell} python
+from hypothesis import given, settings
+import torch
+import pandera.tensordict as pa
+from pandera.strategies import tensordict_strategy
+from pandera import Check
+
+# Generate only valid actions (0-3)
+schema = pa.TensorDictSchema(
+    keys={
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,), checks=Check.isin([0, 1, 2, 3])),
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+    },
+    batch_size=(32,),
+)
+
+@given(tensordict_strategy(schema))
+@settings(max_examples=10)
+def test_action_space(td):
+    """Test that actions are always in valid range."""
+    assert td["action"].max() < 4
+    assert td["action"].min() >= 0
+
+test_action_space()
+```
+
+## Integration with PyTorch Testing Patterns
+
+```{code-cell} python
+import torch
+from hypothesis import given, settings
+import pandera.tensordict as pa
+from pandera import Check
+from pandera.strategies import tensordict_strategy
+
+class PolicyNetwork(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(10, 5)
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.fc(obs)
+
+# Create the model once so every generated example runs against the
+# same weights.
+model = PolicyNetwork()
+
+# Bound the observations: value checks constrain the generated data
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),
+            checks=Check.in_range(-100.0, 100.0),
+        ),
+    },
+    batch_size=(32,),
+)
+
+@given(tensordict_strategy(schema))
+@settings(max_examples=10)
+def test_policy_model(td):
+    # Test with various inputs
+    output = model(td["observation"])
+    assert output.shape == (32, 5)
+    assert torch.isfinite(output).all()
+
+test_policy_model()
+```
+
+## Use Cases
+
+### 1. Unit Testing Models
+
+Generate diverse inputs for model testing:
+
+```{code-cell} python
+import torch
+from hypothesis import given, settings
+import pandera.tensordict as pa
+from pandera import Check
+from pandera.strategies import tensordict_strategy
+
+class PolicyNetwork(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(10, 5)
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.fc(obs)
+
+# Create the model once so every generated example runs against the
+# same weights.
+model = PolicyNetwork()
+
+# Bound the observations: value checks constrain the generated data
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),
+            checks=Check.in_range(-100.0, 100.0),
+        ),
+    },
+    batch_size=(32,),
+)
+
+@given(tensordict_strategy(schema))
+@settings(max_examples=50)
+def test_policy_model(td):
+    # Test with various inputs
+    output = model(td["observation"])
+    assert output.shape == (32, 5)
+    assert torch.isfinite(output).all()
+
+test_policy_model()
+```
+
+### 2. Property-Based Testing of RL Algorithms
+
+Test reinforcement learning algorithms with generated rollouts:
+
+```{code-cell} python
+from tensordict import tensorclass
+from hypothesis import given, settings
+import pandera.tensordict as pa
+from pandera.strategies import tensorclass_strategy
+
+@tensorclass
+class Rollout:
+    observations: torch.Tensor
+    actions: torch.Tensor
+    rewards: torch.Tensor
+    dones: torch.Tensor
+
+rollout_schema = pa.TensorDictSchema(
+    keys={
+        "observations": pa.Tensor(dtype=torch.float32, shape=(None, 17)),
+        "actions": pa.Tensor(dtype=torch.float32, shape=(None, 6)),
+        "rewards": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "dones": pa.Tensor(dtype=torch.bool, shape=(None,)),
+    },
+    batch_size=(256,),
+)
+
+class ReplayBuffer:
+    def __init__(self):
+        self.data = []
+
+    def add(self, rollout: Rollout):
+        self.data.append(rollout)
+
+    def sample(self) -> Rollout:
+        import random
+        return random.choice(self.data) if self.data else None
+
+@given(tensorclass_strategy(Rollout, rollout_schema))
+@settings(max_examples=10)
+def test_replay_buffer(rollout):
+    """Test replay buffer with generated rollouts."""
+    replay_buffer = ReplayBuffer()
+    replay_buffer.add(rollout)
+    sampled = replay_buffer.sample()
+
+    # Properties
+    assert sampled is not None
+    assert "observations" in sampled.keys()
+
+test_replay_buffer()
+```
+
+### 3. Stress Testing Data Preprocessing
+
+Test preprocessing pipelines with edge cases:
+
+```{code-cell} python
+import torch
+from hypothesis import assume, given, settings
+import pandera.tensordict as pa
+from pandera import Check
+from pandera.strategies import tensordict_strategy
+
+def preprocess(td: TensorDict) -> TensorDict:
+    """Normalize observations."""
+    td["observation"] = (td["observation"] - td["observation"].mean()) / td["observation"].std()
+    return td
+
+# Bounding values with a check also bounds the generated data
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),
+            checks=Check.in_range(-10.0, 10.0),
+        ),
+    },
+    batch_size=(32,),
+)
+
+@given(tensordict_strategy(schema))
+@settings(max_examples=50)
+def test_preprocessing(td):
+    """Test preprocessing handles various inputs."""
+    # Skip degenerate inputs where normalization is undefined
+    std = td["observation"].std()
+    assume(torch.isfinite(std) and std > 1e-2)
+
+    processed = preprocess(td)
+
+    # Check normalization
+    assert torch.allclose(processed["observation"].mean(), torch.tensor(0.0), atol=1e-2)
+
+test_preprocessing()
+```
+
+## See also
+
+- {ref}`pytorch-tensordict-schema` — define validation schemas
+- {ref}`pytorch-checks` — value constraints
+- [Hypothesis documentation](https://hypothesis.readthedocs.io/)

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -70,6 +70,8 @@ See :ref:`api-core` for full details.
 
    * - :ref:`Xarray <api-xarray>`
      - Schemas for labelled N-dimensional :mod:`xarray` arrays, datasets, and datatrees
+   * - :ref:`PyTorch <api-pytorch>`
+     - Schemas for :mod:`tensordict` TensorDict and tensorclass objects
 ```
 
 ```{toctree}
@@ -87,4 +89,5 @@ narwhals
 extensions
 errors
 xarray
+pytorch
 ```

--- a/docs/source/reference/pytorch.rst
+++ b/docs/source/reference/pytorch.rst
@@ -1,0 +1,78 @@
+.. _api-pytorch:
+
+PyTorch
+=======
+
+*New in 0.32.0*
+
+Schemas and components for validating :class:`tensordict.TensorDict` and
+:class:`tensordict.tensorclass`. Typical imports use :mod:`pandera.tensordict`;
+implementations live under :mod:`pandera.api.tensordict`.
+See :ref:`pytorch-guide` for usage examples.
+
+The :mod:`pandera.tensordict` entry point also re-exports
+:class:`~pandera.api.checks.Check` and :mod:`pandera.errors` —
+see :ref:`api-core` for those APIs.
+
+Schemas
+-------
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.api.tensordict.container.TensorDictSchema
+
+Schema components
+-----------------
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.api.tensordict.components.Tensor
+
+Declarative models
+------------------
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.api.tensordict.model.TensorDictModel
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   pandera.api.tensordict.model_components.Field
+
+Configuration
+-------------
+
+See also :ref:`api-core` for the full configuration API.
+
+.. autosummary::
+   :toctree: generated
+   :template: class.rst
+   :nosignatures:
+
+   pandera.config.ValidationDepth
+   pandera.config.ValidationScope
+
+Dtypes
+------
+
+See :ref:`api-dtypes` for :class:`~pandera.engines.tensordict_engine.DataType` and
+:class:`~pandera.engines.tensordict_engine.Engine`.
+
+See also
+--------
+
+- :ref:`pytorch-guide` — tutorials and examples
+- :ref:`api-core` — :class:`~pandera.api.checks.Check`, configuration, errors
+- :ref:`api-dtypes` — dtype engines including PyTorch
+- :ref:`api-decorators` — validation decorators

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,10 @@ dependencies:
   # narwhals extra
   - narwhals >= 1.26.0
 
+  # torch extra
+  - torch
+  - tensordict
+
   # modin extra
   - modin
   - protobuf

--- a/noxfile.py
+++ b/noxfile.py
@@ -148,7 +148,9 @@ def _testing_requirements(
     pydantic = pydantic or PYDANTIC_VERSIONS[-1]
     polars = polars or POLARS_VERSIONS[-1]
 
-    _requirements = PYPROJECT["project"]["dependencies"]
+    # copy so that += below doesn't mutate the shared PYPROJECT dict when
+    # multiple sessions run in the same nox process
+    _requirements = list(PYPROJECT["project"]["dependencies"])
     if extra is not None:
         _requirements += PYPROJECT["project"]["optional-dependencies"][extra]
     # narwhals backend tests run with polars+ibis co-installed (TEST-03).
@@ -194,6 +196,13 @@ def _testing_requirements(
             req = f"{req}, {_numpy}"
         if req == "pyarrow" or req.startswith("pyarrow "):
             req = "pyarrow >= 13"
+        if req.startswith("pyspark"):
+            # pyspark 4.2.0 leaks "Worker Monitor" python worker threads
+            # (regression of SPARK-35009), exhausting the macOS CI runner's
+            # per-process thread limit and crashing the JVM with
+            # "OutOfMemoryError: unable to create native thread". Pin until
+            # fixed upstream.
+            req = "pyspark[connect] >= 3.2.0, < 4.2"
         if req == "ibis-framework" or req.startswith("ibis-framework "):
             req = "ibis-framework[duckdb] >= 11.0.0"
         if req == "polars":

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,12 @@ EXTRAS_REQUIRING_PANDAS = frozenset(
     ]
 )
 
+EXTRAS_REQUIRING_TORCH = frozenset(
+    [
+        "torch",
+    ]
+)
+
 CI_RUN = os.environ.get("CI") == "true"
 if CI_RUN:
     print("Running on CI")
@@ -160,6 +166,12 @@ def _testing_requirements(
             PYPROJECT["project"]["optional-dependencies"]["pandas"]
         )
 
+    # torch extra requires torch and tensordict
+    if extra in EXTRAS_REQUIRING_TORCH:
+        _requirements.extend(
+            PYPROJECT["project"]["optional-dependencies"]["torch"]
+        )
+
     _requirements = list(set(_requirements))
 
     _numpy: str | None = None
@@ -221,6 +233,7 @@ DATAFRAME_EXTRAS = {
     "ibis",
     "xarray",
     "narwhals",  # TEST-03: narwhals backend runs with polars+ibis co-installed
+    "torch",
 }
 for extra in OPTIONAL_DEPENDENCIES:
     if extra == "pandas":
@@ -444,6 +457,9 @@ def docs(session: Session) -> None:
             "sphinx-build",
             *args,
         )
+
+    # Ensure torch is available for TensorDictModel doctests
+    session.run("python", "-c", "import torch")
 
     session.run("xdoctest", PACKAGE, "--quiet")
 

--- a/pandera/api/tensordict/__init__.py
+++ b/pandera/api/tensordict/__init__.py
@@ -1,0 +1,18 @@
+"""Pandera TensorDict API."""
+
+from __future__ import annotations
+
+from pandera import errors
+
+from .components import Tensor
+from .container import TensorDictSchema
+from .model import TensorDictModel
+from .model_components import Field
+
+__all__ = [
+    "Tensor",
+    "TensorDictSchema",
+    "TensorDictModel",
+    "Field",
+    "errors",
+]

--- a/pandera/api/tensordict/components.py
+++ b/pandera/api/tensordict/components.py
@@ -1,0 +1,65 @@
+"""Tensor component for TensorDict schemas."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from pandera.api.base.types import CheckList
+from pandera.engines import tensordict_engine
+
+
+class Tensor:
+    """Validate a single tensor entry in a TensorDict.
+
+    Analogous to :class:`~pandera.api.pandas.components.Column` for DataFrames
+    and :class:`~pandera.api.xarray.components.DataVar` for xarray Datasets.
+    """
+
+    def __init__(
+        self,
+        dtype: Any = None,
+        shape: tuple[int | None, ...] | None = None,
+        checks: CheckList | None = None,
+        nullable: bool = False,
+        coerce: bool = False,
+        name: str | None = None,
+        required: bool = True,
+    ) -> None:
+        """Create tensor validator.
+
+        :param dtype: PyTorch dtype (e.g., ``torch.float32``, ``torch.int64``).
+            If a string is provided, it will be converted to the corresponding
+            torch.dtype.
+        :param shape: Expected shape tuple. Use ``None`` for flexible dimensions.
+            For example, ``(None, 10)`` allows any batch size with 10 features.
+        :param checks: List of :class:`~pandera.api.checks.Check` instances for
+            value validation.
+        :param nullable: Whether the key can be missing from the TensorDict.
+        :param coerce: Whether to coerce dtype during validation.
+        :param name: Tensor key name in TensorDict. If ``None``, uses the key
+            from the schema definition.
+        :param required: Whether the tensor is required (always ``True`` for
+            now, as missing keys are handled separately).
+        """
+        self.dtype = (
+            tensordict_engine.Engine.dtype(dtype)
+            if dtype is not None
+            else None
+        )
+        self.shape = shape
+
+        # Normalize checks to a list
+        self.checks: list = []
+        if checks is not None:
+            if isinstance(checks, (list, tuple)):
+                self.checks = list(checks)
+            else:
+                self.checks = [checks]
+
+        self.nullable = nullable
+        self.coerce = coerce
+        self.name = name
+        self.required = required
+
+    def __repr__(self) -> str:
+        return f"Tensor(dtype={self.dtype}, shape={self.shape})"

--- a/pandera/api/tensordict/container.py
+++ b/pandera/api/tensordict/container.py
@@ -1,0 +1,160 @@
+"""TensorDict container specification."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from pandera.api.base.schema import BaseSchema
+from pandera.api.tensordict.components import Tensor
+from pandera.backends.base import BaseSchemaBackend
+
+
+class TensorDictSchema(BaseSchema):
+    """Validate TensorDict and tensorclass objects.
+
+    Analogous to :class:`~pandera.api.pandas.DataFrameSchema` for DataFrames
+    and :class:`~pandera.api.xarray.DatasetSchema` for xarray Datasets.
+
+    The schema accepts a ``keys`` parameter (instead of ``columns``) which is
+    more semantically appropriate for TensorDict's dictionary-like structure.
+    """
+
+    def __init__(
+        self,
+        keys: dict[str, Tensor] | None = None,
+        batch_size: tuple[int | None, ...] | None = None,
+        dtype: Any = None,
+        checks=None,
+        coerce: bool = False,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        metadata: dict | None = None,
+    ) -> None:
+        """Create TensorDict schema.
+
+        :param keys: Dictionary mapping key names to :class:`Tensor` components.
+            If a list of strings is provided, creates default Tensor components
+            for each key.
+        :param batch_size: Expected batch dimensions. Use ``None`` for flexible
+            dimensions. For example, ``(32,)`` requires exactly 32 samples,
+            while ``(None,)`` allows any batch size.
+        :param dtype: Override dtype for all tensors (optional).
+        :param checks: Schema-wide checks applied to the entire TensorDict.
+        :param coerce: Enable automatic dtype coercion during validation.
+        :param name: Name of the schema.
+        :param title: Human-readable title for the schema.
+        :param description: Detailed description of the schema.
+        :param metadata: Additional metadata associated with the schema.
+        """
+        if keys is None:
+            keys = {}
+        elif isinstance(keys, list):
+            keys = {k: Tensor() for k in keys}
+
+        super().__init__(
+            dtype=dtype,
+            checks=checks,
+            coerce=coerce,
+            name=name,
+            title=title,
+            description=description,
+            metadata=metadata,
+        )
+
+        self.keys: dict[str, Tensor] = keys
+        self.batch_size = batch_size
+
+    @staticmethod
+    def register_default_backends(check_obj_cls: type) -> None:
+        """Register default backends at validation time."""
+        from pandera.backends.tensordict.register import (
+            register_tensordict_backends,
+        )
+
+        register_tensordict_backends()
+
+    @classmethod
+    def get_backend(
+        cls, check_obj: Any | None = None, check_type: type | None = None
+    ) -> BaseSchemaBackend:
+        """Get the backend for TensorDict validation.
+
+        Overrides base class to handle tensorclass objects which have unique
+        types at runtime. We use TensorDict's backend since tensorclasses share
+        the same interface and both inherit from object in their MRO.
+        """
+        if check_obj is not None:
+            try:
+                # Check if it's a valid TensorDict/tensorclass object
+                from pandera.backends.tensordict.base import _is_tensordict
+
+                if _is_tensordict(check_obj):
+                    check_type = type(check_obj)
+                    cls.register_default_backends(check_type)
+
+                    # Try to get backend for this exact type first, walking
+                    # the MRO so any TensorDictBase subclass matches the
+                    # registered TensorDictBase backend.
+                    for _class in inspect.getmro(check_type):
+                        try:
+                            return cls.BACKEND_REGISTRY[(cls, _class)]()
+                        except KeyError:
+                            pass
+
+                    # tensorclass instances don't inherit from TensorDictBase
+                    # (each decorated class is a unique type), so fall back to
+                    # the TensorDictBase backend, which shares the interface.
+                    from tensordict import TensorDictBase, is_tensorclass
+
+                    if is_tensorclass(check_obj):
+                        try:
+                            return cls.BACKEND_REGISTRY[
+                                (cls, TensorDictBase)
+                            ]()
+                        except KeyError:
+                            pass
+            except ImportError:
+                pass
+
+        # Default fallback to base class implementation
+        return super().get_backend(check_obj)
+
+    def validate(
+        self,
+        check_obj: Any,
+        head: int | None = None,
+        tail: int | None = None,
+        sample: int | None = None,
+        random_state: int | None = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> Any:
+        """Validate a TensorDict against the schema.
+
+        :param check_obj: TensorDict or tensorclass to validate.
+        :param head: Number of leading samples to validate (not used for TensorDict).
+        :param tail: Number of trailing samples to validate (not used for TensorDict).
+        :param sample: Number of random samples to validate (not used for TensorDict).
+        :param random_state: Random seed for sampling (not used for TensorDict).
+        :param lazy: If ``True``, collect all errors instead of fail-fast.
+        :param inplace: Whether to modify object in place (not supported for TensorDict).
+        :returns: Validated TensorDict or tensorclass.
+        :raises SchemaError: If validation fails.
+        """
+        return self.get_backend(check_obj).validate(
+            check_obj=check_obj,
+            schema=self,
+            head=head,
+            tail=tail,
+            sample=sample,
+            random_state=random_state,
+            lazy=lazy,
+            inplace=inplace,
+        )
+
+    def __repr__(self) -> str:
+        """Return string representation of the schema."""
+        keys_str = ", ".join(repr(k) for k in self.keys.keys())
+        return f"TensorDictSchema(keys={{{keys_str}}}, batch_size={self.batch_size})"

--- a/pandera/api/tensordict/model.py
+++ b/pandera/api/tensordict/model.py
@@ -1,0 +1,657 @@
+"""TensorDictModel for class-based schema definitions."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import threading
+import types as types_module
+import typing
+from typing import Any, ClassVar, cast
+
+import typing_inspect
+
+# Import torch if available for TensorDict type hints in docstrings
+try:
+    import torch  # noqa: F401
+except ImportError:
+    pass
+
+from pandera.api.base.model import BaseModel
+from pandera.api.checks import Check
+from pandera.api.parsers import Parser
+from pandera.api.tensordict.components import Tensor
+from pandera.api.tensordict.container import TensorDictSchema
+from pandera.api.tensordict.model_config import BaseConfig
+from pandera.errors import SchemaInitError
+from pandera.typing import AnnotationInfo
+
+TFields = dict[str, tuple[AnnotationInfo, Any]]
+TChecks = dict[str, list[Check]]
+TParsers = dict[str, list[Parser]]
+
+_CONFIG_KEY = "Config"
+MODEL_CACHE: dict[tuple[type[TensorDictModel], int], Any] = {}
+
+
+def _is_field(name: str) -> bool:
+    return not name.startswith("_") and name != _CONFIG_KEY
+
+
+def _metaclass_dict(cls: type) -> Any:
+    """``type(cls).__dict__`` (typeshed types ``.__dict__`` on metaclass poorly)."""
+    return cast(Any, type(cls).__dict__)
+
+
+def _get_tensor_dict_class_type_hints(
+    cls: type,
+    globalns: dict[str, Any] | None = None,
+    localns: dict[str, Any] | None = None,
+    *,
+    include_extras: bool = True,
+) -> dict[str, Any]:
+    """Resolve class annotations like :func:`typing.get_type_hints`.
+
+    String annotations (PEP 563) such as ``"torch.float32"`` evaluate to
+    ``torch.dtype`` instances; :func:`typing.get_type_hints` rejects those
+    because they are not :class:`type` objects. TensorDict field annotations
+    intentionally use dtypes, so string annotations are resolved with
+    :func:`eval` like :func:`inspect.get_annotations` (same security model as
+    normal forward references).
+    """
+    # typing.get_type_hints uses these; they are not in typeshed (private API).
+    _eval_type = cast(Any, getattr(typing, "_eval_type"))
+    _strip_annotations = cast(Any, getattr(typing, "_strip_annotations"))
+
+    if getattr(cls, "__no_type_check__", None):
+        return {}
+    hints: dict[str, Any] = {}
+    for base in reversed(cls.__mro__):
+        if globalns is None:
+            base_globals = getattr(
+                sys.modules.get(base.__module__, None),
+                "__dict__",
+                {},
+            )
+        else:
+            base_globals = globalns
+        ann = base.__dict__.get("__annotations__", {})
+        if isinstance(ann, types_module.GetSetDescriptorType):
+            ann = {}
+        base_locals = dict(vars(base)) if localns is None else localns
+        if localns is None and globalns is None:
+            base_globals, base_locals = base_locals, base_globals
+        for name, value in ann.items():
+            if value is None:
+                value = type(None)
+            if isinstance(value, str):
+                value = eval(value, base_globals, base_locals)
+            else:
+                value = _eval_type(value, base_globals, base_locals)
+            hints[name] = value
+    if include_extras:
+        return hints
+    return {k: _strip_annotations(t) for k, t in hints.items()}
+
+
+class _FieldsDescriptor:
+    def __init__(self) -> None:
+        self.cache: dict[type, Any] = {}
+
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> TFields:
+        if self.cache.get(cls) is None:
+            self.cache[cls] = cls._collect_fields()
+        return self.cache[cls]
+
+
+class _SchemaDescriptor:
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> Any:
+        tid = threading.get_ident()
+        key = (cls, tid)
+        if MODEL_CACHE.get(key) is None:
+            try:
+                MODEL_CACHE[key] = cls.build_schema_()
+            except Exception as e:
+                raise AttributeError(
+                    f"'{cls.__name__}' does not implement build_schema_() and cannot "
+                    f"generate a schema. To be able to generate a schema, subclass the"
+                    "TensorDictModel."
+                ) from e
+        return MODEL_CACHE[key]
+
+
+class _ChecksDescriptor:
+    def __init__(self) -> None:
+        self.cache: dict[type, Any] = {}
+
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> TChecks:
+        if self.cache.get(cls) is None:
+            check_infos = typing.cast(
+                list[Any], cls._collect_check_infos(CHECK_KEY)
+            )
+            self.cache[cls] = cls._extract_checks(
+                check_infos, field_names=list(cls.__fields__.keys())
+            )
+        return self.cache[cls]
+
+
+class _RootCheckDescriptor:
+    def __init__(self) -> None:
+        self.cache: dict[type, Any] = {}
+
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> list[Check]:
+        if self.cache.get(cls) is None:
+            df_check_infos = cls._collect_check_infos(DATAFRAME_CHECK_KEY)
+            custom = cls._extract_df_checks(df_check_infos)
+            reg = _convert_extras_to_checks(
+                {} if cls.__extras__ is None else cls.__extras__
+            )
+            self.cache[cls] = custom + reg
+        return self.cache[cls]
+
+
+class _ParsersDescriptor:
+    def __init__(self) -> None:
+        self.cache: dict[type, Any] = {}
+
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> TParsers:
+        if self.cache.get(cls) is None:
+            parser_infos = typing.cast(
+                list[Any], cls._collect_parser_infos(PARSER_KEY)
+            )
+            self.cache[cls] = cls._extract_parsers(
+                parser_infos, field_names=list(cls.__fields__.keys())
+            )
+        return self.cache[cls]
+
+
+class _RootParsersDescriptor:
+    def __init__(self) -> None:
+        self.cache: dict[type, Any] = {}
+
+    def __get__(self, obj: Any, cls: type[TensorDictModel]) -> list[Parser]:
+        if self.cache.get(cls) is None:
+            df_parser_infos = cls._collect_parser_infos(DATAFRAME_PARSER_KEY)
+            self.cache[cls] = cls._extract_df_parsers(df_parser_infos)
+        return self.cache[cls]
+
+
+CHECK_KEY = "__check_config__"
+DATAFRAME_CHECK_KEY = "__dataframe_check_config__"
+PARSER_KEY = "__parser_config__"
+DATAFRAME_PARSER_KEY = "__dataframe_parser_config__"
+
+
+def _convert_extras_to_checks(extras: dict[str, Any]) -> list[Check]:
+    """Convert extras to checks."""
+    from pandera.api.checks import Check
+
+    checks = []
+    for name, value in extras.items():
+        if isinstance(value, tuple):
+            args, kwargs = value, {}
+        elif isinstance(value, dict):
+            args, kwargs = (), value
+        elif value is Ellipsis:
+            args, kwargs = (), {}
+        else:
+            args, kwargs = (value,), {}
+
+        checks.append(getattr(Check, name)(*args, **kwargs))
+
+    return checks
+
+
+class TensorDictModel(BaseModel):
+    """Declarative TensorDict schema using class definitions.
+
+        Fields are defined using ``pa.Field`` directly in type annotations. Use PyTorch dtypes
+    (e.g., `torch.float32`, `torch.int64`) to specify the expected data type:
+
+        Example:
+            >>> import torch
+            >>> import pandera.tensordict as pa
+
+            >>> class MySchema(pa.TensorDictModel):
+            ...     observation: torch.float32 = pa.Field(shape=(None, 10))
+            ...     action: torch.int64 = pa.Field(shape=(None,))
+            ...
+            ...     class Config:
+            ...         batch_size = (32,)
+
+            >>> schema = MySchema.to_schema()
+    """
+
+    Config: type[BaseConfig] = BaseConfig
+    __schema__ = _SchemaDescriptor()
+    __config__: type[BaseConfig] | None = None
+
+    #: Key according to `FieldInfo.name`
+    __fields__: ClassVar[TFields] = cast(TFields, _FieldsDescriptor())
+    __checks__ = cast(TChecks, _ChecksDescriptor())
+    __parsers__: TParsers = cast(TParsers, _ParsersDescriptor())
+    __root_checks__ = cast(list[Check], _RootCheckDescriptor())
+    __root_parsers__ = cast(list[Parser], _RootParsersDescriptor())
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Initialize subclass and build schema from class annotations."""
+        if _CONFIG_KEY in cls.__dict__:
+            if not hasattr(cls.Config, "name"):
+                cls.Config.name = None
+        else:
+            cls.Config = type("Config", (cls.Config,), {})
+
+        super().__init_subclass__(**kwargs)
+        hints = _get_tensor_dict_class_type_hints(cls, include_extras=True)
+
+        for fname in hints.keys():
+            if not _is_field(fname):
+                continue
+            if fname in cls.__dict__:
+                continue
+            # Auto-add Field() if not explicitly defined
+            from pandera.api.tensordict.model_components import Field
+
+            field = Field()
+            field.__set_name__(cls, fname)
+            setattr(cls, fname, field)
+
+        cls.__config__, cls.__extras__ = cls._collect_config_and_extras()
+
+    @classmethod
+    def _get_model_attrs(cls) -> dict[str, Any]:
+        """Return all attributes from the model class."""
+        bases = inspect.getmro(cls)[:-1]
+        attrs: dict[str, Any] = {}
+        for base in reversed(bases):
+            if (
+                issubclass(base, TensorDictModel)
+                and base is not TensorDictModel
+            ):
+                attrs.update(base.__dict__)
+        return attrs
+
+    @classmethod
+    def _collect_fields(cls) -> TFields:
+        """Centralize publicly named fields and their corresponding annotations."""
+        from pandera.api.tensordict.model_components import TensorDictFieldInfo
+
+        annotations = _get_tensor_dict_class_type_hints(
+            cls, include_extras=True
+        )
+        attrs = cls._get_model_attrs()
+
+        missing = []
+        for name, attr in attrs.items():
+            if inspect.isroutine(attr):
+                continue
+            if not _is_field(name):
+                annotations.pop(name, None)
+            elif name not in annotations:
+                missing.append(name)
+
+        if missing:
+            raise SchemaInitError(f"Found missing annotations: {missing}")
+
+        fields = {}
+        for field_name, annotation in annotations.items():
+            if not _is_field(field_name):
+                continue
+            field = attrs[field_name]
+
+            # Check if it's a TensorDictFieldInfo instance
+            if not isinstance(field, TensorDictFieldInfo):
+                raise SchemaInitError(
+                    f"'{field_name}' can only be assigned a 'Field', "
+                    f"not a '{type(field)}'."
+                )
+            fields[field.name] = (AnnotationInfo(annotation), field)
+        return fields
+
+    @classmethod
+    def _extract_config_options_and_extras(
+        cls,
+        config: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Extract config options and extras from Config class."""
+        from pandera.api.dataframe.model_config import (
+            BaseConfig as DataFrameBaseConfig,
+        )
+
+        config_options = {}
+        extras = {}
+
+        # Get allowed config option names
+        if hasattr(DataFrameBaseConfig, "__dataclass_fields__"):
+            config_field_names = list(
+                DataFrameBaseConfig.__dataclass_fields__.keys()
+            )
+        else:
+            config_field_names = [
+                attr
+                for attr in vars(cls.Config)
+                if not attr.startswith("_")
+                and callable(getattr(cls.Config, attr)) is False
+            ]
+
+        for name, value in vars(config).items():
+            if name in config_field_names:
+                config_options[name] = value
+            elif _is_field(name):
+                extras[name] = value
+
+        return config_options, extras
+
+    @classmethod
+    def _collect_config_and_extras(
+        cls,
+    ) -> tuple[type[BaseConfig], dict[str, Any]]:
+        """Collect config options from bases, splitting off unknown options."""
+        bases = inspect.getmro(cls)[:-1]
+        bases = tuple(
+            base for base in bases if issubclass(base, TensorDictModel)
+        )
+        root_model, *models = reversed(bases)
+
+        options, extras = cls._extract_config_options_and_extras(
+            root_model.Config
+        )
+
+        for model in models:
+            config = getattr(model, _CONFIG_KEY, {})
+            base_options, base_extras = cls._extract_config_options_and_extras(
+                config
+            )
+            options.update(base_options)
+            extras.update(base_extras)
+
+        return type("Config", (cls.Config,), options), extras
+
+    @classmethod
+    def _collect_check_infos(cls, key: str) -> list[Any]:
+        """Collect inherited check metadata from bases."""
+        bases = inspect.getmro(cls)[:-2]
+        bases = tuple(
+            base for base in bases if issubclass(base, TensorDictModel)
+        )
+
+        method_names = set()
+        check_infos = []
+        for base in bases:
+            for attr_name, attr_value in vars(base).items():
+                check_info = getattr(attr_value, key, None)
+                if not isinstance(
+                    check_info,
+                    _metaclass_dict(cls).get("Field", object).__bases__[0]
+                    if hasattr(
+                        _metaclass_dict(cls).get("Field", object),
+                        "__bases__",
+                    )
+                    else object,
+                ):
+                    continue
+                if attr_name in method_names:
+                    continue
+                method_names.add(attr_name)
+                check_infos.append(check_info)
+        return check_infos
+
+    @classmethod
+    def _collect_parser_infos(cls, key: str) -> list[Any]:
+        """Collect inherited parser metadata from bases."""
+        bases = inspect.getmro(cls)[:-2]
+        bases = tuple(
+            base for base in bases if issubclass(base, TensorDictModel)
+        )
+
+        method_names = set()
+        parser_infos = []
+        for base in bases:
+            for attr_name, attr_value in vars(base).items():
+                parser_info = getattr(attr_value, key, None)
+                if not isinstance(
+                    parser_info,
+                    _metaclass_dict(cls).get("Field", object).__bases__[0]
+                    if hasattr(
+                        _metaclass_dict(cls).get("Field", object),
+                        "__bases__",
+                    )
+                    else object,
+                ):
+                    continue
+                method_names.add(attr_name)
+                parser_infos.append(parser_info)
+        return parser_infos
+
+    @staticmethod
+    def _regex_filter(seq: Any, regexps: Any) -> set[str]:
+        """Filter items matching at least one of the regexes."""
+        import re
+
+        matched: set[str] = set()
+        for pattern_str in regexps:
+            pattern = re.compile(pattern_str)
+            matched.update(filter(pattern.match, seq))
+        return matched
+
+    @classmethod
+    def _extract_checks(
+        cls, check_infos: list[Any], field_names: list[str]
+    ) -> dict[str, list[Check]]:
+        """Collect field annotations from bases in mro reverse order."""
+        checks: dict[str, list[Check]] = {}
+        for check_info in check_infos:
+            if not hasattr(check_info, "fields"):
+                continue
+
+            check_info_fields = {
+                field.name
+                if isinstance(
+                    field,
+                    _metaclass_dict(cls).get("Field", object).__bases__[0]
+                    if hasattr(
+                        _metaclass_dict(cls).get("Field", object),
+                        "__bases__",
+                    )
+                    else object,
+                )
+                else field
+                for field in check_info.fields
+            }
+
+            matched = (
+                cls._regex_filter(field_names, check_info_fields)
+                if hasattr(check_info, "regex") and check_info.regex
+                else check_info_fields
+            )
+
+            check_ = (
+                check_info.to_check(cls)
+                if hasattr(check_info, "to_check")
+                else None
+            )
+
+            for field in matched:
+                if field not in field_names:
+                    raise SchemaInitError(
+                        f"Check {check_.name if check_ else 'unknown'} is assigned to a non-existing field '{field}'."
+                    )
+                if field not in checks:
+                    checks[field] = []
+                if check_ is not None:
+                    checks[field].append(check_)
+        return checks
+
+    @classmethod
+    def _extract_df_checks(cls, check_infos: list[Any]) -> list[Check]:
+        """Collect dataframe-level checks."""
+        result: list[Check] = []
+        for check_info in check_infos:
+            if hasattr(check_info, "to_check"):
+                check_ = check_info.to_check(cls)
+                if check_ is not None:
+                    result.append(check_)
+        return result
+
+    @classmethod
+    def _extract_parsers(
+        cls, parser_infos: list[Any], field_names: list[str]
+    ) -> dict[str, list[Parser]]:
+        """Collect field parsers from bases in mro reverse order."""
+        parsers: dict[str, list[Parser]] = {}
+        for parser_info in parser_infos:
+            if not hasattr(parser_info, "fields"):
+                continue
+
+            parser_info_fields = {
+                field.name
+                if isinstance(
+                    field,
+                    _metaclass_dict(cls).get("Field", object).__bases__[0]
+                    if hasattr(
+                        _metaclass_dict(cls).get("Field", object),
+                        "__bases__",
+                    )
+                    else object,
+                )
+                else field
+                for field in parser_info.fields
+            }
+
+            matched = (
+                cls._regex_filter(field_names, parser_info_fields)
+                if hasattr(parser_info, "regex") and parser_info.regex
+                else parser_info_fields
+            )
+
+            parser_ = (
+                parser_info.to_parser(cls)
+                if hasattr(parser_info, "to_parser")
+                else None
+            )
+
+            for field in matched:
+                if field not in field_names:
+                    raise SchemaInitError(
+                        f"Parser {parser_.name if parser_ else 'unknown'} is assigned to a non-existing field '{field}'."
+                    )
+                if field not in parsers:
+                    parsers[field] = []
+                if parser_ is not None:
+                    parsers[field].append(parser_)
+        return parsers
+
+    @classmethod
+    def _extract_df_parsers(cls, parser_infos: list[Any]) -> list[Parser]:
+        """Collect dataframe-level parsers."""
+        result: list[Parser] = []
+        for parser_info in parser_infos:
+            if hasattr(parser_info, "to_parser"):
+                parser_ = parser_info.to_parser(cls)
+                if parser_ is not None:
+                    result.append(parser_)
+        return result
+
+    @classmethod
+    def build_schema_(cls, **kwargs) -> TensorDictSchema:
+        """Create TensorDictSchema from model class.
+
+        :returns: TensorDictSchema with fields converted to Tensor components.
+        """
+        cfg = cls.__config__
+        fields = cls.__fields__
+
+        columns: dict[str, Any] = {}
+
+        for fname, (ann, fi) in fields.items():
+            # Get dtype from annotation
+            dtype = ann.arg
+
+            # Handle DataType special case - convert to torch.dtype if possible
+            if dtype is not None:
+                try:
+                    from pandera.engines.tensordict_engine import (
+                        DataType as _DataType,
+                    )
+
+                    if isinstance(dtype, type) and issubclass(
+                        dtype, _DataType
+                    ):
+                        dtype = dtype.type
+                except Exception:
+                    pass
+
+            # Get shape from Field info
+            shape = fi.shape if hasattr(fi, "shape") else None
+
+            # Build tensor kwargs
+            tensor_kwargs: dict[str, Any] = {
+                "dtype": dtype,
+                "shape": shape,
+                "name": fname,
+                "nullable": getattr(fi, "nullable", False),
+                "coerce": getattr(fi, "coerce", False),
+                "required": getattr(fi, "required", True),
+            }
+
+            if hasattr(fi, "checks") and fi.checks:
+                tensor_kwargs["checks"] = fi.checks
+
+            columns[fname] = Tensor(**tensor_kwargs)
+
+        # Get schema-level options from Config
+        batch_size: tuple[int | None, ...] | None = (
+            getattr(cfg, "batch_size", None) if cfg else None
+        )
+        schema_kwargs: dict[str, Any] = {}
+        if cfg is not None:
+            for option in ("coerce", "name", "title", "description"):
+                value = getattr(cfg, option, None)
+                if value is not None:
+                    schema_kwargs[option] = value
+
+        try:
+            return TensorDictSchema(
+                keys=columns or None,
+                batch_size=batch_size,
+                **schema_kwargs,
+            )
+        except ImportError as e:
+            raise RuntimeError("Could not import TensorDictSchema") from e
+
+    @classmethod
+    def to_schema(cls: type[TensorDictModel]) -> TensorDictSchema:
+        """Create :class:`~pandera.TensorDictSchema` from the :class:`.TensorDictModel`."""
+        return cls.__schema__
+
+    @classmethod
+    def validate(
+        cls: type[TensorDictModel],
+        check_obj: Any,
+        head: int | None = None,
+        tail: int | None = None,
+        sample: int | None = None,
+        random_state: int | None = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ) -> Any:
+        """Validate data against model schema.
+
+        :param check_obj: TensorDict or tensorclass to validate.
+        :returns: Validated data object.
+        """
+        if cls.__schema__ is not None:
+            return cls.__schema__.validate(
+                check_obj=check_obj,
+                head=head,
+                tail=tail,
+                sample=sample,
+                random_state=random_state,
+                lazy=lazy,
+                inplace=inplace,
+            )
+        raise RuntimeError("Model schema was not initialized")
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        """Validate data against model schema."""
+        return cls.validate(*args, **kwargs)

--- a/pandera/api/tensordict/model_components.py
+++ b/pandera/api/tensordict/model_components.py
@@ -1,0 +1,159 @@
+"""Field descriptors for TensorDict declarative models."""
+
+from collections.abc import Iterable
+from typing import Any, Union
+
+from pandera.api.base.model_components import to_checklist
+from pandera.api.checks import Check
+from pandera.api.dataframe.model_components import FieldInfo, _check_dispatch
+from pandera.errors import SchemaInitError
+
+CHECK_KEY = "__check_config__"
+TENSOR_CHECK_KEY = "__tensor_check_config__"
+
+
+class TensorDictFieldInfo(FieldInfo):
+    """Field metadata for :class:`TensorDictModel`."""
+
+    def __init__(
+        self,
+        *,
+        shape: tuple[int | None, ...] | None = None,
+        required: bool = True,
+        checks: Any = None,
+        parses: Any = None,
+        nullable: bool = False,
+        unique: bool = False,
+        coerce: bool = False,
+        regex: bool = False,
+        alias: Any = None,
+        check_name: bool | None = None,
+        dtype_kwargs: dict[str, Any] | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        default: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            checks=checks,
+            parses=parses,
+            nullable=nullable,
+            unique=unique,
+            coerce=coerce,
+            regex=regex,
+            alias=alias,
+            check_name=check_name,
+            dtype_kwargs=dtype_kwargs,
+            title=title,
+            description=description,
+            default=default,
+            metadata=metadata,
+        )
+        self.shape = shape
+        self.required = required
+
+    def to_tensor_kwargs(
+        self,
+        dtype: Any,
+        *,
+        optional: bool,
+        checks: Any = None,
+    ) -> dict[str, Any]:
+        """Keyword args for :class:`~pandera.api.tensordict.components.Tensor`."""
+        return {
+            "dtype": dtype,
+            "checks": to_checklist(self.checks) + to_checklist(checks),
+            "shape": self.shape,
+            "name": self.alias or self.name,
+            "title": self.title,
+            "description": self.description,
+            "nullable": self.nullable,
+            "coerce": self.coerce,
+        }
+
+
+def Field(
+    *,
+    dtype: Any = None,
+    shape: tuple[int | None, ...] | None = None,
+    eq: Any | None = None,
+    ne: Any | None = None,
+    gt: Any | None = None,
+    ge: Any | None = None,
+    lt: Any | None = None,
+    le: Any | None = None,
+    in_range: Union[
+        tuple[Any, Any],
+        tuple[Any, Any, bool, bool],
+        tuple[Any, Any, bool, bool, bool],
+        tuple[Any, Any, bool, bool, bool, bool],
+        dict[str, Any],
+        None,
+    ] = None,
+    isin: Iterable[Any] | None = None,
+    notin: Iterable[Any] | None = None,
+    no_nan: bool = False,
+    no_inf: bool = False,
+    nullable: bool = False,
+    unique: bool = False,
+    coerce: bool = False,
+    regex: bool = False,
+    ignore_na: bool = True,
+    raise_warning: bool = False,
+    n_failure_cases: int | None = None,
+    alias: Any | None = None,
+    check_name: bool | None = None,
+    dtype_kwargs: dict[str, Any] | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    default: Any | None = None,
+    metadata: dict[str, Any] | None = None,
+    required: bool = True,
+    **kwargs: Any,
+) -> Any:
+    """Field specification for TensorDict models."""
+    check_kwargs = {
+        "ignore_na": ignore_na,
+        "raise_warning": raise_warning,
+        "n_failure_cases": n_failure_cases,
+    }
+    args = locals()
+    checks = []
+
+    check_dispatch = _check_dispatch()
+    for key in kwargs:
+        if key not in check_dispatch:
+            raise SchemaInitError(
+                f"custom check '{key}' is not available. Make sure you use "
+                "pandera.extensions.register_check_method decorator to "
+                "register your custom check method."
+            )
+
+    for arg_name, check_constructor in check_dispatch.items():
+        arg_value = args.get(arg_name, kwargs.get(arg_name))
+        if arg_value is None:
+            continue
+        if isinstance(arg_value, dict):
+            check_ = check_constructor(**arg_value, **check_kwargs)
+        elif isinstance(arg_value, tuple):
+            check_ = check_constructor(*arg_value, **check_kwargs)
+        else:
+            check_ = check_constructor(arg_value, **check_kwargs)
+        checks.append(check_)
+
+    return TensorDictFieldInfo(
+        checks=checks or None,
+        nullable=nullable,
+        unique=unique,
+        coerce=coerce,
+        regex=regex,
+        check_name=check_name,
+        alias=alias,
+        title=title,
+        description=description,
+        default=default,
+        dtype_kwargs=dtype_kwargs,
+        metadata=metadata,
+        required=required,
+        shape=shape,
+    )

--- a/pandera/api/tensordict/model_config.py
+++ b/pandera/api/tensordict/model_config.py
@@ -1,0 +1,14 @@
+"""Class-based TensorDict model API configuration."""
+
+from typing import Any
+
+from pandera.api.dataframe.model_config import BaseConfig as _BaseConfig
+
+
+class BaseConfig(_BaseConfig):
+    """Define TensorDictSchema-wide options.
+
+    *new in 0.19.0*
+    """
+
+    batch_size: tuple[int, ...] | None = None

--- a/pandera/api/tensordict/types.py
+++ b/pandera/api/tensordict/types.py
@@ -1,0 +1,16 @@
+"""Type definitions for pandera tensordict integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_tensordict(obj: Any) -> bool:
+    """Check if object is a TensorDict (any TensorDictBase subclass) or a
+    tensorclass instance."""
+    try:
+        from tensordict import is_tensor_collection
+
+        return is_tensor_collection(obj)
+    except ImportError:
+        return False

--- a/pandera/backends/tensordict/__init__.py
+++ b/pandera/backends/tensordict/__init__.py
@@ -1,0 +1,1 @@
+"""Pandera TensorDict backend."""

--- a/pandera/backends/tensordict/base.py
+++ b/pandera/backends/tensordict/base.py
@@ -1,0 +1,455 @@
+"""TensorDict parsing, validation, and error-reporting backends."""
+
+import copy
+from collections import defaultdict
+from typing import Any
+
+from pandera import errors
+from pandera.api.base.error_handler import ErrorHandler, get_error_category
+from pandera.backends.base import BaseSchemaBackend, CoreCheckResult
+from pandera.errors import SchemaError, SchemaErrorReason
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+def _is_tensordict(obj: Any) -> bool:
+    """Check if object is a TensorDict (any TensorDictBase subclass, e.g.
+    LazyStackedTensorDict) or a tensorclass instance."""
+    if torch is None:
+        return False
+    try:
+        from tensordict import is_tensor_collection
+
+        return is_tensor_collection(obj)
+    except ImportError:
+        return False
+
+
+def _get_tensor(obj: Any, key: str) -> Any:
+    """Get tensor from TensorDict or tensorclass object."""
+    # For TensorDict, use __getitem__
+    try:
+        return obj[key]
+    except (KeyError, TypeError, ValueError):
+        pass
+
+    # For tensorclass, use attribute access
+    if hasattr(obj, key):
+        return getattr(obj, key)
+
+    raise KeyError(f"Key '{key}' not found in object")
+
+
+class TensorDictSchemaBackend(BaseSchemaBackend):
+    """Backend for TensorDict schema validation."""
+
+    def preprocess(self, check_obj, inplace: bool = False):
+        """Preprocesses a check object before applying check functions."""
+        if not inplace:
+            if _is_tensordict(check_obj):
+                check_obj = check_obj.clone()
+            else:
+                check_obj = check_obj.copy()
+        return check_obj
+
+    def validate(
+        self,
+        check_obj,
+        schema,
+        *,
+        head: int | None = None,
+        tail: int | None = None,
+        sample: int | None = None,
+        random_state: int | None = None,
+        lazy: bool = False,
+        inplace: bool = False,
+    ):
+        """Validate a TensorDict against the schema."""
+        error_handler = ErrorHandler(lazy)
+
+        check_obj = self.preprocess(check_obj, inplace=inplace)
+
+        if schema.coerce or any(
+            tensor.coerce for tensor in schema.keys.values()
+        ):
+            check_obj = self.coerce_dtype(check_obj, schema=schema)
+
+        error_handler = self.run_checks_and_handle_errors(
+            error_handler, schema, check_obj, lazy
+        )
+
+        if error_handler.collected_errors:
+            raise errors.SchemaErrors(
+                schema=schema,
+                schema_errors=error_handler.schema_errors,
+                data=check_obj,
+            )
+
+        return check_obj
+
+    def coerce_dtype(self, check_obj, schema=None):
+        """Coerce the dtype of tensors in the TensorDict."""
+        from pandera import errors
+        from pandera.api.base.error_handler import ErrorHandler
+
+        error_handler = ErrorHandler(lazy=True)
+
+        def _set_tensor(obj, key, value):
+            """Set tensor in TensorDict or tensorclass object."""
+            try:
+                from tensordict import TensorDictBase
+
+                if isinstance(obj, TensorDictBase):
+                    obj[key] = value
+                else:
+                    # For tensorclass, use attribute access
+                    setattr(obj, key, value)
+            except (KeyError, TypeError):
+                pass
+
+        for key, tensor_schema in schema.keys.items():
+            # Apply coercion if either schema-level coerce is True or
+            # tensor-level coerce is True, and dtype is specified
+            if (
+                not (schema.coerce or tensor_schema.coerce)
+                or tensor_schema.dtype is None
+            ):
+                continue
+
+            try:
+                tensor = _get_tensor(check_obj, key)
+                coerced_tensor = tensor_schema.dtype.try_coerce(tensor)
+                _set_tensor(check_obj, key, coerced_tensor)
+            except errors.SchemaError as err:
+                error_handler.collect_error(
+                    get_error_category(err.reason_code),
+                    err.reason_code,
+                    err,
+                )
+            except Exception as exc:
+                from pandera.errors import SchemaError, SchemaErrors
+
+                # Wrap non-SchemaError exceptions in SchemaError
+                error = SchemaError(
+                    schema=schema,
+                    data=check_obj,
+                    message=f"Coercion failed for key '{key}': {exc}",
+                    reason_code=SchemaErrorReason.DATATYPE_COERCION,
+                )
+                error_handler.collect_error(
+                    get_error_category(error.reason_code),
+                    error.reason_code,
+                    error,
+                )
+
+        if error_handler.collected_errors:
+            raise errors.SchemaErrors(
+                schema=schema,
+                schema_errors=error_handler.schema_errors,
+                data=check_obj,
+            )
+
+        return check_obj
+
+    def run_checks_and_handle_errors(
+        self, error_handler, schema, check_obj, lazy
+    ):
+        """Run all checks and collect errors."""
+        self._check_batch_size(check_obj, schema, error_handler, lazy)
+        self._check_keys(check_obj, schema, error_handler, lazy)
+        self._check_dtypes_and_shapes(check_obj, schema, error_handler, lazy)
+        self._run_value_checks(check_obj, schema, error_handler, lazy)
+
+        return error_handler
+
+    def _check_batch_size(self, check_obj, schema, error_handler, lazy):
+        """Validate batch_size matches."""
+        if schema.batch_size is None:
+            return
+
+        actual_batch_size = check_obj.batch_size
+        expected_batch_size = schema.batch_size
+
+        if len(actual_batch_size) != len(expected_batch_size):
+            error_msg = (
+                f"Expected batch_size {expected_batch_size}, "
+                f"got {actual_batch_size}"
+            )
+            error = SchemaError(
+                schema=schema,
+                data=check_obj,
+                message=error_msg,
+                reason_code=SchemaErrorReason.WRONG_DATATYPE,
+            )
+            error_handler.collect_error(
+                get_error_category(error.reason_code),
+                error.reason_code,
+                error,
+            )
+            return
+
+        for i, (exp, act) in enumerate(
+            zip(expected_batch_size, actual_batch_size)
+        ):
+            if exp is not None and exp != act:
+                error_msg = f"Expected batch_size[{i}]={exp}, got batch_size[{i}]={act}"
+                error = SchemaError(
+                    schema=schema,
+                    data=check_obj,
+                    message=error_msg,
+                    reason_code=SchemaErrorReason.WRONG_DATATYPE,
+                )
+                error_handler.collect_error(
+                    get_error_category(error.reason_code),
+                    error.reason_code,
+                    error,
+                )
+
+    def _check_keys(self, check_obj, schema, error_handler, lazy):
+        """Validate required keys exist."""
+        for key in schema.keys:
+            # Check if key exists - use different methods for TensorDict vs tensorclass
+            is_key_present = False
+
+            try:
+                from tensordict import TensorDictBase
+
+                if isinstance(check_obj, TensorDictBase):
+                    is_key_present = key in check_obj.keys()
+                else:
+                    # For tensorclass, use keys() method or attribute access
+                    if hasattr(check_obj, "keys"):
+                        is_key_present = key in check_obj.keys()
+                    elif hasattr(check_obj, key):
+                        is_key_present = True
+            except ImportError:
+                pass
+
+            if not is_key_present:
+                error_msg = f"Missing key '{key}' in TensorDict"
+                error = SchemaError(
+                    schema=schema,
+                    data=check_obj,
+                    message=error_msg,
+                    reason_code=SchemaErrorReason.COLUMN_NOT_IN_DATAFRAME,
+                )
+                error_handler.collect_error(
+                    get_error_category(error.reason_code),
+                    error.reason_code,
+                    error,
+                )
+
+    def _check_dtypes_and_shapes(self, check_obj, schema, error_handler, lazy):
+        """Validate tensor dtypes and shapes."""
+        for key, tensor_schema in schema.keys.items():
+            try:
+                tensor = _get_tensor(check_obj, key)
+            except KeyError:
+                # Key doesn't exist (should already be caught by _check_keys)
+                continue
+
+            if not isinstance(tensor, torch.Tensor):
+                error_msg = f"Key '{key}' is not a torch.Tensor"
+                error = SchemaError(
+                    schema=schema,
+                    data=check_obj,
+                    message=error_msg,
+                    reason_code=SchemaErrorReason.WRONG_DATATYPE,
+                )
+                error_handler.collect_error(
+                    get_error_category(error.reason_code),
+                    error.reason_code,
+                    error,
+                )
+                continue
+
+            if tensor_schema.dtype is not None:
+                expected_dtype = tensor_schema.dtype.type
+                actual_dtype = tensor.dtype
+                if actual_dtype != expected_dtype:
+                    error_msg = (
+                        f"Key '{key}': expected dtype {expected_dtype}, "
+                        f"got {actual_dtype}"
+                    )
+                    error = SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=error_msg,
+                        reason_code=SchemaErrorReason.WRONG_DATATYPE,
+                    )
+                    error_handler.collect_error(
+                        get_error_category(error.reason_code),
+                        error.reason_code,
+                        error,
+                    )
+
+            if tensor_schema.shape is not None:
+                actual_shape = tuple(tensor.shape)
+                expected_shape = tensor_schema.shape
+
+                if len(actual_shape) != len(expected_shape):
+                    error_msg = (
+                        f"Key '{key}': expected shape {expected_shape}, "
+                        f"got {actual_shape}"
+                    )
+                    error = SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=error_msg,
+                        reason_code=SchemaErrorReason.WRONG_DATATYPE,
+                    )
+                    error_handler.collect_error(
+                        get_error_category(error.reason_code),
+                        error.reason_code,
+                        error,
+                    )
+                    continue
+
+                for i, (exp, act) in enumerate(
+                    zip(expected_shape, actual_shape)
+                ):
+                    if exp is not None and exp != act:
+                        error_msg = (
+                            f"Key '{key}': expected shape[{i}]={exp}, "
+                            f"got shape[{i}]={act}"
+                        )
+                        error = SchemaError(
+                            schema=schema,
+                            data=check_obj,
+                            message=error_msg,
+                            reason_code=SchemaErrorReason.WRONG_DATATYPE,
+                        )
+                        error_handler.collect_error(
+                            get_error_category(error.reason_code),
+                            error.reason_code,
+                            error,
+                        )
+
+    def _run_value_checks(self, check_obj, schema, error_handler, lazy):
+        """Run value checks on tensor values."""
+        from pandera.api.base.checks import CheckResult
+
+        for key, tensor_schema in schema.keys.items():
+            try:
+                tensor = _get_tensor(check_obj, key)
+            except KeyError:
+                continue
+
+            if not tensor_schema.checks:
+                continue
+
+            # For value checks, we need to pass the tensor data
+            tensor_data = {key: tensor}
+
+            for check_index, check in enumerate(tensor_schema.checks):
+                try:
+                    # Use TensorDictCheckBackend directly
+                    from pandera.backends.tensordict.checks import (
+                        TensorDictCheckBackend,
+                    )
+
+                    check_backend = TensorDictCheckBackend(check)
+
+                    # Apply check to the tensor (not dict)
+                    check_result = check_backend.apply(tensor)
+
+                    # Postprocess result
+                    check_result = check_backend.postprocess(
+                        tensor, check_result
+                    )
+                except Exception as exc:
+                    check_result = CoreCheckResult(
+                        passed=False,
+                        check=check,
+                        check_index=check_index,
+                        reason_code=SchemaErrorReason.CHECK_ERROR,
+                        message=str(exc),
+                    )
+
+                if not check_result.check_passed:
+                    error_msg = (
+                        f"Check '{check}' failed for key '{key}': check failed"
+                    )
+                    error = SchemaError(
+                        schema=schema,
+                        data=check_obj,
+                        message=error_msg,
+                        check=check,
+                        check_index=check_index,
+                        reason_code=SchemaErrorReason.CHECK_ERROR,
+                    )
+                    error_handler.collect_error(
+                        get_error_category(error.reason_code),
+                        error.reason_code,
+                        error,
+                    )
+
+    def run_check(self, check_obj, schema, check, check_index, *args):
+        """Run a single check on the check object."""
+        raise NotImplementedError("Use _run_value_checks instead")
+
+    def run_checks(self, check_obj, schema):
+        """Run a list of checks on the check object."""
+        raise NotImplementedError("Use _run_value_checks instead")
+
+    def run_schema_component_checks(
+        self, check_obj, schema, schema_components, lazy
+    ):
+        """Run checks for all schema components."""
+        raise NotImplementedError("Use _run_value_checks instead")
+
+    def check_name(self, check_obj, schema):
+        """Core check that checks the name of the check object."""
+        raise NotImplementedError
+
+    def check_nullable(self, check_obj, schema):
+        """Core check that checks the nullability of a check object."""
+        raise NotImplementedError
+
+    def check_unique(self, check_obj, schema):
+        """Core check that checks the uniqueness of values in a check object."""
+        raise NotImplementedError
+
+    def check_dtype(self, check_obj, schema):
+        """Core check that checks the data type of a check object."""
+        raise NotImplementedError
+
+    def failure_cases_metadata(
+        self, schema_name: str, schema_errors: list[SchemaError]
+    ):
+        """Get failure cases metadata for lazy validation."""
+        from collections import defaultdict
+
+        from pandera.api.base.error_handler import ErrorHandler
+        from pandera.errors import FailureCaseMetadata
+
+        error_dicts = {}
+        error_handler = ErrorHandler()
+        error_handler.collect_errors(schema_errors)
+
+        if error_handler.collected_errors:
+            error_dicts = error_handler.summarize(schema_name=schema_name)
+            error_dicts = dict(error_dicts)
+
+        failure_cases = [
+            err.failure_cases for err in schema_errors if err.failure_cases
+        ]
+
+        error_counts: dict[str, int] = defaultdict(int)
+        for error in error_handler.collected_errors:
+            error_counts[error["reason_code"].name] += 1
+
+        return FailureCaseMetadata(
+            failure_cases=failure_cases,
+            message=error_dicts,
+            error_counts=dict(error_counts),
+        )
+
+    def drop_invalid_rows(self, check_obj, error_handler):
+        """Remove invalid elements in a check_obj."""
+        raise NotImplementedError(
+            "drop_invalid_rows is not applicable for TensorDict"
+        )

--- a/pandera/backends/tensordict/builtin_checks.py
+++ b/pandera/backends/tensordict/builtin_checks.py
@@ -1,0 +1,137 @@
+"""Built-in checks for TensorDict."""
+
+import sys
+
+# Import torch first to get the actual type, not string annotation
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+    torch = None
+
+from collections.abc import Callable, Iterable
+from functools import partial
+from typing import Any
+
+try:
+    from pandera.api.extensions import register_builtin_check
+
+    if TORCH_AVAILABLE:
+
+        @register_builtin_check(
+            aliases=["gt"],
+            error="greater_than({min_value})",
+        )
+        def greater_than(data: torch.Tensor, min_value: Any) -> torch.Tensor:
+            """Ensure values are strictly greater than a minimum value.
+
+            :param data: Input tensor data.
+            :param min_value: Lower bound to be exceeded.
+            """
+            return data > min_value
+
+        @register_builtin_check(
+            aliases=["ge"],
+            error="greater_than_or_equal_to({min_value})",
+        )
+        def greater_than_or_equal_to(
+            data: torch.Tensor, min_value: Any
+        ) -> torch.Tensor:
+            """Ensure all values are greater than or equal to a minimum value.
+
+            :param data: Input tensor data.
+            :param min_value: Allowed minimum value.
+            """
+            return data >= min_value
+
+        @register_builtin_check(
+            aliases=["lt"],
+            error="less_than({max_value})",
+        )
+        def less_than(data: torch.Tensor, max_value: Any) -> torch.Tensor:
+            """Ensure all values are strictly less than a maximum value.
+
+            :param data: Input tensor data.
+            :param max_value: Allowed maximum value.
+            """
+            return data < max_value
+
+        @register_builtin_check(
+            aliases=["le"],
+            error="less_than_or_equal_to({max_value})",
+        )
+        def less_than_or_equal_to(
+            data: torch.Tensor, max_value: Any
+        ) -> torch.Tensor:
+            """Ensure all values are less than or equal to a maximum value.
+
+            :param data: Input tensor data.
+            :param max_value: Allowed maximum value.
+            """
+            return data <= max_value
+
+        @register_builtin_check(
+            aliases=["in_range"],
+            error="in_range({min_value}, {max_value})",
+        )
+        def in_range(
+            data: torch.Tensor,
+            min_value: Any,
+            max_value: Any,
+            include_min: bool = True,
+            include_max: bool = True,
+        ) -> torch.Tensor:
+            """Ensure all values are within a range.
+
+            :param data: Input tensor data.
+            :param min_value: Minimum allowed value.
+            :param max_value: Maximum allowed value.
+            :param include_min: If True, min_value is included in the range.
+            :param include_max: If True, max_value is included in the range.
+            """
+            if include_min and include_max:
+                return (data >= min_value) & (data <= max_value)
+            elif include_min:
+                return (data >= min_value) & (data < max_value)
+            elif include_max:
+                return (data > min_value) & (data <= max_value)
+            else:
+                return (data > min_value) & (data < max_value)
+
+        @register_builtin_check(
+            aliases=["isin"],
+            error="isin({allowed_values})",
+        )
+        def isin(data: torch.Tensor, allowed_values: Iterable) -> torch.Tensor:
+            """Ensure all values are in a set of allowed values.
+
+            :param data: Input tensor data.
+            :param allowed_values: Set of allowed values.
+            """
+            return torch.isin(data, torch.as_tensor(list(allowed_values)))
+
+except ImportError:
+    # extensions not available yet
+    def register_builtin_check(
+        fn=None,
+        strategy: Callable | None = None,
+        constraint: Callable | None = None,
+        _check_cls: type = None,  # type: ignore[assignment]
+        aliases: list[str] | None = None,
+        **outer_kwargs,
+    ):
+        def decorator(f):
+            return f
+
+        if fn is None:
+            return partial(
+                register_builtin_check,
+                strategy=strategy,
+                constraint=constraint,
+                _check_cls=_check_cls,
+                aliases=aliases,
+                **outer_kwargs,
+            )
+        return decorator(fn)

--- a/pandera/backends/tensordict/checks.py
+++ b/pandera/backends/tensordict/checks.py
@@ -1,0 +1,119 @@
+"""Check backend for TensorDict."""
+
+from functools import partial
+from typing import Any
+
+from pandera.api.base.checks import CheckResult
+from pandera.api.checks import Check
+from pandera.backends.base import BaseCheckBackend, CoreCheckResult
+from pandera.errors import SchemaErrorReason
+
+
+class TensorDictCheckBackend(BaseCheckBackend):
+    """Check backend for TensorDict."""
+
+    def __init__(self, check: Check):
+        """Initializes a check backend object."""
+        super().__init__(check)
+        self.check = check
+        self.check_fn = (
+            partial(check._check_fn, **check._check_kwargs)
+            if check._check_fn is not None
+            else None
+        )
+
+    def preprocess(self, check_obj: Any, key: Any = None) -> Any:
+        """Preprocesses the check object before applying the check function."""
+        # For tensor data, no preprocessing needed
+        return check_obj
+
+    def apply(self, check_obj: Any) -> CheckResult:
+        """Apply the check function to the check object.
+
+        :param check_obj: Tensor data to validate.
+        :returns: CheckResult with passed status and output.
+        """
+        check_obj = self.preprocess(check_obj)
+
+        if self.check_fn is None:
+            return CheckResult(
+                check_output=True,
+                check_passed=True,
+                checked_object=check_obj,
+                failure_cases=None,
+            )
+
+        # Apply the check function
+        try:
+            result = self.check_fn(check_obj)
+        except Exception as exc:
+            return CheckResult(
+                check_output=False,
+                check_passed=False,
+                checked_object=check_obj,
+                failure_cases=None,
+            )
+
+        # Reduce to boolean
+        passed = self._reduce_to_bool(result)
+
+        if not passed:
+            failure_cases = self._get_failure_cases(check_obj, result)
+        else:
+            failure_cases = None
+
+        return CheckResult(
+            check_output=result,
+            check_passed=passed,
+            checked_object=check_obj,
+            failure_cases=failure_cases,
+        )
+
+    def _reduce_to_bool(self, result: Any) -> bool:
+        """Reduce a boolean tensor/array to a single boolean value."""
+        try:
+            import torch
+
+            if isinstance(result, torch.Tensor):
+                return result.all().item()
+        except ImportError:
+            pass
+
+        try:
+            import numpy as np
+
+            if isinstance(result, np.ndarray):
+                return result.all().item()
+        except ImportError:
+            pass
+
+        # Assume it's already a boolean
+        return bool(result)
+
+    def _get_failure_cases(self, check_obj: Any, result: Any) -> Any | None:
+        """Get the failure cases from the check result."""
+        try:
+            import torch
+
+            if isinstance(check_obj, torch.Tensor):
+                # Get indices where check failed
+                if isinstance(result, torch.Tensor):
+                    failure_mask = ~result
+                    return check_obj[failure_mask]
+        except ImportError:
+            pass
+
+        return None
+
+    def postprocess(
+        self, check_obj: Any, check_output: CheckResult
+    ) -> CheckResult:
+        """Postprocesses the result of applying the check function."""
+        if isinstance(check_output, CheckResult):
+            return check_output
+        return CheckResult(
+            check_output=check_output,
+            check_passed=bool(check_output),
+            checked_object=check_obj,
+            failure_cases=None,
+        )

--- a/pandera/backends/tensordict/register.py
+++ b/pandera/backends/tensordict/register.py
@@ -1,0 +1,43 @@
+"""Register TensorDict backends."""
+
+from functools import lru_cache
+
+
+@lru_cache
+def register_tensordict_backends() -> None:
+    """Register TensorDict backends.
+
+    This function is called at schema initialization in the _register_*_backends
+    method to register validation backends for TensorDict and tensorclass objects.
+    """
+    from pandera.api.checks import Check
+    from pandera.api.tensordict.container import TensorDictSchema
+
+    # Import builtin checks to register check functions
+    from pandera.backends.tensordict import builtin_checks
+    from pandera.backends.tensordict.base import (
+        TensorDictSchemaBackend,
+        _is_tensordict,
+    )
+    from pandera.backends.tensordict.checks import TensorDictCheckBackend
+
+    try:
+        import torch
+        from tensordict import TensorDictBase
+
+        # Register the schema backend for TensorDictBase so that any
+        # TensorDict subclass (TensorDict, LazyStackedTensorDict, etc.) is
+        # matched by the MRO lookup in ``get_backend``.
+        TensorDictSchema.register_backend(
+            TensorDictBase, TensorDictSchemaBackend
+        )
+
+        # For tensorclass, we handle it in get_backend() since each decorated
+        # class creates a unique type. We use TensorDictBase's backend since
+        # they share the same interface.
+
+        # Register check backend for tensors
+        Check.register_backend(torch.Tensor, TensorDictCheckBackend)
+
+    except ImportError:
+        pass

--- a/pandera/engines/tensordict_engine.py
+++ b/pandera/engines/tensordict_engine.py
@@ -1,0 +1,154 @@
+"""TensorDict engine and data types."""
+
+import dataclasses
+from typing import Any, Union
+
+from pandera import dtypes
+from pandera.dtypes import immutable
+from pandera.engines import engine
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+if torch is not None:
+
+    @immutable(init=True)
+    class DataType(dtypes.DataType):
+        """DataType for boxing PyTorch tensor dtypes."""
+
+        type: torch.dtype = dataclasses.field(
+            default=torch.float32, repr=False, init=False
+        )
+
+        def __init__(self, dtype: Any):
+            super().__init__()
+            if isinstance(dtype, torch.dtype):
+                actual_dtype = dtype
+            elif isinstance(dtype, str):
+                dtype_str = dtype.replace("torch.", "")
+                actual_dtype = getattr(torch, dtype_str, None)
+                if not isinstance(actual_dtype, torch.dtype):
+                    raise ValueError(f"Unknown torch dtype: {dtype}")
+            else:
+                raise ValueError(
+                    f"Data type '{dtype}' not understood for TensorDict. "
+                    "Expected a torch.dtype or string like 'float32'."
+                )
+            object.__setattr__(self, "type", actual_dtype)
+
+        def __post_init__(self):
+            if isinstance(self.type, torch.dtype):
+                return
+            actual_dtype = getattr(torch, str(self.type), None)
+            if actual_dtype is not None:
+                object.__setattr__(self, "type", actual_dtype)
+
+        def coerce(self, data_container: torch.Tensor) -> torch.Tensor:
+            """Coerce tensor to the specified dtype."""
+            return data_container.type(self.type)
+
+        def coerce_value(self, value: Any) -> Any:
+            """Coerce a value to the particular type."""
+            return torch.tensor(value, dtype=self.type)
+
+        def try_coerce(self, data_container: torch.Tensor) -> torch.Tensor:
+            try:
+                return self.coerce(data_container)
+            except Exception as exc:
+                from pandera import errors
+
+                raise errors.ParserError(
+                    f"Could not coerce tensor to type {self.type}",
+                    failure_cases=None,
+                ) from exc
+
+        def __str__(self) -> str:
+            return str(self.type)
+
+        def __repr__(self) -> str:
+            return f"DataType({self})"
+
+    class Engine(metaclass=engine.Engine, base_pandera_dtypes=DataType):
+        """PyTorch TensorDict data type engine."""
+
+        @classmethod
+        def dtype(cls, data_type: Any) -> dtypes.DataType:
+            """Convert input into a PyTorch-compatible Pandera DataType."""
+            if isinstance(data_type, type) and issubclass(data_type, DataType):
+                return DataType(str(data_type.type))
+            try:
+                return engine.Engine.dtype(cls, data_type)
+            except (TypeError, ValueError):
+                try:
+                    if isinstance(data_type, torch.dtype):
+                        return DataType(str(data_type))
+                    elif isinstance(data_type, str):
+                        return DataType(data_type)
+                    else:
+                        return DataType(data_type)
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"Data type '{data_type}' not understood for TensorDict. "
+                        f"Expected a torch.dtype or string like 'float32'."
+                    ) from None
+
+        @classmethod
+        def register_dtype(cls, pandera_dtype_cls: type[DataType]):
+            """Register a Pandera DataType for PyTorch dtypes."""
+            cls._check_source_dtype(pandera_dtype_cls)
+            equivalents = {}
+            strict_equivalents: dict[Any, DataType] = {}
+            for source_dtype in (pandera_dtype_cls.type,):
+                if source_dtype is not None:
+                    equivalents[source_dtype] = pandera_dtype_cls  # type: ignore[assignment]
+
+            if equivalents:
+                registry = cls._registry[cls]
+                registry.equivalents.update(equivalents)
+                registry.strict_equivalents.update(strict_equivalents)
+
+    def _register_torch_dtypes():
+        """Register all torch dtypes."""
+        torch_dtype_names = [
+            "float32",
+            "float64",
+            "float16",
+            "bfloat16",
+            "float8_e4m3fn",
+            "float8_e5m2",
+            "int64",
+            "int32",
+            "int16",
+            "int8",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "bool",
+            "complex64",
+            "complex128",
+        ]
+
+        for dtype_name in torch_dtype_names:
+            try:
+                torch_dtype = getattr(torch, dtype_name, None)
+                if torch_dtype is not None:
+                    Engine.register_dtype(DataType(dtype_name))
+            except (AttributeError, ValueError):
+                pass
+
+    _register_torch_dtypes()
+
+else:
+
+    class _DataTypePlaceholder:
+        pass
+
+    class _EnginePlaceholder:
+        pass
+
+    DataType = None  # type: ignore[misc, assignment]
+    Engine = None  # type: ignore[misc, assignment]

--- a/pandera/io/__init__.py
+++ b/pandera/io/__init__.py
@@ -7,4 +7,5 @@ Examples:
 - ``import pandera.io.pyspark_sql_io`` — PySpark SQL API schemas
 - ``import pandera.io.ibis_io`` — Ibis API schemas
 - ``import pandera.io.xarray_io`` — xarray API schemas
+- ``import pandera.io.tensordict_io`` — TensorDict API schemas
 """

--- a/pandera/io/tensordict_io.py
+++ b/pandera/io/tensordict_io.py
@@ -1,0 +1,299 @@
+"""Serialize and deserialize TensorDict schemas."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pandera.api.checks import Check
+from pandera.api.tensordict.components import Tensor
+from pandera.api.tensordict.container import TensorDictSchema
+from pandera.engines import tensordict_engine
+from pandera.errors import SchemaDefinitionError
+from pandera.io._check_io import checks_dict_to_list
+
+
+def serialize_schema(
+    dataframe_schema, *, minimal: bool = True
+) -> dict[str, Any]:
+    """Serialize a TensorDict schema into JSON/YAML-compatible dict."""
+    from pandera import __version__
+
+    statistics: dict[str, Any] = {
+        "keys": {},
+        "batch_size": (
+            list(dataframe_schema.batch_size)
+            if dataframe_schema.batch_size
+            else None
+        ),
+    }
+
+    if dataframe_schema.keys:
+        for key_name, tensor_component in dataframe_schema.keys.items():
+            statistics["keys"][key_name] = {
+                "dtype": (
+                    str(tensor_component.dtype)
+                    if tensor_component.dtype is not None
+                    else None
+                ),
+                "shape": list(tensor_component.shape)
+                if tensor_component.shape
+                else None,
+                "nullable": getattr(tensor_component, "nullable", False),
+                "checks": (
+                    [
+                        {
+                            "options": {"check_name": check.name},
+                            **(check.statistics or {}),
+                        }
+                        for check in tensor_component.checks
+                    ]
+                    if hasattr(tensor_component, "checks")
+                    and tensor_component.checks
+                    else None
+                ),
+            }
+
+    out = {
+        "schema_type": "tensordict",
+        "version": __version__,
+        "keys": statistics["keys"],
+        "batch_size": statistics["batch_size"],
+        "coerce": dataframe_schema.coerce,
+        "dtype": (
+            str(dataframe_schema.dtype) if dataframe_schema.dtype else None
+        ),
+    }
+
+    return out
+
+
+def _deserialize_check_stats(check, serialized_check_stats):
+    """Deserialize check statistics and reconstruct Check with options."""
+    options = {}
+    if isinstance(serialized_check_stats, dict):
+        options = serialized_check_stats.pop("options", {})
+
+        if (
+            "value" in serialized_check_stats
+            and len(serialized_check_stats) == 1
+        ):
+            serialized_check_stats = serialized_check_stats["value"]
+
+    check_instance = check(**serialized_check_stats)
+
+    if options:
+        for option_name, option_value in options.items():
+            if option_name != "check_name":
+                setattr(check_instance, option_name, option_value)
+
+    return check_instance
+
+
+def _deserialize_tensor_stats(serialized_tensor_stats):
+    """Deserialize Tensor component stats and reconstruct Tensor."""
+    serialized_tensor_stats = dict(serialized_tensor_stats)
+
+    dtype = serialized_tensor_stats.get("dtype")
+    if dtype:
+        try:
+            dtype = tensordict_engine.Engine.dtype(dtype)
+        except (TypeError, ValueError):
+            dtype = tensordict_engine.Engine.dtype(str(dtype).lower())
+
+    shape = serialized_tensor_stats.get("shape")
+    if shape is not None:
+        shape = tuple(shape)
+
+    checks = checks_dict_to_list(serialized_tensor_stats.get("checks"))
+    if checks is not None:
+        checks = [
+            _deserialize_check_stats(
+                getattr(Check, check["options"]["check_name"]), check
+            )
+            for check in checks
+        ]
+
+    return {
+        "dtype": dtype,
+        "shape": shape,
+        "nullable": serialized_tensor_stats.get("nullable", False),
+        "checks": checks,
+        **{
+            key: serialized_tensor_stats.get(key)
+            for key in ["description", "title"]
+            if key in serialized_tensor_stats
+        },
+    }
+
+
+def deserialize_schema(serialized_schema):
+    """Deserialize a mapping into TensorDictSchema."""
+    serialized_schema = serialized_schema if serialized_schema else {}
+
+    if not isinstance(serialized_schema, Mapping):
+        raise SchemaDefinitionError("Schema representation must be a mapping.")
+
+    st = serialized_schema.get("schema_type")
+    if st is not None and st != "tensordict":
+        raise SchemaDefinitionError(
+            f"Expected schema_type 'tensordict', got {st!r}"
+        )
+
+    keys = serialized_schema.get("keys")
+    if keys is not None:
+        keys = {
+            key_name: Tensor(**_deserialize_tensor_stats(tensor_stats))
+            for key_name, tensor_stats in keys.items()
+        }
+
+    batch_size = serialized_schema.get("batch_size")
+    if batch_size is not None:
+        batch_size = tuple(batch_size)
+
+    return TensorDictSchema(
+        keys=keys,
+        batch_size=batch_size,
+        coerce=serialized_schema.get("coerce", False),
+        dtype=serialized_schema.get("dtype"),
+    )
+
+
+def from_yaml(yaml_schema):
+    """Load a TensorDictSchema from YAML."""
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "PyYAML is required for YAML support. "
+            "Install with: pip install pyyaml"
+        ) from exc
+
+    try:
+        with Path(yaml_schema).open("r", encoding="utf-8") as f:
+            serialized_schema = yaml.safe_load(f)
+    except (TypeError, OSError):
+        serialized_schema = yaml.safe_load(yaml_schema)
+
+    return deserialize_schema(serialized_schema)
+
+
+def to_yaml(dataframe_schema, stream=None, *, minimal: bool = True):
+    """Write a TensorDictSchema to YAML."""
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "PyYAML is required for YAML support. "
+            "Install with: pip install pyyaml"
+        ) from exc
+
+    statistics = serialize_schema(dataframe_schema, minimal=minimal)
+
+    def _write_yaml(obj, stream):
+        return yaml.safe_dump(obj, stream=stream, sort_keys=False)
+
+    try:
+        with Path(stream).open("w", encoding="utf-8") as f:
+            _write_yaml(statistics, f)
+    except (TypeError, OSError):
+        return _write_yaml(statistics, stream)
+
+
+def from_json(source):
+    """Load a TensorDictSchema from JSON."""
+    if isinstance(source, str):
+        try:
+            serialized_schema = json.loads(source)
+        except json.decoder.JSONDecodeError:
+            with Path(source).open(encoding="utf-8") as f:
+                serialized_schema = json.load(fp=f)
+    elif isinstance(source, Path):
+        with source.open(encoding="utf-8") as f:
+            serialized_schema = json.load(fp=f)
+    else:
+        serialized_schema = json.load(fp=source)
+
+    return deserialize_schema(serialized_schema)
+
+
+def to_json(dataframe_schema, target=None, *, minimal: bool = True, **kwargs):
+    """Write a TensorDictSchema to JSON."""
+    serialized_schema = serialize_schema(dataframe_schema, minimal=minimal)
+
+    if target is None:
+        return json.dumps(serialized_schema, sort_keys=False, **kwargs)
+
+    if isinstance(target, (str, Path)):
+        with Path(target).open("w", encoding="utf-8") as f:
+            json.dump(serialized_schema, fp=f, sort_keys=False, **kwargs)
+    else:
+        json.dump(serialized_schema, fp=target, sort_keys=False, **kwargs)
+
+
+def save(dataframe_schema, tensor_dict, path):
+    """Save TensorDict to disk with schema metadata embedded."""
+    import torch
+
+    path = Path(path)
+
+    if isinstance(tensor_dict, dict):
+        from tensordict import TensorDict
+
+        td = TensorDict(tensor_dict)
+        # Infer batch dimensions from the tensors so that the saved
+        # TensorDict round-trips through schema validation in ``load``.
+        batch_dims = (
+            len(dataframe_schema.batch_size)
+            if dataframe_schema.batch_size is not None
+            else None
+        )
+        td.auto_batch_size_(batch_dims=batch_dims)
+    else:
+        td = tensor_dict
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    torch.save(
+        {
+            "tensordict": td,
+            "schema": serialize_schema(dataframe_schema),
+        },
+        path,
+    )
+
+
+def load(path):
+    """Load TensorDict from disk and validate with schema."""
+    import torch
+
+    data = torch.load(path, weights_only=False)
+
+    if isinstance(data, dict) and "tensordict" in data:
+        td = data["tensordict"]
+        saved_schema = data.get("schema")
+
+        if saved_schema:
+            loaded_schema = deserialize_schema(saved_schema)
+            return loaded_schema.validate(td)
+
+    if isinstance(data, dict):
+        try:
+            from tensordict import TensorDict
+
+            from pandera.schema_inference.tensordict import infer_schema
+
+            if any(hasattr(v, "dtype") for v in data.values()):
+                td = TensorDict(data)
+
+                try:
+                    schema = infer_schema(td)
+                    return schema.validate(td)
+                except Exception:
+                    return td
+        except ImportError:
+            pass
+
+    return data

--- a/pandera/schema_inference/tensordict.py
+++ b/pandera/schema_inference/tensordict.py
@@ -1,0 +1,150 @@
+"""Module for inferring TensorDict schema from data."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from pandera.api.tensordict.components import Tensor
+from pandera.api.tensordict.container import TensorDictSchema
+
+
+def infer_schema(tensordict: Any) -> TensorDictSchema:
+    """Infer schema for a TensorDict or tensorclass object.
+
+    Automatically detects dtypes, shapes, and value statistics from data.
+
+    :param tensordict: TensorDict or tensorclass object to infer.
+    :returns: TensorDictSchema with inferred properties.
+    :raises TypeError: if tensordict is not a valid TensorDict/tensorclass.
+
+    Example:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> import pandera.tensordict as pa
+        >>> td = TensorDict({
+        ...     "obs": torch.randn(32, 10),
+        ...     "action": torch.randint(0, 4, (32,))
+        ... }, batch_size=[32])
+        >>> schema = pa.infer_schema(td)
+    """
+    try:
+        import tensordict as _tensordict  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "tensordict is required for infer_schema but is not installed. "
+            "Install with: pip install tensordict"
+        ) from exc
+
+    if not _is_tensordict_instance(tensordict):
+        raise TypeError(
+            f"Expected TensorDict or tensorclass, got {type(tensordict)}"
+        )
+
+    keys = {}
+    for key in _get_keys_from_tensordict(tensordict):
+        tensor = tensordict.get(key)
+        if tensor is not None:
+            keys[key] = _infer_tensor_schema(tensor)
+
+    # Convert batch_size from torch.Size to tuple
+    batch_size_tuple = (
+        tuple(tensordict.batch_size) if tensordict.batch_size else None
+    )
+
+    return TensorDictSchema(
+        keys=keys,
+        batch_size=batch_size_tuple,
+        coerce=True,
+    )
+
+
+def _get_keys_from_tensordict(obj):
+    """Get keys from a TensorDict or tensorclass object."""
+    try:
+        # For TensorDict, use .keys()
+        if hasattr(obj, "keys") and callable(getattr(obj, "keys")):
+            return list(obj.keys())
+
+        # For tensorclass, try to get from _tensordict
+        if hasattr(obj, "_tensordict"):
+            td = obj._tensordict
+            if hasattr(td, "keys") and callable(getattr(td, "keys")):
+                return list(td.keys())
+    except Exception:
+        pass
+
+    # Fallback: try to iterate over attributes
+    keys = []
+    for attr in dir(obj):
+        if not attr.startswith("_"):
+            val = getattr(obj, attr, None)
+            if isinstance(val, torch.Tensor):
+                keys.append(attr)
+
+    return keys
+
+
+def _is_tensordict_instance(obj) -> bool:
+    """Check if object is a TensorDict or tensorclass instance."""
+    try:
+        from tensordict import is_tensor_collection
+
+        return is_tensor_collection(obj)
+    except ImportError:
+        return False
+
+
+def _infer_tensor_schema(tensor: torch.Tensor) -> Tensor:
+    """Infer Tensor schema from a PyTorch tensor.
+
+    :param tensor: PyTorch tensor to infer.
+    :returns: Tensor component with inferred dtype, shape, and checks.
+    """
+    # Infer dtype
+    dtype = tensor.dtype
+
+    # Infer shape (None for dynamic dimensions)
+    shape = tuple(s if s > 0 else None for s in tensor.shape)
+
+    # Infer value range statistics
+    checks = _infer_tensor_checks(tensor)
+
+    return Tensor(dtype=dtype, shape=shape, checks=checks)
+
+
+def _infer_tensor_checks(tensor: torch.Tensor) -> list | None:
+    """Infer check constraints from tensor data.
+
+    :param tensor: PyTorch tensor to analyze.
+    :returns: List of Check objects or None if no meaningful checks can be inferred.
+    """
+    import pandera as pa
+
+    # Only infer checks for numeric tensors
+    if not torch.is_floating_point(tensor) and not torch.is_complex(tensor):
+        return []
+
+    has_nan = torch.isnan(tensor).any().item()
+    has_inf = torch.isinf(tensor).any().item()
+
+    checks = []
+
+    if not has_nan and not has_inf:
+        try:
+            min_val = tensor.min()
+            max_val = tensor.max()
+
+            # Use torch.isfinite on the tensor values
+            if torch.all(torch.isfinite(min_val)) and torch.all(
+                torch.isfinite(max_val)
+            ):
+                checks.append(
+                    pa.Check.greater_than_or_equal_to(min_val.item())
+                )
+                checks.append(pa.Check.less_than_or_equal_to(max_val.item()))
+        except (AttributeError, RuntimeError):
+            pass
+
+    return checks if checks else None

--- a/pandera/strategies/__init__.py
+++ b/pandera/strategies/__init__.py
@@ -3,3 +3,17 @@
 Example: ``import pandera.strategies.pandas_strategies`` or
 ``import pandera.strategies.xarray_strategies``.
 """
+
+from typing import Any
+
+_TENSORDICT_STRATEGIES = ("tensordict_strategy", "tensorclass_strategy")
+
+
+def __getattr__(name: str) -> Any:
+    # Lazily expose tensordict strategies so that importing this package
+    # doesn't require torch/tensordict to be installed.
+    if name in _TENSORDICT_STRATEGIES:
+        from pandera.strategies import tensordict_strategies
+
+        return getattr(tensordict_strategies, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pandera/strategies/tensordict_strategies.py
+++ b/pandera/strategies/tensordict_strategies.py
@@ -1,0 +1,216 @@
+"""Generate synthetic TensorDict data from schema definitions.
+
+This module generates :class:`tensordict.TensorDict` and
+:class:`tensordict.tensorclass` objects that conform to
+:class:`~pandera.api.tensordict.container.TensorDictSchema` specifications.
+
+Built on top of the
+`hypothesis <https://hypothesis.readthedocs.io/en/latest/index.html>`_
+package.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar, cast
+
+import numpy as np
+import torch
+
+from pandera.strategies.base_strategies import HAS_HYPOTHESIS
+
+if HAS_HYPOTHESIS:
+    from hypothesis import strategies as st
+    from hypothesis.extra import numpy as npst
+    from hypothesis.strategies import SearchStrategy, composite
+else:  # pragma: no cover
+    from pandera.strategies.base_strategies import SearchStrategy, composite
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _strategy_import_error(fn: F) -> F:
+    """Decorator to raise ImportError when hypothesis is missing."""
+
+    @wraps(fn)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not HAS_HYPOTHESIS:
+            raise ImportError(
+                'Strategies for generating data requires "hypothesis" '
+                "to be installed.\n"
+                "pip install pandera[strategies]"
+            )
+        return fn(*args, **kwargs)
+
+    return cast(F, _wrapper)
+
+
+def _resolve_batch_size(schema, default_size: int) -> tuple[int, ...]:
+    """Resolve a schema batch_size into concrete dimensions."""
+    if not schema.batch_size:
+        return (default_size,)
+    return tuple(
+        s if s is not None else default_size for s in schema.batch_size
+    )
+
+
+def _check_bounds(checks) -> dict[str, Any]:
+    """Extract element-value constraints from built-in checks."""
+    bounds: dict[str, Any] = {}
+    for check in checks or []:
+        stats = check.statistics or {}
+        if check.name == "isin":
+            bounds["allowed_values"] = list(stats["allowed_values"])
+        elif check.name in ("greater_than", "greater_than_or_equal_to"):
+            bounds["min_value"] = stats["min_value"]
+            bounds["exclude_min"] = check.name == "greater_than"
+        elif check.name in ("less_than", "less_than_or_equal_to"):
+            bounds["max_value"] = stats["max_value"]
+            bounds["exclude_max"] = check.name == "less_than"
+        elif check.name == "in_range":
+            bounds["min_value"] = stats["min_value"]
+            bounds["max_value"] = stats["max_value"]
+            bounds["exclude_min"] = not stats.get("include_min", True)
+            bounds["exclude_max"] = not stats.get("include_max", True)
+    return bounds
+
+
+def _element_strategy(torch_dtype: torch.dtype, checks) -> SearchStrategy:
+    """Build a strategy for single elements honoring built-in checks."""
+    bounds = _check_bounds(checks)
+    if "allowed_values" in bounds:
+        return st.sampled_from(bounds["allowed_values"])
+
+    if torch_dtype == torch.bool:
+        return st.booleans()
+
+    if torch_dtype.is_floating_point:
+        width = 32 if torch.finfo(torch_dtype).bits <= 32 else 64
+        return st.floats(
+            min_value=bounds.get("min_value"),
+            max_value=bounds.get("max_value"),
+            exclude_min=bounds.get("exclude_min", False),
+            exclude_max=bounds.get("exclude_max", False),
+            allow_nan=False,
+            allow_infinity=False,
+            width=width,
+        )
+
+    if torch_dtype.is_complex:
+        return st.complex_numbers(allow_nan=False, allow_infinity=False)
+
+    # Integer types: apply bounds, defaulting to a small non-negative range.
+    min_value = bounds.get("min_value", 0)
+    max_value = bounds.get("max_value", 1000)
+    if bounds.get("exclude_min"):
+        min_value += 1
+    if bounds.get("exclude_max"):
+        max_value -= 1
+    return st.integers(min_value=min_value, max_value=max_value)
+
+
+def _numpy_dtype(torch_dtype: torch.dtype) -> np.dtype:
+    """Numpy dtype used to generate values for a torch dtype.
+
+    Falls back to float32 for torch-only floating dtypes (e.g. bfloat16,
+    float8) which have no numpy equivalent; the generated array is cast to
+    the target dtype afterwards.
+    """
+    try:
+        return torch.empty(0, dtype=torch_dtype).numpy().dtype
+    except TypeError:
+        return np.dtype("float32")
+
+
+def _draw_tensor(
+    draw,
+    tensor_schema,
+    default_size: int,
+    batch_size: tuple[int, ...] = (),
+) -> torch.Tensor:
+    """Draw a tensor conforming to a Tensor component's dtype, shape, and
+    built-in value checks."""
+    shape_list = list(tensor_schema.shape) if tensor_schema.shape else []
+
+    # Resolve dynamic dimensions: leading None dims align with the
+    # TensorDict batch dimensions, remaining ones use default_size.
+    resolved_shape = tuple(
+        (batch_size[i] if i < len(batch_size) else default_size)
+        if s is None
+        else s
+        for i, s in enumerate(shape_list)
+    )
+
+    torch_dtype = (
+        tensor_schema.dtype.type
+        if tensor_schema.dtype is not None
+        else torch.float32
+    )
+
+    arr = draw(
+        npst.arrays(
+            dtype=_numpy_dtype(torch_dtype),
+            shape=resolved_shape,
+            elements=_element_strategy(torch_dtype, tensor_schema.checks),
+        )
+    )
+    return torch.from_numpy(np.ascontiguousarray(arr)).to(torch_dtype)
+
+
+@_strategy_import_error
+def tensordict_strategy(
+    schema,
+    size: int | None = None,
+) -> SearchStrategy:
+    """Create a strategy from a TensorDictSchema.
+
+    :param schema: The TensorDictSchema to use.
+    :param size: Default size for None dimensions.
+    :returns: hypothesis strategy producing conforming TensorDicts.
+    """
+    default_size = size or 3
+
+    @composite
+    def generate_tensordict(draw):
+        from tensordict import TensorDict
+
+        batch_size = _resolve_batch_size(schema, default_size)
+        data = {
+            key_name: _draw_tensor(
+                draw, tensor_schema, default_size, batch_size
+            )
+            for key_name, tensor_schema in schema.keys.items()
+        }
+        return TensorDict(data, batch_size=batch_size)
+
+    return generate_tensordict()
+
+
+@_strategy_import_error
+def tensorclass_strategy(
+    cls,
+    schema,
+    size: int | None = None,
+) -> SearchStrategy:
+    """Create a strategy for generating tensorclass instances.
+
+    :param cls: The tensorclass class to generate.
+    :param schema: The TensorDictSchema defining the structure.
+    :param size: Default size for None dimensions.
+    :returns: hypothesis strategy producing conforming tensorclass instances.
+    """
+    default_size = size or 3
+
+    @composite
+    def generate_tensorclass(draw):
+        batch_size = _resolve_batch_size(schema, default_size)
+        data = {
+            key_name: _draw_tensor(
+                draw, tensor_schema, default_size, batch_size
+            )
+            for key_name, tensor_schema in schema.keys.items()
+        }
+        return cls(**data, batch_size=batch_size)
+
+    return generate_tensorclass()

--- a/pandera/tensordict.py
+++ b/pandera/tensordict.py
@@ -1,0 +1,70 @@
+"""Pandera TensorDict API."""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from pandera import errors
+
+try:
+    from pandera.engines.tensordict_engine import DataType as _DataType
+
+    DataType: type[_DataType] | None = _DataType
+except ImportError:
+    DataType = None
+
+from pandera.api.tensordict.components import Tensor
+from pandera.api.tensordict.container import TensorDictSchema
+from pandera.api.tensordict.model import TensorDictModel
+from pandera.api.tensordict.model_components import Field
+
+__all__ = [
+    "Tensor",
+    "TensorDictSchema",
+    "TensorDictModel",
+    "Field",
+    "errors",
+    "DataType",
+    "SchemaError",
+    "SchemaErrors",
+]
+
+if TYPE_CHECKING:
+    from pandera.schema_inference.tensordict import (
+        infer_schema as _infer_schema,
+    )
+else:
+    try:
+        from pandera.schema_inference.tensordict import infer_schema
+
+        __all__.append("infer_schema")
+    except ImportError as e:
+        warnings.warn(f"Could not import infer_schema: {e}")
+        infer_schema = None  # type: ignore[assignment]
+
+from pandera.errors import SchemaError, SchemaErrors
+
+# Import IO module if available
+try:
+    from pandera.io.tensordict_io import (
+        from_json,
+        from_yaml,
+        load,
+        save,
+        to_json,
+        to_yaml,
+    )
+
+    __all__.extend(
+        [
+            "from_json",
+            "from_yaml",
+            "to_json",
+            "to_yaml",
+            "save",
+            "load",
+        ]
+    )
+except ImportError:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ xarray = [
     "numpy >= 1.24.4",
 ]
 narwhals = ["narwhals >= 1.26.0"]
+torch = [
+    "torch",
+    "tensordict",
+]
 all = [
     "hypothesis >= 6.92.7",
     "scipy",
@@ -121,6 +125,8 @@ all = [
     "xarray >= 2024.10.0",
     "numpy >= 1.24.4",
     "narwhals >= 1.26.0",
+    "torch",
+    "tensordict",
 ]
 
 [dependency-groups]
@@ -155,6 +161,7 @@ testing = [
 ]
 docs = [
     "setuptools",
+    "duckdb",
     "pyarrow-hotfix",
     "sphinx<9",
     "sphinx-design",
@@ -166,11 +173,14 @@ docs = [
     "sphinx-docsearch",
     "grpcio",
     "ray",
+    "torch",
+    "tensordict",
     "types-click",
     "types-pytz",
     "types-pyyaml",
     "types-requests",
     "types-setuptools",
+    "xdoctest",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ pyspark[connect] >= 3.2.0
 polars >= 0.20.0
 xarray >= 2024.10.0
 narwhals >= 1.26.0
+torch
+tensordict
 modin
 protobuf
 geopandas

--- a/specs/pytorch-tensordict.md
+++ b/specs/pytorch-tensordict.md
@@ -1,0 +1,1296 @@
+# PyTorch TensorDict Integration Spec
+
+> **Status:** Draft
+> **Issue:** TBD
+> **Author:** opencode
+> **Related work:** [xarray-schema](https://github.com/xarray-contrib/xarray-schema)
+
+---
+
+## 1. Motivation
+
+[TensorDict](https://pytorch.org/tensordict/) is a powerful container for managing groups of tensors with the same batch dimension. It is central to many modern PyTorch workflows, especially in reinforcement learning and large-scale distributed training.
+
+Adding TensorDict support extends pandera's reach to the PyTorch ecosystem, providing a consistent validation API for high-dimensional tensor containers, alongside its existing tabular backends.
+
+### The Problem: Imperative Validation is Brittle
+
+In real-world ML pipelines, tensor containers often need to satisfy complex constraints that go beyond structural integrity:
+
+- Ensuring tensor values fall within a specific range (e.g., normalized inputs between -1 and 1).
+- Validating that specific keys exist with expected dtypes.
+- Checking that batch dimensions are consistent across all tensors.
+- Ensuring data meets quality standards before expensive training runs.
+
+While `tensordict` ensures that all tensors share a common `batch_size`, it doesn't provide built-in mechanisms for validating the **content** or **metadata** of those tensors. Developers often resort to verbose, imperative validation code that is hard to maintain and reuse.
+
+### The Solution: Declarative Schemas with Pandera
+
+Pandera adds value by enabling **declarative, schema-based validation** for TensorDict and tensorclass objects:
+
+1.  **Type Safety:** Catch structural errors at development time with Python type hints via `@check_types`.
+2.  **Complex Value Checks:** Leverage the existing Pandera `Check` ecosystem (e.g., `in_range`, `isin`, `greater_than`, etc.) for tensor values and dimensions.
+3.  **Unified API:** Use the same validation patterns across pandas, polars, and PyTorch for a consistent developer experience.
+4.  **Reusable Schemas:** Define validation logic once in a schema, then reuse it across multiple pipelines or data sources.
+
+---
+
+### Comprehensive Usage Examples
+
+#### Example 1: Validating TensorDict Structure and Values
+
+**Before (Imperative Validation - The "Pants on Fire" Approach)**
+
+```python
+import torch
+from tensordict import TensorDict
+
+def validate_batch(td: TensorDict):
+    """Manual validation - error-prone, hard to maintain."""
+    # Check batch size
+    assert td.batch_size[0] == 32, f"Expected batch_size[0]=32, got {td.batch_size[0]}"
+
+    # Check keys exist
+    assert "observation" in td, "Missing 'observation' key"
+    assert "action" in td, "Missing 'action' key"
+
+    # Check dtypes
+    assert td["observation"].dtype == torch.float32, f"Expected float32, got {td['observation'].dtype}"
+    assert td["action"].dtype == torch.float32, f"Expected float32, got {td['action'].dtype}"
+
+    # Check value ranges (normalized observations)
+    obs = td["observation"]
+    assert obs.min() >= -1.0, f"observation min value {obs.min()} < -1.0"
+    assert obs.max() <= 1.0, f"observation max value {obs.max()} > 1.0"
+
+    # Check action bounds
+    action = td["action"]
+    assert action.min() >= -2.0, f"action min value {action.min()} < -2.0"
+    assert action.max() <= 2.0, f"action max value {action.max()} > 2.0"
+
+# Usage
+batch = TensorDict({
+    "observation": torch.rand(32, 10) * 2 - 1,  # Range [-1, 1]
+    "action": torch.rand(32, 5) * 4 - 2           # Range [-2, 2]
+}, batch_size=[32])
+
+validate_batch(batch)  # Runs all checks
+```
+
+**After (Declarative Validation with Pandera)**
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera import Check
+
+# Define the schema once - reusable and self-documenting
+batch_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(32, 10),
+            checks=[
+                Check.greater_than_or_equal_to(-1.0),
+                Check.less_than_or_equal_to(1.0),
+            ]
+        ),
+        "action": pa.Tensor(
+            dtype=torch.float32,
+            shape=(32, 5),
+            checks=[
+                Check.greater_than_or_equal_to(-2.0),
+                Check.less_than_or_equal_to(2.0),
+            ]
+        ),
+    },
+    batch_size=(32,)  # Validate batch_size[0] == 32
+)
+
+# Usage - clean and simple
+batch = TensorDict({
+    "observation": torch.rand(32, 10) * 2 - 1,
+    "action": torch.rand(32, 5) * 4 - 2
+}, batch_size=[32])
+
+validated_batch = batch_schema.validate(batch)
+```
+
+#### Example 2: Lazy Validation with Multiple Errors
+
+When validation fails, you want to see **all** errors at once, not just the first one:
+
+```python
+import pandera.tensordict as pa
+from pandera import Check, SchemaError
+
+# Schema with multiple checks per tensor
+policy_schema = pa.TensorDictSchema(
+    keys={
+        "logits": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),  # None means "any size"
+            checks=Check.in_range(-10.0, 10.0)
+        ),
+        "values": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=Check.greater_than(0.0)  # Value estimates must be positive
+        ),
+    },
+    batch_size=(64,)
+)
+
+# Create invalid data
+invalid_batch = TensorDict({
+    "logits": torch.randn(64, 10) * 20,  # Some values outside [-10, 10]
+    "values": torch.randn(64)             # Some negative values
+}, batch_size=[64])
+
+# Validate with lazy=True to collect ALL errors
+try:
+    policy_schema.validate(invalid_batch, lazy=True)
+except pa.SchemaErrors as e:
+    print(e)
+    # Output shows both dtype and value errors for each key
+```
+
+#### Example 3: Declarative API with `TensorDictModel`
+
+For a more Pydantic-like experience, use class-based models. **Type annotations specify the dtype directly**, and `pa.Field` defines additional constraints:
+
+```python
+import torch
+import pandera.tensordict as pa
+from pandera import Check
+
+class PolicyModel(pa.TensorDictModel):
+    """Schema for a policy network output."""
+
+    # Dtype is specified in the type annotation, Field defines constraints
+    logits: torch.float32 = pa.Field(
+        shape=(None, 10),
+        ge=-5.0,
+        le=5.0
+    )
+    value: torch.float32 = pa.Field(
+        shape=(None,),
+        gt=0.0
+    )
+
+    class Config:
+        batch_size = (64,)
+
+# Validate using the model - schema is built automatically from class definition
+validated_batch = PolicyModel.validate(batch)
+```
+
+#### Example 4: Validating `tensorclass` Objects
+
+The same schema works for both `TensorDict` and `tensorclass`:
+
+```python
+from tensordict import TensorDict, tensorclass
+import pandera.tensordict as pa
+from pandera import Check
+
+# Define a schema
+rl_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(32, 64, 64, 3)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(32,), checks=Check.isin([0, 1, 2, 3])),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(32,)),
+        "done": pa.Tensor(dtype=torch.bool, shape=(32,)),
+    },
+    batch_size=(32,)
+)
+
+# Validate a TensorDict
+td = TensorDict({
+    "observation": torch.randn(32, 64, 64, 3),
+    "action": torch.randint(0, 4, (32,)),
+    "reward": torch.randn(32),
+    "done": torch.zeros(32, dtype=torch.bool)
+}, batch_size=[32])
+rl_schema.validate(td)  # Works!
+
+# Validate a tensorclass (same schema!)
+@tensorclass
+class RLData:
+    observation: torch.Tensor
+    action: torch.Tensor
+    reward: torch.Tensor
+    done: torch.Tensor
+
+tc = RLData(
+    observation=torch.randn(32, 64, 64, 3),
+    action=torch.randint(0, 4, (32,)),
+    reward=torch.randn(32),
+    done=torch.zeros(32, dtype=torch.bool),
+    batch_size=[32]
+)
+rl_schema.validate(tc)  # Works with tensorclass too!
+```
+
+#### Example 5: Coercion and Type Conversion
+
+Pandera can automatically convert types when needed:
+
+```python
+import pandera.tensordict as pa
+from pandera import Check
+
+# Schema with coercion enabled
+coercing_schema = pa.TensorDictSchema(
+    keys={
+        "features": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 128),
+            checks=Check.in_range(0.0, 1.0)
+        ),
+        "labels": pa.Tensor(dtype=torch.int32, shape=(None,)),
+    },
+    batch_size=(100,),
+    coerce=True  # Enable automatic dtype coercion
+)
+
+# Input has wrong dtype - will be coerced automatically
+td = TensorDict({
+    "features": torch.rand(100, 128),  # float64 by default
+    "labels": torch.arange(100, dtype=torch.int64)
+}, batch_size=[100])
+
+validated = coercing_schema.validate(td)
+# "features" is now float32, "labels" is now int32
+```
+
+#### Example 6: Validating Data at Rest (Serialization/Deserialization)
+
+TensorDict supports efficient serialization to disk (using `memmap` for large datasets). When loading data back, validation ensures no corruption occurred:
+
+```python
+import torch
+from tensordict import TensorDict, MemmapTensor
+import pandera.tensordict as pa
+from pandera import Check
+
+# Schema for serializable data
+dataset_schema = pa.TensorDictSchema(
+    keys={
+        "image": pa.Tensor(
+            dtype=torch.uint8,
+            shape=(None, 224, 224, 3),
+        ),
+        "label": pa.Tensor(dtype=torch.int64, shape=(None,)),
+        "weight": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=Check.greater_than_or_equal_to(0.0),
+        ),
+        "metadata": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),
+        ),
+    },
+    batch_size=(1000,),
+)
+
+# Save dataset to disk efficiently
+def save_dataset(td: TensorDict, path: str):
+    """Save TensorDict with memmap for large datasets."""
+    td.memmap_(path)
+    return td
+
+# Load and validate - catches disk corruption, dtype mismatches, etc.
+def load_and_validate_dataset(path: str) -> TensorDict:
+    """Load dataset and validate before use."""
+    td = TensorDict.load(path)
+
+    # Validate schema compliance
+    validated = dataset_schema.validate(td)
+
+    return validated
+
+# Create and save a large dataset (e.g., ImageNet subset)
+dataset = TensorDict({
+    "image": torch.randint(0, 256, (10000, 224, 224, 3), dtype=torch.uint8),
+    "label": torch.randint(0, 1000, (10000,)),
+    "weight": torch.rand(10000).abs(),
+    "metadata": torch.randn(10000, 10),
+}, batch_size=[10000])
+
+save_dataset(dataset, "./data/image_dataset")
+
+# Later: Load and validate before training
+training_data = load_and_validate_dataset("./data/image_dataset")
+# training_data is guaranteed to have correct dtypes, shapes, and value ranges
+```
+
+#### Example 7: Validating TensorClass Serialization
+
+`tensorclass` objects can also be serialized. Pandera validates upon deserialization:
+
+```python
+import torch
+from tensordict import TensorDict, tensorclass
+import pandera.tensordict as pa
+from pandera import Check
+
+# Define a tensorclass for robot trajectory data
+@tensorclass
+class TrajectoryData:
+    states: torch.Tensor      # (T, state_dim)
+    actions: torch.Tensor    # (T, action_dim)
+    rewards: torch.Tensor    # (T,)
+    dones: torch.Tensor      # (T,)
+    returns_to_go: torch.Tensor  # (T,)
+
+# Schema for trajectory validation
+trajectory_schema = pa.TensorDictSchema(
+    keys={
+        "states": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 64),  # state_dim
+            checks=[
+                Check.no_nan(),
+                Check.no_inf(),
+            ]
+        ),
+        "actions": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 8),  # action_dim
+            checks=Check.in_range(-1.0, 1.0),  # Normalized actions
+        ),
+        "rewards": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "dones": pa.Tensor(dtype=torch.bool, shape=(None,)),
+        "returns_to_go": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=Check.greater_than_or_equal_to(0.0),
+        ),
+    },
+    batch_size=(None,)  # Variable length trajectories
+)
+
+# Save/Load tensorclass data
+def save_trajectory(tc: TrajectoryData, path: str):
+    """Serialize tensorclass to disk."""
+    tc.save(path)
+
+def load_trajectory(path: str) -> TrajectoryData:
+    """Load and validate tensorclass from disk."""
+    tc = TrajectoryData.load(path)
+
+    # Validate - catches any corruption from disk I/O
+    return trajectory_schema.validate(tc)
+
+# Create and save trajectory
+trajectory = TrajectoryData(
+    states=torch.randn(100, 64),
+    actions=torch.rand(100, 8) * 2 - 1,
+    rewards=torch.randn(100),
+    dones=torch.zeros(100, dtype=torch.bool),
+    returns_to_go=torch.cumsum(torch.randn(100).abs(), dim=0),
+    batch_size=[100]
+)
+
+save_trajectory(trajectory, "./data/trajectory.pt")
+
+# Load before training - validates data integrity
+loaded_trajectory = load_trajectory("./data/trajectory.pt")
+
+# Now safe to use in offline RL algorithms (CQL, IQL, etc.)
+```
+
+#### Example 8: Batch Validation for Large-Scale Datasets
+
+For large datasets, validate in batches to catch issues early:
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera import Check
+from pathlib import Path
+
+# Schema for a large stored dataset
+large_dataset_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 128)),
+        "action": pa.Tensor(dtype=torch.float32, shape=(None, 16)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "next_observation": pa.Tensor(dtype=torch.float32, shape=(None, 128)),
+        "done": pa.Tensor(dtype=torch.bool, shape=(None,)),
+    },
+    batch_size=(1024,)
+)
+
+# Validate all batches in a directory of TensorDicts
+def validate_dataset_directory(data_dir: Path) -> list[str]:
+    """Validate all TensorDict files in a directory."""
+    errors = []
+    schema = large_dataset_schema
+
+    for td_file in sorted(data_dir.glob("*.pt")):
+        td = TensorDict.load(td_file)
+
+        try:
+            schema.validate(td, lazy=True)
+        except pa.SchemaErrors as e:
+            errors.append(f"{td_file}: {e}")
+
+    return errors
+
+# Check entire dataset before starting training
+data_errors = validate_dataset_directory(Path("./data/experience_buffer"))
+
+if data_errors:
+    print("Dataset validation failed:")
+    for err in data_errors:
+        print(f"  - {err}")
+else:
+    print("Dataset validation passed - ready for training!")
+```
+
+#### Example 9: Validating TorchRL Rollouts
+
+Real RL pipelines like those in [TorchRL](https://pytorch.org/rl/) rely on environment rollouts. Pandera ensures rollouts meet expected specifications before going into the replay buffer or training loop:
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera import Check
+
+# Schema for a typical TorchRL environment rollout
+rollout_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 4, 64, 64),  # Image observation (CIFAR-like)
+            checks=[
+                Check.greater_than_or_equal_to(0.0),  # Pixel values normalized
+                Check.less_than_or_equal_to(1.0),
+            ]
+        ),
+        "action": pa.Tensor(dtype=torch.float32, shape=(None, 2)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "done": pa.Tensor(dtype=torch.bool, shape=(None,)),
+        "next": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 4, 64, 64),
+        ),
+    },
+    batch_size=(256,)  # Rollout batch size
+)
+
+# Simulate a TorchRL environment rollout
+def collect_rollout(env, policy, num_steps=256):
+    rollout = env.rollout(max_steps=num_steps, policy=policy)
+    return rollout
+
+# Validate before adding to replay buffer
+rollout = collect_rollout(env, policy)
+validated_rollout = rollout_schema.validate(rollout)  # Fails fast if invalid
+
+# Add to replay buffer - now we know data is valid!
+replay_buffer.add(validated_rollout)
+```
+
+#### Example 7: Replay Buffer Validation with TorchRL
+
+When sampling from replay buffers in large-scale training, you want to validate that the sampled batches meet your schema. This is especially important when using heterogeneous storage backends:
+
+```python
+from torchrl.data.replay_buffers import ReplayBuffer
+from torchrl.data.replay_buffers.storages import LazyTensorStorage
+import pandera.tensordict as pa
+from pandera import Check
+
+# Define schema for replay buffer contents
+replay_schema = pa.TensorDictSchema(
+    keys={
+        "state": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "next_state": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "done": pa.Tensor(dtype=torch.bool, shape=(None,)),
+        "priority": pa.Tensor(dtype=torch.float32, shape=(None,)),
+    },
+    batch_size=(256,),
+    # Allow dtype coercion for storage efficiency
+    coerce=True,
+)
+
+# Create replay buffer (like in distributed training)
+replay_buffer = ReplayBuffer(
+    storage=LazyTensorStorage(max_size=100000),
+    batch_size=256,
+)
+
+# Validate sampled data before training
+def train_step():
+    batch = replay_buffer.sample()
+
+    # Validate the batch - catch data corruption or storage errors
+    validated_batch = replay_schema.validate(batch)
+
+    # Now safe to pass to loss computation
+    loss = compute_ppo_loss(validated_batch)
+    loss.backward()
+    optimizer.step()
+```
+
+#### Example 8: Actor-Critic Model Output Validation
+
+In actor-critic methods (PPO, A2C, etc.), both the policy and value networks output structured data. Pandera validates these outputs match expected signatures:
+
+```python
+import torch
+import pandera.tensordict as pa
+from pandera import Check
+
+# Schema for actor-critic network output
+class ActorCriticOutput(pa.TensorDictModel):
+    """Output from an actor-critic network."""
+
+    action_mean: torch.Tensor = pa.Field(
+        dtype=torch.float32,
+        shape=(None, 4),  # 4D action space
+        ge=-2.0,
+        le=2.0,
+    )
+    action_std: torch.Tensor = pa.Field(
+        dtype=torch.float32,
+        shape=(None, 4),
+        gt=1e-6,  # Standard deviation > 0
+    )
+    value: torch.Tensor = pa.Field(
+        dtype=torch.float32,
+        shape=(None,),
+        gt=-100.0,  # Reasonable value bounds
+        lt=100.0,
+    )
+
+    class Config:
+        batch_size = (32,)
+
+# Validate model output before computing loss
+model = ActorCriticNetwork()
+batch = TensorDict({"observation": torch.randn(32, 64)}, batch_size=[32])
+
+# Forward pass
+output = model(batch)
+
+# Validate output - ensures no NaN/Inf from unstable training
+validated = ActorCriticOutput().validate(output)
+
+# Safe to use in PPO loss
+ppo_loss = compute_ppo_loss(validated["action_mean"], validated["action_std"], validated["value"])
+```
+
+#### Example 9: Distributed Training Data Validation
+
+In distributed RL training, data flows between collectors, replay buffers, and trainers. Schema validation at each stage ensures data integrity:
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+from pandera import Check
+
+# Define a unified schema for the entire training pipeline
+training_schema = pa.TensorDictSchema(
+    keys={
+        # Environment interaction data
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 17)),
+        "action": pa.Tensor(dtype=torch.float32, shape=(None, 6)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "done": pa.Tensor(dtype=torch.bool, shape=(None,)),
+
+        # PPO-specific data
+        "log_prob": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "value": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "advantage": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        "return": pa.Tensor(dtype=torch.float32, shape=(None,)),
+    },
+    batch_size=(512,),
+)
+
+# Validator for data collector (ensures valid env interactions)
+collector_validator = training_schema
+
+# Validator for trainer (additional PPO-specific checks)
+trainer_validator = pa.TensorDictSchema(
+    keys={
+        **training_schema.keys,
+        "log_prob": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=Check.less_than(0.0),  # Log prob should be negative
+        ),
+        "advantage": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None,),
+            checks=[
+                Check.mean().greater_than(0.0),  # Positive advantage on average
+            ],
+        ),
+    },
+    batch_size=(512,),
+)
+
+# In your distributed training loop:
+def distributed_train_step(collector_rank, trainer_rank):
+    # Collect experiences
+    experience = collector.collect_experiences()
+
+    # Validate before sending to replay buffer
+    validated_exp = collector_validator.validate(experience)
+
+    # Send to buffer (RRef)
+    replay_buffer_ref.add(validated_exp)
+
+    # Trainer pulls batch
+    batch = replay_buffer_ref.sample()
+
+    # Validate before training
+    validated_batch = trainer_validator.validate(batch)
+
+    # Train
+    optimizer.zero_grad()
+    loss = compute_ppo_loss(validated_batch)
+    loss.backward()
+    optimizer.step()
+```
+
+#### Example 10: Integration with Custom TensorDictModules
+
+For users building custom neural network modules with `tensordict.nn`, Pandera can validate inputs/outputs:
+
+```python
+import torch
+import torch.nn as nn
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+import pandera.tensordict as pa
+from pandera import Check
+
+# Custom module that processes observations
+class CustomEncoder(TensorDictModule):
+    def __init__(self):
+        super().__init__(
+            module=nn.Sequential(
+                nn.Linear(128, 256),
+                nn.ReLU(),
+                nn.Linear(256, 128),
+            ),
+            in_keys=["observation"],
+            out_keys=["encoded"],
+        )
+
+# Schema for encoder input/output
+encoder_schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 128),
+            checks=[
+                Check.greater_than_or_equal_to(-10.0),  # Input bounds
+                Check.less_than_or_equal_to(10.0),
+                Check.no_inf(),  # No infinite values
+                Check.no_nan(),  # No NaN values
+            ]
+        ),
+        "encoded": pa.Tensor(
+            dtype=torch.float32,
+            shape=(None, 128),
+            checks=[
+                Check.no_nan(),
+                Check.no_inf(),
+            ]
+        ),
+    },
+    batch_size=(32,)
+)
+
+# Validation hook for model inputs/outputs
+def validate_encoder_io(td: TensorDict) -> TensorDict:
+    """Validate encoder input/output for debugging."""
+    return encoder_schema.validate(td)
+
+# Usage in training loop
+encoder = CustomEncoder()
+batch = TensorDict({"observation": torch.randn(32, 128)}, batch_size=[32])
+
+# Forward pass with validation
+encoded = encoder(batch)  # First pass through model
+
+# Validate - catches numerical instability
+validated = validate_encoder_io(encoded)
+
+print(f"Encoded mean: {validated['encoded'].mean():.4f}")
+```
+
+## 2. TensorDict Data Model Primer
+
+Reference: [TensorDict documentation](https://pytorch.org/tensordict/)
+
+### 2.1 Core Container Types
+
+| TensorDict type | Description |
+|---|---|
+| `tensordict` | A dict-like container of tensors that share a common batch dimension. Analogous to a pandas `DataFrame`. |
+| `tensorclass` | A class-based representation of a TensorDict where entries are mapped to class attributes. |
+
+### 2.2 Key Concepts
+
+- **batch_size** — A `Size` object representing the common leading dimensions of all tensors in the container. This is the fundamental structural constraint.
+- **keys** — The names of the entries within the container.
+- **tensors** — The actual PyTorch tensors stored within the container, all sharing the same `batch_size`.
+- **dtype** — The expected data type for the underlying tensors.
+
+---
+
+
+
+## 3. Design Principles
+
+### 3.1 Small Public API Surface
+
+The public API should be minimal and consistent with other backends:
+- **Schema classes**: `TensorDictSchema`.
+- **Model classes**: `TensorDictModel`.
+- **Component classes**: `Tensor` (analogous to `Column`).
+
+### 3.2 Consistent with Existing Pandera Patterns
+
+The implementation must follow pandera's layered architecture:
+1. **API layer** (`pandera/api/tensordict/`)
+2. **Backend layer** (`pandera/backends/tensordict/`)
+3. **Engine layer** (`pandera/engines/tensordict_engine.py`)
+
+### 3.3 Schema Components Mirror the pandas Pattern
+
+- `TensorDictSchema` → standalone schema for a `tensordict` or `tensorclass`.
+- `Tensor` → defines constraints for a single entry in the container (dtype, shape/size, checks).
+
+### 3.4 Leverage `Check` for Data-Level Validation
+
+Structural validation (batch size, keys, dtypes) is handled by schema keyword arguments. Data-level validation (tensor values, ranges, etc.) is handled via pandera's existing `Check` system.
+
+---
+
+
+
+## 4. Public API Design
+
+### 4.1 Entry Point
+
+```python
+import pandera.tensordict as pa
+```
+
+### 4.2 `TensorDictSchema`
+
+`TensorDictSchema` validates a `tensordict`.
+
+```python
+class TensorDictSchema(BaseSchema):
+    def __init__(
+        self,
+        keys: dict[str, Tensor] | list[str] | None = None,
+        batch_size: tuple[int, ...] | None = None,
+        dtype: torch.dtype | None = None,
+        checks: Check | list[Check] | None = None,
+        coerce: bool = False,
+        nullable: bool = False,
+        # ... other common params
+    ):
+        ...
+
+    def validate(self, check_obj: TensorDict, ...) -> TensorDict:
+        ...
+
+    def validate(self, check_obj: TensorClass, ...) -> TensorClass:
+        ...
+```
+
+### 4.3 `TensorDict` validation (for `tensorclass`)
+
+Validates a `*tensorclass*` object, ensuring it adheres to the specified structure and types.
+
+### 4.4 Class-Based Models (Declarative API)
+
+Using `TensorDictModel` for class-based definitions.
+
+```python
+class MyTensorDictModel(pa.TensorDictModel):
+    data: torch.Tensor = pa.Field(dtype=torch.float32, shape=(None, 10))
+    label: torch.Tensor = pa.Field(dtype=torch.int64, shape=(None,))
+
+    class Config:
+        batch_size = (None,)
+```
+
+
+
+### 4.5 Class-Based Model Implementation
+
+The `TensorDictModel` class follows the same pattern as `xarray.DatasetModel` and `pandas.DataFrameModel`. The API supports direct usage of `pa.Field` in type annotations without requiring custom `_field` classmethods or other complex patterns.
+
+**Key principles:**
+- Use PyTorch dtypes (e.g., `torch.float32`, `torch.int64`) in type annotations
+- Define constraints using `pa.Field()` descriptor
+- Configuration via nested `Config` class
+
+#### Example: Complete Model Definition
+
+```python
+import torch
+import pandera.tensordict as pa
+from pandera import Check
+
+class RLModel(pa.TensorDictModel):
+    """Reinforcement learning model output schema."""
+
+    # Dtype in annotation, constraints in Field
+    observation: torch.float32 = pa.Field(shape=(None, 128))
+    action: torch.int64 = pa.Field(
+        shape=(None,),
+        checks=Check.isin([0, 1, 2, 3])
+    )
+    reward: torch.float32 = pa.Field()
+
+    class Config:
+        batch_size = (32,)
+
+# Access schema directly
+schema = RLModel.to_schema()
+
+# Or validate directly
+batch = TensorDict({
+    "observation": torch.randn(32, 128),
+    "action": torch.randint(0, 4, (32,)),
+    "reward": torch.randn(32)
+}, batch_size=[32])
+
+validated = RLModel.validate(batch)
+```
+
+#### Example: Class-Based Model with Field-Level Checks
+
+```python
+class ActorCriticOutput(pa.TensorDictModel):
+    """Actor-critic network output."""
+
+    action_mean: torch.float32 = pa.Field(
+        shape=(None, 4),
+        ge=-2.0,
+        le=2.0,
+    )
+    action_std: torch.float32 = pa.Field(
+        shape=(None, 4),
+        gt=1e-6,
+    )
+    value: torch.float32 = pa.Field(
+        shape=(None,),
+        gt=-100.0,
+        lt=100.0,
+    )
+
+    class Config:
+        batch_size = (32,)
+```
+
+#### Example: Lazy Validation with Class-Based Model
+
+```python
+# Create invalid data
+invalid_batch = TensorDict({
+    "observation": torch.randn(32, 128),
+    "action": torch.randint(0, 4, (16,)),  # Wrong batch size!
+    "reward": torch.randn(32)
+}, batch_size=[32])
+
+try:
+    RLModel.validate(invalid_batch, lazy=True)
+except pa.SchemaErrors as e:
+    print(e)  # Shows all validation errors
+```
+
+#### Example: TensorDictSchema vs TensorDictModel
+
+For simple use cases, `TensorDictSchema` is sufficient:
+
+```python
+# Standalone schema - no class definition needed
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(32,)
+)
+
+validated = schema.validate(batch)
+```
+
+For reusable, self-documenting schemas with type hints, use `TensorDictModel`:
+
+```python
+class MySchema(pa.TensorDictModel):
+    observation: torch.float32 = pa.Field(shape=(None, 10))
+    action: torch.int64 = pa.Field(shape=(None,))
+
+    class Config:
+        batch_size = (32,)
+
+# Schema is automatically built from class definition
+schema = MySchema.to_schema()  # Same as standalone schema above!
+validated = MySchema.validate(batch)  # Direct validation
+```
+
+---
+
+
+---
+
+## 5. Implementation Roadmap
+
+### Phase 1: Core Infrastructure & API
+- Define `pandera/api/tensordict/` structure.
+- Implement `TensorDictSchema` and `Tensor`.
+- Implement basic batch size and key existence validation.
+- Create the engine for PyTorch dtype resolution.
+
+### Phase 2: Backend Implementation
+- Implement `pandera/backends/tensordict/` logic.
+- Implement structural checks (dtype, shape/size of entries).
+- Integrate with Pandera's existing `Check` system for tensor value validation.
+- Ensure support for both `TensorDict` and `tensorclass` objects.
+
+### Phase 3: Advanced Features & Integration
+- Support for `coerce=True` (dtype/shape coercion).
+- Implementation of specialized TensorDict checks (e.g., cross-entry constraints).
+- Comprehensive test suite coverage across all backend features.
+
+### Phase 4: Schema Inference, IO, and Hypothesis Strategies
+- **Schema Inference**: Infer TensorDict schemas from data using `pa.infer_schema()`.
+- **IO Serialization/Deserialization**: Support for saving/loading TensorDicts with schema validation (JSON, YAML, Torch formats).
+- **Hypothesis Strategies**: Generate test data with Hypothesis for property-based testing of TensorDict schemas.
+
+---
+
+### 7.1 Schema Inference
+
+Automatically infer a `TensorDictSchema` from existing data:
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Existing data
+data = TensorDict({
+    "observation": torch.randn(100, 64),
+    "action": torch.randint(0, 4, (100,)),
+    "reward": torch.randn(100),
+}, batch_size=[100])
+
+# Infer schema from data
+schema = pa.infer_schema(data)
+print(schema)
+
+# Output includes inferred dtypes, shapes, and value ranges
+```
+
+**Features:**
+- Automatically detect dtypes (torch.float32, torch.int64, etc.)
+- Infer shape dimensions (including batch_size)
+- Detect value ranges and patterns from sample data
+- Support for both `TensorDict` and `tensorclass` objects
+
+### 7.2 IO Serialization/Deserialization
+
+#### 7.2.1 Save/Load with Schema Validation
+
+```python
+import torch
+from tensordict import TensorDict
+import pandera.tensordict as pa
+
+# Define schema
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+        "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+    },
+    batch_size=(1000,),
+)
+
+# Save dataset with schema metadata
+dataset = TensorDict({
+    "observation": torch.randn(1000, 64),
+    "action": torch.randint(0, 4, (1000,)),
+    "reward": torch.randn(1000),
+}, batch_size=[1000])
+
+# Save to disk
+schema.save(dataset, "./data/dataset.pt")
+
+# Load and validate
+loaded = schema.load("./data/dataset.pt")
+```
+
+#### 7.2.2 YAML/JSON Configuration Files
+
+Define schemas in configuration files:
+
+```python
+import pandera.tensordict as pa
+
+# Load schema from YAML
+schema = pa.TensorDictSchema.from_yaml("config/schema.yaml")
+
+# Save schema to YAML
+schema.to_yaml("config/schema.yaml")
+```
+
+**YAML Example:**
+```yaml
+keys:
+  observation:
+    dtype: float32
+    shape: [null, 64]
+  action:
+    dtype: int64
+    shape: [null]
+  reward:
+    dtype: float32
+    shape: [null]
+batch_size: [1000]
+coerce: true
+```
+
+#### 7.2.3 Integration with Memmap and Large Datasets
+
+```python
+import torch
+from tensordict import TensorDict, MemmapTensor
+import pandera.tensordict as pa
+
+# Schema for memmap-backed datasets
+schema = pa.TensorDictSchema(
+    keys={
+        "image": pa.Tensor(dtype=torch.uint8, shape=(None, 224, 224, 3)),
+        "label": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(10000,),
+)
+
+# Create memmap-backed dataset
+dataset = TensorDict({
+    "image": MemmapTensor(10000, 224, 224, 3, dtype=torch.uint8),
+    "label": MemmapTensor(10000, dtype=torch.int64),
+}, batch_size=[10000])
+
+# Save to disk with schema
+schema.save(dataset, "./data/large_dataset")
+
+# Load with validation
+loaded = schema.load("./data/large_dataset")
+```
+
+### 7.3 Hypothesis Strategies
+
+Generate test data for property-based testing:
+
+```python
+import torch
+from hypothesis import given, strategies as st
+import pandera.tensordict as pa
+from pandera.strategies import tensordict_strategies as tgt_strats
+
+# Define schema
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(32,),
+)
+
+# Generate valid TensorDicts for testing
+@given(tgt_strats.tensordict(schema))
+def test_policy_output(td):
+    """Property-based test for policy network."""
+    # schema validates automatically
+    assert td["observation"].shape == (32, 10)
+    assert td["action"].dtype == torch.int64
+
+# Generate data with custom constraints
+custom_strategy = tgt_strats.tensordict(
+    schema,
+    observation_kwargs={"min_value": -1.0, "max_value": 1.0},
+)
+
+@given(custom_strategy)
+def test_normalized_inputs(td):
+    """Test that observations are normalized."""
+    assert td["observation"].min() >= -1.0
+    assert td["observation"].max() <= 1.0
+
+# Generate tensorclasses
+@tensorclass
+class RLData:
+    observation: torch.Tensor
+    action: torch.Tensor
+
+schema = pa.TensorDictSchema(
+    keys={
+        "observation": pa.Tensor(dtype=torch.float32, shape=(None, 64)),
+        "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+    },
+    batch_size=(64,),
+)
+
+@given(tgt_strats.tensorclass(RLData, schema))
+def test_tensorclass_generation(tc):
+    """Generate and validate tensorclass objects."""
+    assert tc.batch_size == [64]
+```
+
+**Features:**
+- Automatic strategy generation from schema definitions
+- Support for dtype constraints (e.g., `min_value`, `max_value`)
+- Integration with Hypothesis' existing strategies
+- Works with both `TensorDict` and `tensorclass`
+
+### 7.4 Complete Phase 4 Example: ML Pipeline with Validation
+
+```python
+import torch
+from tensordict import TensorDict, tensorclass
+import pandera.tensordict as pa
+from pandera.strategies import tensordict_strategies as tgt_strats
+from hypothesis import given, settings
+import yaml
+
+# Define schema in YAML config
+config = """
+keys:
+  observation:
+    dtype: float32
+    shape: [null, 128]
+  action:
+    dtype: int64
+    shape: [null]
+  reward:
+    dtype: float32
+    shape: [null]
+batch_size: [256]
+coerce: true
+"""
+
+# Save schema to file
+with open("config/rl_schema.yaml", "w") as f:
+    f.write(config)
+
+# Load schema from config
+schema = pa.TensorDictSchema.from_yaml("config/rl_schema.yaml")
+
+# Phase 4.1: Infer schema from sample data
+sample_data = TensorDict({
+    "observation": torch.randn(256, 128),
+    "action": torch.randint(0, 4, (256,)),
+    "reward": torch.randn(256),
+}, batch_size=[256])
+
+inferred_schema = pa.infer_schema(sample_data)
+assert inferred_schema.batch_size == schema.batch_size
+
+# Phase 4.2: IO with validation
+schema.save(sample_data, "./data/rl_dataset.pt")
+loaded = schema.load("./data/rl_dataset.pt")
+
+# Phase 4.3: Hypothesis-based testing
+@given(tgt_strats.tensordict(schema))
+@settings(max_examples=100)
+def test_training_batch(td):
+    """Property-based test for RL training batches."""
+    assert td["observation"].shape == (256, 128)
+    assert td["action"].max() < 4  # Action space size
+    assert td["reward"].dtype == torch.float32
+
+# Run tests
+test_training_batch()
+
+# Phase 4.4: Schema evolution
+# Save schema for version tracking
+schema.to_yaml("config/rl_schema_v1.yaml")
+
+# Later: load and evolve schema
+updated_schema = pa.TensorDictSchema.from_yaml("config/rl_schema_v1.yaml")
+updated_schema.keys["new_feature"] = pa.Tensor(dtype=torch.float32, shape=(None,))
+updated_schema.to_yaml("config/rl_schema_v2.yaml")
+```
+
+---
+
+## 6. Architecture
+
+### 6.1 Module Layout
+
+```
+pandera/
+├── api/
+│   └── tensordict/
+│       ├── __init__.py
+│       ├── container.py        # TensorDictSchema
+│       ├── components.py       # Tensor
+│       ├── model.py            # TensorDictModel
+│       ├── model_components.py # Field, TensorDictFieldInfo
+│       ├── model_config.py     # BaseConfig
+│       └── types.py            # Type aliases
+├── backends/
+│   └── tensordict/
+│       ├── __init__.py
+│       ├── base.py             # TensorDictSchemaBackend
+│       ├── checks.py           # TensorDictCheckBackend
+│       └── register.py         # Backend registration
+├── engines/
+│   └── tensordict_engine.py    # Engine for torch dtype registry
+├── strategies/
+│   └── tensordict_strategies.py  # Hypothesis strategies
+└── schema_inference/
+    └── tensordict.py           # Schema inference logic
+└── tensordict.py               # Entry point: import pandera.tensordict as pa
+```
+
+### 6.2 Phase 4 API
+
+```python
+import pandera.tensordict as pa
+from pandera.strategies import tensordict_strategies as tgt_strats
+
+# Schema inference
+schema = pa.infer_schema(data)
+
+# IO operations
+schema.save(tensor_dict, "path.pt")
+loaded = schema.load("path.pt")
+
+# YAML/JSON support
+schema.to_yaml("config.yaml")
+schema = pa.TensorDictSchema.from_yaml("config.yaml")
+
+# Hypothesis strategies
+@given(tgt_strats.tensordict(schema))
+def test_my_function(td):
+    ...
+```
+
+---

--- a/tests/tensordict/__init__.py
+++ b/tests/tensordict/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for pandera tensordict integration."""

--- a/tests/tensordict/test_tensordict_container.py
+++ b/tests/tensordict/test_tensordict_container.py
@@ -1,0 +1,971 @@
+"""Unit tests for TensorDict container and components."""
+
+import pytest
+
+try:
+    import torch
+    from tensordict import TensorDict, tensorclass
+except ImportError:
+    torch = None
+    TensorDict = None
+    tensorclass = None
+
+torch_condition = pytest.mark.skipif(
+    torch is None, reason="torch not installed"
+)
+
+
+@torch_condition
+class TestTensorComponent:
+    """Tests for Tensor component."""
+
+    def test_tensor_creation(self):
+        """Test Tensor component creation."""
+        from pandera.tensordict import Tensor
+
+        tensor = Tensor(dtype=torch.float32, shape=(None, 10))
+        assert tensor.dtype.type == torch.float32
+        assert tensor.shape == (None, 10)
+
+    def test_tensor_with_checks(self):
+        """Test Tensor component with checks."""
+        from pandera import Check
+        from pandera.tensordict import Tensor
+
+        tensor = Tensor(
+            dtype=torch.float32,
+            shape=(None, 10),
+            checks=Check.greater_than(0.0),
+        )
+        assert tensor.dtype.type == torch.float32
+        assert tensor.shape == (None, 10)
+        assert len(tensor.checks) == 1
+
+    def test_tensor_repr(self):
+        """Test Tensor repr."""
+        from pandera.tensordict import Tensor
+
+        tensor = Tensor(dtype=torch.float32, shape=(None, 10))
+        repr_str = repr(tensor)
+        assert "Tensor" in repr_str
+        assert "float32" in repr_str
+
+
+@torch_condition
+class TestTensorDictSchema:
+    """Tests for TensorDictSchema."""
+
+    def test_tensordict_schema_creation(self):
+        """Test TensorDictSchema creation."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(None, 10)),
+                "action": Tensor(dtype=torch.float32, shape=(None, 5)),
+            },
+            batch_size=(32,),
+        )
+        assert "observation" in schema.keys
+        assert "action" in schema.keys
+        assert schema.batch_size == (32,)
+
+    def test_tensordict_schema_from_list(self):
+        """Test TensorDictSchema creation from key list."""
+        from pandera.tensordict import TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys=["observation", "action"], batch_size=(32,)
+        )
+        assert "observation" in schema.keys
+        assert "action" in schema.keys
+
+    def test_tensordict_schema_repr(self):
+        """Test TensorDictSchema repr."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32),
+            },
+            batch_size=(32,),
+        )
+        repr_str = repr(schema)
+        assert "TensorDictSchema" in repr_str
+        assert "observation" in repr_str
+
+
+@torch_condition
+class TestTensorDictValidation:
+    """Tests for TensorDict validation."""
+
+    def test_validate_valid_tensordict(self):
+        """Test validation of valid TensorDict."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(32, 10)),
+                "action": Tensor(dtype=torch.float32, shape=(32, 5)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {
+                "observation": torch.randn(32, 10),
+                "action": torch.randn(32, 5),
+            },
+            batch_size=[32],
+        )
+
+        result = schema.validate(td)
+        assert isinstance(result, TensorDict)
+
+    def test_validate_invalid_batch_size(self):
+        """Test validation fails with wrong batch size."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(32, 10)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {"observation": torch.randn(16, 10)},
+            batch_size=[16],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_validate_missing_key(self):
+        """Test validation fails with missing key."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32),
+                "action": Tensor(dtype=torch.float32),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {"observation": torch.randn(32, 10)},
+            batch_size=[32],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_validate_wrong_dtype(self):
+        """Test validation fails with wrong dtype."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {"observation": torch.randn(32, 10).to(torch.float64)},
+            batch_size=[32],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_validate_wrong_shape(self):
+        """Test validation fails with wrong shape."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(32, 10)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {"observation": torch.randn(32, 20)},
+            batch_size=[32],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_validate_lazy(self):
+        """Test lazy validation collects all errors."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(None, 10)),
+                "action": Tensor(dtype=torch.float32, shape=(None, 5)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {"observation": torch.randn(32, 10), "action": torch.randn(16, 5)},
+            batch_size=None,
+        )
+
+        with pytest.raises(errors.SchemaErrors) as exc_info:
+            schema.validate(td, lazy=True)
+
+        assert len(exc_info.value.schema_errors) > 0
+
+
+@torch_condition
+class TestTensorDictSchemaChecks:
+    """Tests for TensorDictSchema with value checks."""
+
+    def test_validate_with_value_check(self):
+        """Test validation with value check."""
+        from pandera import Check
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "values": Tensor(
+                    dtype=torch.float32,
+                    shape=(None,),
+                    checks=Check.greater_than(0.0),
+                ),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict(
+            {
+                "values": torch.tensor(
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+                )
+            },
+            batch_size=[10],
+        )
+
+        result = schema.validate(td)
+        assert isinstance(result, TensorDict)
+
+    def test_validate_value_check_failure(self):
+        """Test validation fails with value check failure."""
+        from pandera import Check, errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "values": Tensor(
+                    dtype=torch.float32,
+                    shape=(None,),
+                    checks=Check.greater_than(0.0),
+                ),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict(
+            {
+                "values": torch.tensor(
+                    [1.0, -2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+                )
+            },
+            batch_size=[10],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+
+@torch_condition
+class TestTensorDictSchemaBatchSize:
+    """Tests for batch size validation."""
+
+    def test_batch_size_with_none_dimension(self):
+        """Test batch size with None dimension allows any size."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(None, 10)),
+            },
+            batch_size=(None,),
+        )
+
+        td = TensorDict({"observation": torch.randn(5, 10)}, batch_size=[5])
+        result = schema.validate(td)
+        assert isinstance(result, TensorDict)
+
+        td = TensorDict(
+            {"observation": torch.randn(100, 10)}, batch_size=[100]
+        )
+        result = schema.validate(td)
+        assert isinstance(result, TensorDict)
+
+    def test_batch_size_exact_match(self):
+        """Test batch size must match exactly when specified."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(None, 10)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict({"observation": torch.randn(64, 10)}, batch_size=[64])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+
+@torch_condition
+class TestShapeValidation:
+    """Tests for shape validation."""
+
+    def test_shape_with_none_allows_any(self):
+        """Test shape with None allows any size for that dimension."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32, shape=(None, None, 3)),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"data": torch.randn(10, 32, 3)}, batch_size=[10])
+        result = schema.validate(td)
+        assert isinstance(result, TensorDict)
+
+    def test_shape_exact_match(self):
+        """Test shape must match exactly when specified."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32, shape=(32, 10)),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict({"data": torch.randn(32, 20)}, batch_size=[32])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+
+@torch_condition
+class TestTensorClassValidation:
+    """Tests for tensorclass validation."""
+
+    def test_validate_tensorclass(self):
+        """Test validation of tensorclass object."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        @tensorclass
+        class TCData:
+            observation: torch.Tensor
+            action: torch.Tensor
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(32, 10)),
+                "action": Tensor(dtype=torch.float32, shape=(32, 5)),
+            },
+            batch_size=(32,),
+        )
+
+        tc = TCData(
+            observation=torch.randn(32, 10),
+            action=torch.randn(32, 5),
+            batch_size=[32],
+        )
+
+        result = schema.validate(tc)
+        assert result is not None
+
+
+@torch_condition
+class TestTensorDictErrorCases:
+    """Comprehensive error case tests."""
+
+    def test_invalid_input_type(self):
+        """Test validation fails with non-TensorDict input."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(keys={"x": Tensor(dtype=torch.float32)})
+
+        with pytest.raises(
+            errors.BackendNotFoundError, match="Backend not found"
+        ):
+            schema.validate({"x": torch.randn(10)})
+
+    def test_invalid_tensor_in_tensordict(self):
+        """Test validation fails when key contains non-tensor."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": "not a tensor"}, batch_size=[10])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_batch_size_length_mismatch(self):
+        """Test validation fails when batch_size dimensions don't match."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10, 5),
+        )
+
+        td = TensorDict({"x": torch.randn(10)}, batch_size=[10])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_batch_size_value_mismatch_first_dim(self):
+        """Test validation fails when first batch_size dimension doesn't match."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": torch.randn(5)}, batch_size=[5])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_batch_size_value_mismatch_second_dim(self):
+        """Test validation fails when second batch_size dimension doesn't match."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10, 5),
+        )
+
+        td = TensorDict({"x": torch.randn(10, 3)}, batch_size=[10, 3])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_multiple_missing_keys(self):
+        """Test validation fails with multiple missing keys."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(dtype=torch.float32),
+                "b": Tensor(dtype=torch.float32),
+                "c": Tensor(dtype=torch.float32),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"a": torch.randn(10)}, batch_size=[10])
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_multiple_dtype_mismatches(self):
+        """Test validation fails with multiple dtype errors."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(dtype=torch.float32),
+                "b": Tensor(dtype=torch.float32),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict(
+            {
+                "a": torch.randn(10).to(torch.int32),
+                "b": torch.randn(10).to(torch.int64),
+            },
+            batch_size=[10],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_multiple_shape_errors(self):
+        """Test validation fails with multiple shape errors."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(dtype=torch.float32, shape=(10, 5)),
+                "b": Tensor(dtype=torch.float32, shape=(10, 3)),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict(
+            {"a": torch.randn(10, 7), "b": torch.randn(10, 8)},
+            batch_size=[10],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_lazy_collects_all_errors(self):
+        """Test lazy validation collects multiple errors."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(dtype=torch.float32, shape=(32, 5)),
+                "b": Tensor(dtype=torch.float32, shape=(32, 3)),
+                "c": Tensor(dtype=torch.float32),
+            },
+            batch_size=(32,),
+        )
+
+        td = TensorDict(
+            {
+                "a": torch.randn(16, 5),
+                "b": torch.randn(16, 8),
+            },
+            batch_size=[16],
+        )
+
+        with pytest.raises(errors.SchemaErrors) as exc_info:
+            schema.validate(td, lazy=True)
+
+        assert len(exc_info.value.schema_errors) >= 2
+
+    def test_error_message_content_batch_size(self):
+        """Test error message contains batch_size info."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": torch.randn(5)}, batch_size=[5])
+
+        try:
+            schema.validate(td)
+        except errors.SchemaError as e:
+            error_messages = [str(e)]
+            assert any("batch_size" in msg for msg in error_messages)
+
+    def test_error_message_content_dtype(self):
+        """Test error message contains dtype info."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10,),
+        )
+
+        td = TensorDict(
+            {"x": torch.randn(10).to(torch.int32)}, batch_size=[10]
+        )
+
+        try:
+            schema.validate(td)
+        except errors.SchemaError as e:
+            error_messages = [str(e)]
+            assert any("dtype" in msg for msg in error_messages)
+
+    def test_error_message_content_shape(self):
+        """Test error message contains shape info."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32, shape=(10, 5))},
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": torch.randn(10, 3)}, batch_size=[10])
+
+        try:
+            schema.validate(td)
+        except errors.SchemaError as e:
+            error_messages = [str(e)]
+            assert any("shape" in msg for msg in error_messages)
+
+    def test_error_message_content_missing_key(self):
+        """Test error message contains missing key info."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "x": Tensor(dtype=torch.float32),
+                "y": Tensor(dtype=torch.float32),
+            },
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": torch.randn(10)}, batch_size=[10])
+
+        try:
+            schema.validate(td)
+        except errors.SchemaError as e:
+            error_messages = [str(e)]
+            assert any("Missing key" in msg for msg in error_messages)
+
+    def test_schema_error_reason_codes(self):
+        """Test that error reason codes are correctly set."""
+        from pandera import errors
+        from pandera.errors import SchemaErrorReason
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32)},
+            batch_size=(10,),
+        )
+
+        td = TensorDict({"x": torch.randn(5)}, batch_size=[5])
+
+        try:
+            schema.validate(td)
+        except errors.SchemaError as e:
+            reason_codes = [e.reason_code]
+            assert SchemaErrorReason.WRONG_DATATYPE in reason_codes
+
+
+@torch_condition
+class TestTensorDictCoercion:
+    """Tests for TensorDict dtype coercion."""
+
+    def test_coerce_dtype_basic(self):
+        """Test basic dtype coercion with coerce=True."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32, shape=(None, 10)),
+            },
+            batch_size=(16,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {"data": torch.randn(16, 10).to(torch.float64)},
+            batch_size=[16],
+        )
+
+        assert td["data"].dtype == torch.float64
+        result = schema.validate(td)
+        assert result["data"].dtype == torch.float32
+
+    def test_coerce_dtype_multiple_tensors(self):
+        """Test coercion of multiple tensors with different dtypes."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "float_data": Tensor(dtype=torch.float32, shape=(None, 10)),
+                "int_data": Tensor(dtype=torch.int64, shape=(None,)),
+            },
+            batch_size=(16,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {
+                "float_data": torch.randn(16, 10).to(torch.float64),
+                "int_data": torch.arange(16).to(torch.int32),
+            },
+            batch_size=[16],
+        )
+
+        result = schema.validate(td)
+        assert result["float_data"].dtype == torch.float32
+        assert result["int_data"].dtype == torch.int64
+
+    def test_coerce_dtype_with_shape(self):
+        """Test coercion preserves shape."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32, shape=(32, 10)),
+            },
+            batch_size=(32,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {"data": torch.randn(32, 10).to(torch.float64)},
+            batch_size=[32],
+        )
+
+        result = schema.validate(td)
+        assert result["data"].shape == (32, 10)
+        assert result["data"].dtype == torch.float32
+
+    def test_coerce_dtype_tensorclass(self):
+        """Test coercion with tensorclass objects."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        @tensorclass
+        class TCData:
+            observation: torch.Tensor
+            action: torch.Tensor
+
+        schema = TensorDictSchema(
+            keys={
+                "observation": Tensor(dtype=torch.float32, shape=(None, 10)),
+                "action": Tensor(dtype=torch.int64, shape=(None,)),
+            },
+            batch_size=(16,),
+            coerce=True,
+        )
+
+        tc = TCData(
+            observation=torch.randn(16, 10).to(torch.float64),
+            action=torch.randint(0, 5, (16,)).to(torch.int32),
+            batch_size=[16],
+        )
+
+        result = schema.validate(tc)
+        assert result.observation.dtype == torch.float32
+        assert result.action.dtype == torch.int64
+
+    def test_coerce_dtype_with_value_checks(self):
+        """Test coercion works with value checks."""
+        from pandera import Check
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(
+                    dtype=torch.float32,
+                    shape=(None,),
+                    checks=Check.gt(0.0),
+                ),
+            },
+            batch_size=(10,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {"data": torch.rand(10).to(torch.float64) * 2 + 1},
+            batch_size=[10],
+        )
+
+        result = schema.validate(td)
+        assert result["data"].dtype == torch.float32
+        # Check that value validation still works
+        assert (result["data"] > 0.0).all()
+
+    def test_coerce_dtype_lazy_validation(self):
+        """Test coercion with lazy validation."""
+        from pandera import Check, errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(
+                    dtype=torch.float32,
+                    shape=(None, 10),
+                    checks=[Check.gt(0.0)],  # Will fail for random normal data
+                ),
+                "b": Tensor(dtype=torch.int64),
+            },
+            batch_size=(16,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {
+                "a": torch.randn(16, 10).to(
+                    torch.float64
+                ),  # Wrong dtype + value check
+                "b": torch.arange(16).to(torch.int32),  # Wrong dtype
+            },
+            batch_size=[16],
+        )
+
+        with pytest.raises(errors.SchemaErrors) as exc_info:
+            schema.validate(td, lazy=True)
+
+        errors = exc_info.value.schema_errors
+        assert len(errors) >= 1
+
+        # Verify dtypes were coerced despite validation failures
+        result = exc_info.value.data
+        assert result["a"].dtype == torch.float32
+        assert result["b"].dtype == torch.int64
+
+    def test_coerce_dtype_with_schema_level_and_tensor_level(self):
+        """Test that both schema-level and tensor-level coerce flags work."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        # Schema-level coerce applies to all tensors
+        schema = TensorDictSchema(
+            keys={
+                "a": Tensor(dtype=torch.float32),  # No tensor-level coerce
+                "b": Tensor(dtype=torch.int64),
+            },
+            batch_size=(10,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {
+                "a": torch.rand(10).to(torch.float64) * 2 + 1,
+                "b": torch.arange(10).to(torch.int32),
+            },
+            batch_size=[10],
+        )
+
+        result = schema.validate(td)
+        assert result["a"].dtype == torch.float32
+        assert result["b"].dtype == torch.int64
+
+    def test_coerce_dtype_without_schema_level(self):
+        """Test that without coerce=True, dtypes are not coerced."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32),
+            },
+            batch_size=(10,),
+            # coerce=False (default)
+        )
+
+        td = TensorDict(
+            {"data": torch.rand(10).to(torch.float64) * 2 + 1},
+            batch_size=[10],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            schema.validate(td)
+
+    def test_coerce_dtype_error_handling(self):
+        """Test error handling during coercion."""
+        from pandera import errors
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        # This would fail if we tried to coerce a non-tensor
+        schema = TensorDictSchema(
+            keys={
+                "data": Tensor(dtype=torch.float32),
+            },
+            batch_size=(10,),
+            coerce=True,
+        )
+
+        td = TensorDict(
+            {"data": torch.rand(10).to(torch.float64) * 2 + 1},
+            batch_size=[10],
+        )
+
+        # Coercion should succeed
+        result = schema.validate(td)
+        assert result["data"].dtype == torch.float32
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+
+@torch_condition
+class TestTensorDictBaseSubclasses:
+    """Tests for TensorDictBase subclasses (e.g. LazyStackedTensorDict)."""
+
+    def test_validate_lazy_stacked_tensordict(self):
+        """LazyStackedTensorDict instances validate via the TensorDictBase
+        backend registration."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={
+                "obs": Tensor(dtype=torch.float32),
+                "act": Tensor(dtype=torch.int64),
+            },
+        )
+
+        def make_td():
+            return TensorDict(
+                {
+                    "obs": torch.randn(4, 3),
+                    "act": torch.randint(0, 2, (4,)),
+                },
+                batch_size=[4],
+            )
+
+        lazy_stacked = TensorDict.lazy_stack([make_td(), make_td()], dim=0)
+        assert not isinstance(lazy_stacked, TensorDict)
+
+        validated = schema.validate(lazy_stacked)
+        assert validated.batch_size == torch.Size([2, 4])
+
+    def test_validate_lazy_stacked_tensordict_failure(self):
+        """LazyStackedTensorDict validation reports schema errors."""
+        from pandera.errors import SchemaError
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"obs": Tensor(dtype=torch.float64)},
+        )
+        lazy_stacked = TensorDict.lazy_stack(
+            [
+                TensorDict({"obs": torch.randn(4, 3)}, batch_size=[4]),
+                TensorDict({"obs": torch.randn(4, 3)}, batch_size=[4]),
+            ],
+            dim=0,
+        )
+
+        with pytest.raises(SchemaError, match="expected dtype"):
+            schema.validate(lazy_stacked)
+
+    def test_lazy_stacked_batch_size_validation(self):
+        """batch_size validation applies to stacked batch dimensions."""
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"obs": Tensor(dtype=torch.float32)},
+            batch_size=(2, None),
+        )
+        lazy_stacked = TensorDict.lazy_stack(
+            [
+                TensorDict({"obs": torch.randn(4, 3)}, batch_size=[4]),
+                TensorDict({"obs": torch.randn(4, 3)}, batch_size=[4]),
+            ],
+            dim=0,
+        )
+        schema.validate(lazy_stacked)

--- a/tests/tensordict/test_tensordict_engine.py
+++ b/tests/tensordict/test_tensordict_engine.py
@@ -1,0 +1,149 @@
+"""Unit tests for TensorDict engine."""
+
+import pytest
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+torch_condition = pytest.mark.skipif(
+    torch is None, reason="torch not installed"
+)
+
+
+@torch_condition
+class TestTensorDictEngine:
+    """Tests for TensorDict engine."""
+
+    def test_engine_import(self):
+        """Test that tensordict_engine can be imported."""
+        from pandera.engines import tensordict_engine
+
+        assert tensordict_engine is not None
+
+    def test_engine_dtype_from_string(self):
+        """Test engine dtype from string."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.Engine.dtype("float32")
+        assert dtype is not None
+
+    def test_engine_dtype_from_torch_dtype(self):
+        """Test engine dtype from torch.dtype."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.Engine.dtype(torch.float32)
+        assert dtype is not None
+
+    def test_engine_dtype_invalid(self):
+        """Test engine raises on invalid dtype."""
+        from pandera.engines import tensordict_engine
+
+        with pytest.raises(ValueError):
+            tensordict_engine.Engine.dtype("invalid_dtype")
+
+    def test_datatype_coerce(self):
+        """Test DataType coerce method."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+        tensor = torch.randn(10).to(torch.float64)
+        coerced = dtype.coerce(tensor)
+        assert coerced.dtype == torch.float32
+
+    def test_datatype_coerce_value(self):
+        """Test DataType coerce_value method."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+        value = dtype.coerce_value(1.0)
+        assert isinstance(value, torch.Tensor)
+
+    def test_datatype_str(self):
+        """Test DataType str representation."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+        assert "float32" in str(dtype)
+
+    def test_datatype_repr(self):
+        """Test DataType repr."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+        assert "DataType" in repr(dtype)
+
+    def test_engine_multiple_dtypes(self):
+        """Test engine with multiple dtypes."""
+        from pandera.engines import tensordict_engine
+
+        dtypes = [
+            "float32",
+            "float64",
+            "int32",
+            "int64",
+            "int16",
+            "int8",
+            "uint8",
+            "bool",
+        ]
+
+        for dtype_str in dtypes:
+            dtype = tensordict_engine.Engine.dtype(dtype_str)
+            assert dtype is not None
+
+
+@torch_condition
+class TestTensorDictEngineErrorCases:
+    """Error case tests for tensordict engine."""
+
+    def test_engine_dtype_from_invalid_string(self):
+        """Test engine raises on invalid dtype string."""
+        from pandera.engines import tensordict_engine
+
+        with pytest.raises(ValueError, match="not understood"):
+            tensordict_engine.Engine.dtype("invalid_type")
+
+    def test_engine_dtype_from_invalid_type(self):
+        """Test engine raises on invalid dtype type."""
+        from pandera.engines import tensordict_engine
+
+        with pytest.raises(ValueError, match="not understood"):
+            tensordict_engine.Engine.dtype(123)
+
+    def test_datatype_coerce_wrong_type(self):
+        """Test DataType coerce raises on wrong type."""
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+
+        with pytest.raises(Exception):
+            dtype.coerce("not a tensor")
+
+    def test_datatype_try_coerce_wrong_type(self):
+        """Test DataType try_coerce raises on wrong type."""
+        from pandera import errors
+        from pandera.engines import tensordict_engine
+
+        dtype = tensordict_engine.DataType(torch.float32)
+
+        with pytest.raises(errors.ParserError):
+            dtype.try_coerce("not a tensor")
+
+
+@torch_condition
+class TestTensorDictEngineNotInstalled:
+    """Tests when torch is not installed."""
+
+    def test_no_torch_placeholder(self):
+        """Test that engine has placeholder when torch not installed."""
+        import pandera.engines.tensordict_engine as engine
+
+        if torch is None:
+            assert engine.DataType is None
+            assert engine.Engine is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/tensordict/test_tensordict_io.py
+++ b/tests/tensordict/test_tensordict_io.py
@@ -1,0 +1,204 @@
+"""Tests for TensorDict schema serialization/deserialization."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+from tensordict import TensorDict, tensorclass
+
+import pandera.tensordict as pa
+
+
+@pytest.fixture
+def sample_schema():
+    """Create a sample schema for testing."""
+    return pa.TensorDictSchema(
+        keys={
+            "observation": pa.Tensor(dtype=torch.float32, shape=(None, 10)),
+            "action": pa.Tensor(dtype=torch.int64, shape=(None,)),
+            "reward": pa.Tensor(dtype=torch.float32, shape=(None,)),
+        },
+        batch_size=(32,),
+        coerce=True,
+    )
+
+
+@pytest.fixture
+def sample_tensor_dict():
+    """Create a sample TensorDict for testing."""
+    return TensorDict(
+        {
+            "observation": torch.randn(32, 10),
+            "action": torch.randint(0, 4, (32,)),
+            "reward": torch.randn(32),
+        },
+        batch_size=[32],
+    )
+
+
+class TestSchemaSerialization:
+    """Test schema serialization functionality."""
+
+    def test_serialize_schema_to_dict(self, sample_schema):
+        """Test serializing schema to dictionary."""
+        from pandera.io.tensordict_io import serialize_schema
+
+        serialized = serialize_schema(sample_schema)
+
+        assert isinstance(serialized, dict)
+        assert "schema_type" in serialized
+        assert serialized["schema_type"] == "tensordict"
+
+    def test_serialize_deserialize_roundtrip(self, sample_schema):
+        """Test round-trip serialization/deserialization."""
+        # Serialize to YAML string
+        yaml_str = pa.to_yaml(sample_schema)
+
+        # Deserialize from YAML string
+        deserialized = pa.from_yaml(yaml_str)
+
+        assert isinstance(deserialized, pa.TensorDictSchema)
+        assert len(deserialized.keys) == len(sample_schema.keys)
+
+    def test_serialize_deserialize_json(self, sample_schema):
+        """Test JSON serialization/deserialization."""
+        # Serialize to JSON string
+        json_str = pa.to_json(sample_schema)
+
+        # Deserialize from JSON string
+        deserialized = pa.from_json(json_str)
+
+        assert isinstance(deserialized, pa.TensorDictSchema)
+        assert len(deserialized.keys) == len(sample_schema.keys)
+
+    def test_serialize_with_path_object(self, sample_schema, tmp_path):
+        """Test serialization with Path objects."""
+        yaml_path = tmp_path / "schema.yaml"
+
+        pa.to_yaml(sample_schema, yaml_path)
+
+        deserialized = pa.from_yaml(yaml_path)
+
+        assert isinstance(deserialized, pa.TensorDictSchema)
+
+    def test_save_load_with_tensor_dict(
+        self, sample_schema, sample_tensor_dict, tmp_path
+    ):
+        """Test saving/loading TensorDict with schema."""
+        save_path = tmp_path / "data.pt"
+
+        # Save
+        pa.save(sample_schema, sample_tensor_dict, save_path)
+
+        # Load and validate
+        loaded = pa.load(save_path)
+
+        assert isinstance(loaded, TensorDict)
+
+    def test_save_load_with_custom_batch_size(self, tmp_path):
+        """Test save/load with custom batch sizes."""
+        schema = pa.TensorDictSchema(
+            keys={
+                "data": pa.Tensor(dtype=torch.float32, shape=(None, 100)),
+            },
+            batch_size=(64,),
+        )
+
+        td = TensorDict(
+            {
+                "data": torch.randn(64, 100),
+            },
+            batch_size=[64],
+        )
+
+        save_path = tmp_path / "custom.pt"
+        pa.save(schema, td, save_path)
+
+        loaded = pa.load(save_path)
+        # batch_size is returned as torch.Size
+        assert tuple(loaded.batch_size) == (64,)
+
+
+class TestTensorClassSerialization:
+    """Test tensorclass serialization functionality."""
+
+    def test_infer_schema_with_tensorclass(self):
+        """Test schema inference for tensorclass objects."""
+
+        @tensorclass
+        class RLData:
+            observation: torch.Tensor
+            reward: torch.Tensor
+
+        tc = RLData(
+            observation=torch.randn(16, 8),
+            reward=torch.randn(16),
+            batch_size=[16],
+        )
+
+        schema = pa.infer_schema(tc)
+
+        assert isinstance(schema, pa.TensorDictSchema)
+        assert len(schema.keys) == 2
+
+    def test_infer_schema_tensorclass_keys(self):
+        """Test that tensorclass keys are correctly inferred."""
+
+        @tensorclass
+        class Data:
+            x: torch.Tensor
+            y: torch.Tensor
+
+        tc = Data(x=torch.randn(8, 4), y=torch.randn(8), batch_size=[8])
+
+        schema = pa.infer_schema(tc)
+
+        # Check that both keys are present (tensorclass attributes)
+        assert "x" in schema.keys
+        assert "y" in schema.keys
+
+    def test_tensorclass_batch_size_inference(self):
+        """Test that tensorclass batch_size is correctly inferred."""
+
+        @tensorclass
+        class Data:
+            obs: torch.Tensor
+
+        tc = Data(obs=torch.randn(24, 10), batch_size=[24])
+
+        schema = pa.infer_schema(tc)
+        assert tuple(schema.batch_size) == (24,)
+
+
+class TestSaveLoadPlainDict:
+    """Tests for saving plain dicts of tensors."""
+
+    def test_save_plain_dict_roundtrip(self, tmp_path):
+        """A plain dict of tensors is converted to a TensorDict with
+        inferred batch dimensions and validates on load."""
+        from pandera.tensordict import Tensor, TensorDictSchema, load, save
+
+        schema = TensorDictSchema(
+            keys={
+                "obs": Tensor(dtype=torch.float32, shape=(None, 4)),
+                "act": Tensor(dtype=torch.int64, shape=(None,)),
+            },
+            batch_size=(None,),
+        )
+        path = tmp_path / "data.pt"
+        save(
+            schema,
+            {
+                "obs": torch.randn(8, 4),
+                "act": torch.randint(0, 2, (8,)),
+            },
+            path,
+        )
+
+        loaded = load(path)
+        assert isinstance(loaded, TensorDict)
+        assert loaded.batch_size == torch.Size([8])

--- a/tests/tensordict/test_tensordict_model.py
+++ b/tests/tensordict/test_tensordict_model.py
@@ -1,0 +1,145 @@
+"""Unit tests for TensorDictModel."""
+
+import pytest
+
+try:
+    import torch
+    from tensordict import TensorDict
+
+    from pandera.tensordict import DataType  # type: ignore[attr-defined]
+
+    _DataType = DataType  # type: ignore[misc]
+except ImportError:
+    torch = None
+    TensorDict = None
+    DataType = None  # type: ignore[misc, assignment]
+
+torch_condition = pytest.mark.skipif(
+    torch is None, reason="torch not installed"
+)
+
+
+@torch_condition
+class TestTensorDictModelBasic:
+    """Tests for basic TensorDictModel functionality."""
+
+    def test_model_with_field_annotations(self):
+        """Test model with field annotations."""
+        from pandera.tensordict import Field, TensorDictModel
+
+        class MyModel(TensorDictModel):
+            observation: torch.float32 = Field(shape=(None, 10))
+            action: torch.int64 = Field(shape=(None,))
+
+            class Config:
+                batch_size = (32,)
+
+        schema = MyModel.to_schema()
+        assert "observation" in schema.keys
+        assert "action" in schema.keys
+
+    def test_model_validation(self):
+        """Test model validation with valid data."""
+        from pandera.tensordict import Field, TensorDictModel
+
+        class MyModel(TensorDictModel):
+            observation: torch.float32 = Field(shape=(None, 10))
+
+            class Config:
+                batch_size = (32,)
+
+        batch = TensorDict(
+            {"observation": torch.randn(32, 10)},
+            batch_size=[32],
+        )
+
+        validated = MyModel.validate(batch)
+        assert isinstance(validated, TensorDict)
+
+    def test_model_validation_failure(self):
+        """Test model validation fails with invalid data."""
+        import pandera.errors as errors
+        from pandera.tensordict import Field, TensorDictModel
+
+        class MyModel(TensorDictModel):
+            observation: torch.float32 = Field(shape=(None, 10))
+
+            class Config:
+                batch_size = (32,)
+
+        batch = TensorDict(
+            {"observation": torch.randn(16, 10)},
+            batch_size=[16],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            MyModel.validate(batch)
+
+
+@torch_condition
+class TestTensorDictModelWithChecks:
+    """Tests for TensorDictModel with value checks."""
+
+    def test_model_with_field_checks(self):
+        """Test model with Field-level checks."""
+        import pandera.errors as errors
+        from pandera import Check
+        from pandera.tensordict import Field, TensorDictModel
+
+        class MyModel(TensorDictModel):
+            values: torch.float32 = Field(
+                shape=(None,),
+                ge=0.0,
+                le=1.0,
+            )
+
+            class Config:
+                batch_size = (10,)
+
+        # Valid data
+        batch = TensorDict(
+            {"values": torch.rand(10)},
+            batch_size=[10],
+        )
+        validated = MyModel.validate(batch)
+        assert isinstance(validated, TensorDict)
+
+        # Invalid data - outside range
+        batch_invalid = TensorDict(
+            {"values": torch.randn(10)},  # Some negative values
+            batch_size=[10],
+        )
+
+        with pytest.raises(errors.SchemaError):
+            MyModel.validate(batch_invalid)
+
+
+@torch_condition
+class TestTensorDictModelInheritance:
+    """Tests for TensorDictModel inheritance."""
+
+    def test_model_inheritance(self):
+        """Test model can be inherited from."""
+        from pandera.tensordict import Field, TensorDictModel
+
+        class BaseModel(TensorDictModel):
+            observation: torch.float32 = Field(shape=(None, 10))
+
+            class Config:
+                batch_size = (32,)
+
+        class ChildModel(BaseModel):
+            action: torch.int64 = Field(shape=(None,))
+
+        # Base schema should still work
+        base_schema = BaseModel.to_schema()
+        assert "observation" in base_schema.keys
+
+        # Child schema should have both fields
+        child_schema = ChildModel.to_schema()
+        assert "observation" in child_schema.keys
+        assert "action" in child_schema.keys
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/tensordict/test_tensordict_schema_inference.py
+++ b/tests/tensordict/test_tensordict_schema_inference.py
@@ -1,0 +1,113 @@
+"""Tests for TensorDict schema inference."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict, tensorclass
+
+import pandera.tensordict as pa
+
+
+@pytest.fixture
+def sample_tensor_dict():
+    """Create a sample TensorDict for testing."""
+    return TensorDict(
+        {
+            "observation": torch.randn(32, 10),
+            "action": torch.randint(0, 4, (32,)),
+            "reward": torch.randn(32),
+            "done": torch.zeros(32, dtype=torch.bool),
+        },
+        batch_size=[32],
+    )
+
+
+class TestSchemaInference:
+    """Test schema inference functionality."""
+
+    def test_infer_schema_basic(self, sample_tensor_dict):
+        """Test basic schema inference from TensorDict."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        assert isinstance(schema, pa.TensorDictSchema)
+        assert len(schema.keys) == 4
+        assert "observation" in schema.keys
+        assert "action" in schema.keys
+        assert "reward" in schema.keys
+        assert "done" in schema.keys
+
+    def test_infer_schema_batch_size(self, sample_tensor_dict):
+        """Test that batch_size is inferred correctly."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        # batch_size might be torch.Size or tuple, both are acceptable
+        assert schema.batch_size is not None
+        if hasattr(schema.batch_size, "__iter__"):
+            assert tuple(schema.batch_size) == (32,)
+
+    def test_infer_schema_dtype(self, sample_tensor_dict):
+        """Test that dtypes are inferred correctly."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        # Compare using string representation since dtype may be wrapped
+        obs_dtype = str(schema.keys["observation"].dtype)
+        assert "float32" in obs_dtype or "torch.float32" in obs_dtype
+
+        action_dtype = str(schema.keys["action"].dtype)
+        assert "int64" in action_dtype or "torch.int64" in action_dtype
+
+    def test_infer_schema_shape(self, sample_tensor_dict):
+        """Test that shapes are inferred correctly."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        obs_shape = (
+            tuple(schema.keys["observation"].shape)
+            if schema.keys["observation"].shape
+            else None
+        )
+        assert obs_shape == (32, 10)
+
+    def test_infer_schema_with_tensorclass(self):
+        """Test schema inference with tensorclass."""
+
+        @tensorclass
+        class Data:
+            x: torch.Tensor
+            y: torch.Tensor
+
+        tc = Data(
+            x=torch.randn(16, 8), y=torch.randint(0, 2, (16,)), batch_size=[16]
+        )
+
+        schema = pa.infer_schema(tc)
+
+        assert isinstance(schema, pa.TensorDictSchema)
+        assert len(schema.keys) == 2
+
+    def test_infer_schema_value_ranges(self, sample_tensor_dict):
+        """Test that value range checks are inferred."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        # Check that numeric tensors have range checks
+        obs_schema = schema.keys["observation"]
+        assert len(obs_schema.checks) >= 2  # min and max bounds
+
+    def test_infer_schema_invalid_type(self):
+        """Test that invalid types raise TypeError."""
+        with pytest.raises(TypeError, match="Expected TensorDict"):
+            pa.infer_schema({"not": "a tensordict"})
+
+    def test_infer_schema_boolean_dtype(self, sample_tensor_dict):
+        """Test that boolean dtypes are inferred correctly."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        done_dtype = str(schema.keys["done"].dtype)
+        assert "bool" in done_dtype or "torch.bool" in done_dtype
+
+    def test_infer_schema_integer_dtypes(self, sample_tensor_dict):
+        """Test that integer dtypes are handled correctly."""
+        schema = pa.infer_schema(sample_tensor_dict)
+
+        action_dtype = str(schema.keys["action"].dtype)
+        assert "int64" in action_dtype or "torch.int64" in action_dtype

--- a/tests/tensordict/test_tensordict_strategies.py
+++ b/tests/tensordict/test_tensordict_strategies.py
@@ -1,0 +1,163 @@
+"""Tests for TensorDict Hypothesis strategies."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from hypothesis import given, settings
+    from hypothesis.strategies import composite
+
+    HAS_HYPOTHESIS = True
+except ImportError:
+    HAS_HYPOTHESIS = False
+
+import torch
+
+import pandera.tensordict as pa
+
+
+@pytest.mark.skipif(not HAS_HYPOTHESIS, reason="hypothesis not installed")
+class TestTensorDictStrategies:
+    """Test TensorDict Hypothesis strategies."""
+
+    @pytest.fixture
+    def simple_schema(self):
+        """Create a simple schema for testing with scalar values (per batch).
+
+        Note: With batch_size=(N,), tensors should have shape (N, ...) to include
+        the batch dimension in their shape.
+        """
+        return pa.TensorDictSchema(
+            keys={
+                "data": pa.Tensor(dtype=torch.float32, shape=(8,)),
+            },
+            batch_size=(8,),
+        )
+
+    @pytest.fixture
+    def complex_schema(self):
+        """Create a more complex schema with multiple tensors."""
+        return pa.TensorDictSchema(
+            keys={
+                "obs": pa.Tensor(dtype=torch.float32, shape=(8, 10)),
+                "action": pa.Tensor(dtype=torch.int64, shape=(8,)),
+                "reward": pa.Tensor(dtype=torch.float32, shape=(8,)),
+            },
+            batch_size=(8,),
+        )
+
+    def test_tensordict_strategy_generates_valid_data(self, simple_schema):
+        """Test that strategy generates valid TensorDicts."""
+        from pandera.strategies import tensordict_strategy
+
+        @given(tensordict_strategy(simple_schema))
+        @settings(max_examples=5)
+        def check(td):
+            # Validate that generated data conforms to schema
+            validated = simple_schema.validate(td)
+
+            assert isinstance(validated, type(td))
+            assert "data" in td.keys()
+
+        check()
+
+    def test_strategy_batch_size(self, complex_schema):
+        """Test that strategy respects batch_size."""
+        from pandera.strategies import tensordict_strategy
+
+        @given(tensordict_strategy(complex_schema))
+        @settings(max_examples=5)
+        def check(td):
+            assert tuple(td.batch_size) == (8,)
+
+        check()
+
+    def test_strategy_dtypes(self, complex_schema):
+        """Test that strategy generates correct dtypes."""
+        from pandera.strategies import tensordict_strategy
+
+        @given(tensordict_strategy(complex_schema))
+        @settings(max_examples=5)
+        def check(td):
+            assert td["obs"].dtype == torch.float32
+            assert td["action"].dtype == torch.int64
+            assert td["reward"].dtype == torch.float32
+
+        check()
+
+    def test_strategy_shapes(self, complex_schema):
+        """Test that strategy generates correct shapes."""
+        from pandera.strategies import tensordict_strategy
+
+        @given(tensordict_strategy(complex_schema))
+        @settings(max_examples=5)
+        def check(td):
+            # Tensors should match schema's full shape (including batch dim)
+            assert td["obs"].shape == torch.Size([8, 10])
+            assert td["action"].shape == torch.Size([8])
+
+        check()
+
+    def test_tensorclass_strategy(self, complex_schema):
+        """Test tensorclass strategy generation."""
+        from tensordict import tensorclass
+
+        from pandera.strategies import tensorclass_strategy
+
+        @tensorclass
+        class Data:
+            obs: torch.Tensor
+            action: torch.Tensor
+            reward: torch.Tensor
+
+        strategy = tensorclass_strategy(Data, complex_schema)
+
+        @given(strategy)
+        @settings(max_examples=5)
+        def check(tc):
+            assert tuple(tc.batch_size) == (8,)
+            assert hasattr(tc, "obs")
+            assert hasattr(tc, "action")
+
+        check()
+
+
+@pytest.mark.skipif(not HAS_HYPOTHESIS, reason="hypothesis not installed")
+class TestStrategyDtypeFidelity:
+    """Tests that strategies generate the schema's exact dtypes."""
+
+    def test_strategy_preserves_float64(self):
+        from pandera.strategies import tensordict_strategy
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float64, shape=(None, 2))},
+            batch_size=(None,),
+        )
+        strategy = tensordict_strategy(schema, size=3)
+
+        @given(strategy)
+        @settings(max_examples=5, deadline=None)
+        def check(td):
+            assert td["x"].dtype == torch.float64
+            assert td.batch_size == torch.Size([3])
+
+        check()
+
+    def test_strategy_resolves_none_batch_dims(self):
+        from pandera.strategies import tensordict_strategy
+        from pandera.tensordict import Tensor, TensorDictSchema
+
+        schema = TensorDictSchema(
+            keys={"x": Tensor(dtype=torch.float32, shape=(None, None, 2))},
+            batch_size=(None, None),
+        )
+        strategy = tensordict_strategy(schema, size=4)
+
+        @given(strategy)
+        @settings(max_examples=5, deadline=None)
+        def check(td):
+            assert td.batch_size == torch.Size([4, 4])
+
+        check()


### PR DESCRIPTION
## Summary

Brings the TensorDict integration work from `dev/pytorch-tensordict-phase4` (phases 1–4) onto latest `main` as a single squashed change, reviewed and updated against the current state of the [pytorch/tensordict](https://github.com/pytorch/tensordict) library (tensordict 0.13, torch 2.12).

### Integration surface

- `TensorDictSchema` / `Tensor` components validating dtype, shape, `batch_size`, and value checks for `TensorDict` and `tensorclass` objects
- Class-based `TensorDictModel` API with `Field` annotations and `Config`
- dtype coercion (schema-level and per-tensor)
- Schema inference from TensorDict/tensorclass data (`pa.infer_schema`)
- YAML/JSON schema serialization plus `save`/`load` with embedded schema metadata
- Hypothesis strategies for TensorDict and tensorclass generation
- New docs guide (`docs/source/pytorch_guide/`) and API reference page
- New `torch` extra: `pip install 'pandera[torch]'`

### Updates on top of the original branch

Reviewed against tensordict 0.13 and fixed issues found along the way:

- **Modern tensordict type handling**: use the canonical `is_tensor_collection` / `is_tensorclass` predicates and register the validation backend on `TensorDictBase`, so all subclasses validate — including `LazyStackedTensorDict` (`TensorDict.lazy_stack` results are *not* `isinstance` of `TensorDict`, so the original code missed them)
- **IO fixes**: `save()` on a plain dict previously crashed (bogus `Engine.dtype("tensordict")` call) — now builds a `TensorDict` and infers batch dims via `auto_batch_size_()`; `load()` referenced an unimported `infer_schema`
- **Model config fixes**: `Config.coerce` (and `name`/`title`/`description`) and per-field `nullable`/`coerce`/`required` were silently dropped when building the schema; per-tensor `coerce=True` now works without schema-level coerce
- **Strategies rewrite**: generation now uses `hypothesis.extra.numpy` with exact dtype fidelity (was hardcoded float32/int64), batch-dim alignment (was generating tensors inconsistent with `batch_size`, a hard `RuntimeError` in current tensordict), and check-aware element generation (`isin`, `ge/gt/le/lt`, `in_range`)
- **Engine**: register modern torch dtypes (`uint16/32/64`, `float8_e4m3fn`, `float8_e5m2`), drop deprecated quantized dtypes, and raise a clear error for unknown dtype inputs
- **Import hygiene**: `pandera.io`, `pandera.strategies`, and `pandera.schema_inference` stay lazy — importing pandera does not import torch (strategies exports use module `__getattr__`)
- **Docs**: removed merge-conflict markers that had been committed into `tensordict_io.md`, and fixed several doc examples that were broken or numerically unsound; all 41 executable code cells in the pytorch guide now run cleanly against tensordict 0.13
- Dropped unrelated drive-by reformatting of pandas/pyspark/xarray modules that the old branch carried, keeping the diff purely additive

### Test plan

- [x] `tests/tensordict/` — 90 tests pass (84 from the original branch + 6 new regression tests for LazyStackedTensorDict validation, plain-dict `save()` round-trip, and strategy dtype/batch fidelity)
- [x] All 41 mystnb code cells in `docs/source/pytorch_guide/` execute cleanly (3 consecutive runs to shake out hypothesis flakiness)
- [x] `tests/pandas/test_schemas.py` passes with torch installed (no cross-backend regressions)
- [x] pre-commit hooks (ruff, mypy, pyupgrade, flynt, codespell) pass on all changed files
- [x] Verified `import pandera` remains torch-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Status
Rebased onto the latest main (92d8a7c). This is the single consolidated PR for all PyTorch TensorDict work (formerly split across #2290 (phase 1) and #2316 (phases 3-4), both now closed as superseded).
