### PR TITLE
fix(pandas): treat NA as coercible for masked nullable dtypes

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -25,6 +25,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import typeguard
+from pandas.core.dtypes.dtypes import BaseMaskedDtype
 from pydantic import BaseModel, ValidationError, create_model
 
 from pandera import dtypes, errors
@@ -160,6 +161,12 @@ class DataType(dtypes.DataType):
 
     def coerce_value(self, value: Any) -> Any:
         """Coerce an value to a particular type."""
+        if isinstance(self.type, BaseMaskedDtype) and pd.isna(value):
+            # masked nullable dtypes support NA values directly, so
+            # delegate to pandas: this mirrors Series.astype, coercing
+            # valid NA values to the dtype's NA sentinel and raising on
+            # invalid ones (e.g. NaT)
+            return pd.array([value], dtype=self.type)[0]
         # by default, the pandas Engine delegates to the underlying numpy
         # datatype to coerce a value to the correct type.
         return self.type.type(value)
@@ -307,8 +314,8 @@ class BOOL(DataType, dtypes.Bool):
     _bool_like = frozenset({True, False})
 
     def coerce_value(self, value: Any) -> Any:
-        """Coerce an value to specified datatime type."""
-        if value not in self._bool_like:
+        """Coerce a value to specified boolean type."""
+        if value not in self._bool_like and not pd.isna(value):
             raise TypeError(
                 f"value {value} cannot be coerced to type {self.type}"
             )

--- a/tests/pandas/test_engine_utils.py
+++ b/tests/pandas/test_engine_utils.py
@@ -26,6 +26,43 @@ def test_numpy_pandas_coercible(
 
 
 @pytest.mark.parametrize(
+    "data_container, data_type, expected_coercible",
+    [
+        [
+            pd.Series([1, pd.NA, "x"], dtype=object),
+            "Int64",
+            [True, True, False],
+        ],
+        [
+            pd.Series([1, pd.NA, "x"], dtype=object),
+            "UInt8",
+            [True, True, False],
+        ],
+        [
+            pd.Series([1.0, pd.NA, "x"], dtype=object),
+            "Float64",
+            [True, True, False],
+        ],
+        [
+            pd.Series([True, pd.NA, "A"], dtype=object),
+            "boolean",
+            [True, True, False],
+        ],
+        # plain numpy dtypes still treat NA values as uncoercible
+        [pd.Series([pd.NA], dtype=object), "int64", [False]],
+    ],
+)
+def test_numpy_pandas_coercible_masked_nullable_na(
+    data_container, data_type, expected_coercible
+):
+    """Test that NA values are coercible for masked nullable dtypes."""
+    assert (
+        expected_coercible
+        == utils.numpy_pandas_coercible(data_container, data_type).tolist()
+    )
+
+
+@pytest.mark.parametrize(
     "data_container",
     [
         pd.Series([1, 2, 3, 4]),

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -180,6 +180,42 @@ def test_pandas_boolean_native_type_error(data):
             dtype.coerce_value(value)
 
 
+@pytest.mark.parametrize(
+    "dtype_alias",
+    [
+        "Int8",
+        "Int16",
+        "Int32",
+        "Int64",
+        "UInt8",
+        "UInt16",
+        "UInt32",
+        "UInt64",
+        "Float32",
+        "Float64",
+        "boolean",
+    ],
+)
+@pytest.mark.parametrize("value", [pd.NA, None, np.nan])
+def test_pandas_masked_nullable_coerce_value_na(dtype_alias, value):
+    """Test masked nullable dtypes coerce NA values to the NA sentinel."""
+    dtype = pandas_engine.Engine.dtype(dtype_alias)
+    assert dtype.coerce_value(value) is pd.NA
+
+
+@pytest.mark.parametrize(
+    "dtype_alias", ["Int64", "UInt8", "Float32", "Float64", "boolean"]
+)
+@pytest.mark.parametrize(
+    "value", [pd.NaT, np.datetime64("NaT", "ns"), np.timedelta64("NaT", "ns")]
+)
+def test_pandas_masked_nullable_coerce_value_nat_raises(dtype_alias, value):
+    """Test masked nullable dtypes still reject non-numeric NaT values."""
+    dtype = pandas_engine.Engine.dtype(dtype_alias)
+    with pytest.raises(TypeError):
+        dtype.coerce_value(value)
+
+
 @hypothesis.settings(max_examples=1000)
 @pytest.mark.parametrize("timezone_aware", [True, False])
 @given(

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -1661,6 +1661,61 @@ def test_lazy_dataframe_validation_nullable() -> None:
             )
 
 
+@pytest.mark.parametrize(
+    "dtype_alias, data, bad_value",
+    [
+        ("Int64", [1, pd.NA, "x"], "x"),
+        ("Float64", [1.0, pd.NA, "x"], "x"),
+        ("boolean", [True, pd.NA, "A"], "A"),
+    ],
+)
+def test_lazy_validation_nullable_dtype_coerce_na_not_failure_case(
+    dtype_alias, data, bad_value
+) -> None:
+    """
+    Test that NA values in a nullable column are not reported as coercion
+    failure cases while genuinely uncoercible values still are.
+    """
+    schema = DataFrameSchema(
+        {"col": Column(dtype_alias, coerce=True, nullable=True)}
+    )
+    df = pd.DataFrame({"col": pd.Series(data, dtype=object)})
+
+    with pytest.raises(errors.SchemaErrors) as exc_info:
+        schema.validate(df, lazy=True)
+
+    failure_cases = exc_info.value.failure_cases
+    assert failure_cases.failure_case.isna().sum() == 0
+    for check_name in (
+        f"coerce_dtype('{dtype_alias}')",
+        f"dtype('{dtype_alias}')",
+    ):
+        failed = failure_cases.query(f'check == "{check_name}"')
+        assert failed.failure_case.tolist() == [bad_value]
+        assert failed["index"].tolist() == [2]
+
+
+def test_lazy_validation_nullable_false_na_reported_via_not_nullable() -> None:
+    """
+    Test that NA values in a non-nullable column are reported by the
+    not_nullable check rather than as coercion failure cases.
+    """
+    schema = DataFrameSchema(
+        {"col": Column("Int64", coerce=True, nullable=False)}
+    )
+    df = pd.DataFrame({"col": pd.Series([1, pd.NA, "x"], dtype=object)})
+
+    with pytest.raises(errors.SchemaErrors) as exc_info:
+        schema.validate(df, lazy=True)
+
+    failure_cases = exc_info.value.failure_cases
+    not_nullable_cases = failure_cases.query("check == 'not_nullable'")
+    assert not_nullable_cases.failure_case.isna().all()
+    assert not_nullable_cases["index"].tolist() == [1]
+    coerce_cases = failure_cases.query("check == \"coerce_dtype('Int64')\"")
+    assert coerce_cases.failure_case.tolist() == ["x"]
+
+
 def test_lazy_dataframe_validation_with_checks() -> None:
     """Test that all failure cases are reported for schemas with checks."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #2021

## Problem

When a nullable column with a masked extension dtype uses `coerce=True`, NA values are wrongly reported as coercion failure cases whenever the column also contains a genuinely uncoercible value:

```python
import pandas as pd
import pandera.pandas as pa

schema = pa.DataFrameSchema(
    {"id": pa.Column("Int64", checks=[pa.Check.ge(1)], coerce=True, nullable=True)}
)
df = pd.DataFrame({"id": [1, 2, 4, 4, 7.5, "8", "9", "x", pd.NA]})
schema.validate(df, lazy=True)
```

`failure_cases` reports `<NA>` under both `coerce_dtype('Int64')` and `dtype('Int64')` even though `nullable=True` and `Series.astype("Int64")` handles NA fine. Only `'x'` is a real coercion failure.

Root cause: when the wholesale `astype` fails, element-wise failure cases are computed via `engines/utils.py::numpy_pandas_coercible`, which calls `DataType.coerce_value` per element. The base implementation is `self.type.type(value)`, i.e. `np.int64(pd.NA)`, which raises, so NA gets flagged as uncoercible. This affects all masked nullable dtypes (`Int8` through `Int64`, `UInt8` through `UInt64`, `Float32`/`Float64`, `boolean`). `BOOL.coerce_value` additionally rejects NA itself via its `_bool_like` membership check.

## Fix

In the base `DataType.coerce_value`, when the dtype is a masked nullable dtype (`BaseMaskedDtype`) and the value is NA, delegate to `pd.array([value], dtype=self.type)[0]`. This mirrors `Series.astype` semantics exactly on whatever pandas version is installed: valid NA values (`None`, `np.nan`, `pd.NA`) coerce to the dtype's NA sentinel, while invalid ones (`pd.NaT`, `np.datetime64("NaT")`, `np.timedelta64("NaT")`) still raise and are still reported as failure cases. `BOOL.coerce_value` now lets NA values through to that guard.

Notes:

- Performance: the guard short circuits on a cheap `isinstance` first, so non masked dtypes pay nothing. The `pd.array` construction only runs per NA element on the failure case reporting path, i.e. after the wholesale `astype` has already failed.
- `BaseMaskedDtype` is imported from `pandas.core.dtypes.dtypes` (stable location since pandas 2.0; the codebase already references `pd.core.dtypes.base.ExtensionDtype` in `engines/type_aliases.py`). If you would rather avoid the private import, an explicit tuple of the 11 public dtype classes works too; happy to switch.
- Behavioral consequences beyond the bug: for `nullable=False` columns NA is no longer double reported as a coercion failure (it is still reported by the `not_nullable` check, covered by a new test). For non coerce dtype checks on object columns containing only valid values plus NAs, element level failure cases become empty and `check_dtype` falls through to its pre-existing dtype string fallback. Plain numpy dtypes (e.g. `int64`) are unchanged: NA remains a coercion failure there (also covered by a new test).
- Before the fix, `np.int64(np.datetime64("NaT"))` silently produced `iinfo(int64).min` garbage instead of failing; the new delegation makes NaT correctly uncoercible for masked dtypes, locked in by a new test.

## Checklist:

- [x] New tests fail before the fix and pass after (unit: `coerce_value` per dtype; utils: `numpy_pandas_coercible`; integration: lazy validation repro from the issue, plus the `nullable=False` path)
- [x] Issue repro verified before/after: `<NA>` no longer appears under `coerce_dtype('Int64')` or `dtype('Int64')`; `'x'` still reported
- [x] `pytest tests/pandas` green (2420 passed, 16 skipped, 4 xfailed)
- [x] pre-commit hooks green (ruff check/format, mypy, codespell)
