### PR TITLE
fix: truncate failure cases in error messages (#577)

### DIFF
--- a/pandera/backends/pandas/error_formatters.py
+++ b/pandera/backends/pandas/error_formatters.py
@@ -12,6 +12,10 @@ from pandera.errors import SchemaError
 # produce multi-KB error strings.
 _MAX_CATEGORIES_IN_MESSAGE = 10
 
+# Same idea as above but for the failure-cases listed in vectorized error
+# messages — without this, large DataFrames can produce multi-MB strings.
+_MAX_FAILURE_CASES_IN_MESSAGE = 10
+
 
 def describe_dtype_mismatch(expected_dtype, actual_dtype) -> tuple[str, str]:
     """Describe an expected/actual dtype pair for a dtype-mismatch message.
@@ -105,10 +109,18 @@ def format_vectorized_error_message(
         "pyspark.pandas"
     ):
         failure_cases = reshaped_failure_cases.failure_case.to_numpy()
-        failure_cases_string = ", ".join(failure_cases.astype(str))
+        cases_list = failure_cases.astype(str).tolist()
     else:
         failure_cases = reshaped_failure_cases.failure_case
-        failure_cases_string = ", ".join(failure_cases.apply(str))
+        cases_list = failure_cases.apply(str).tolist()
+
+    if len(cases_list) > _MAX_FAILURE_CASES_IN_MESSAGE:
+        failure_cases_string = (
+            ", ".join(cases_list[:_MAX_FAILURE_CASES_IN_MESSAGE])
+            + f", ... and {len(cases_list) - _MAX_FAILURE_CASES_IN_MESSAGE} more"
+        )
+    else:
+        failure_cases_string = ", ".join(cases_list)
 
     return (
         f"{parent_schema.__class__.__name__} '{parent_schema.name}' failed "

--- a/tests/pandas/test_errors.py
+++ b/tests/pandas/test_errors.py
@@ -522,3 +522,34 @@ def test_describe_dtype_mismatch_falls_back_without_categories():
         Category(["a", "b"]), Category()
     )
     assert (expected, actual) == ("category", "category")
+
+
+def test_vectorized_error_message_truncates_many_failure_cases():
+    """Failure cases in error messages are truncated when there are more than 10."""
+    schema = DataFrameSchema(
+        {"n": Column(int, Check.greater_than(30))}
+    )
+    df = pd.DataFrame({"n": range(20)})
+
+    with pytest.raises(SchemaError) as exc:
+        schema.validate(df)
+
+    msg = str(exc.value)
+    assert "... and" in msg and "more" in msg
+    # full failure_cases DF should still have everything
+    assert len(exc.value.failure_cases) > 10
+
+
+def test_vectorized_error_message_no_truncation_when_few_cases():
+    """Few failure cases are not truncated in error messages."""
+    schema = DataFrameSchema(
+        {"n": Column(int, Check.greater_than(100))}
+    )
+    df = pd.DataFrame({"n": range(5)})
+
+    with pytest.raises(SchemaError) as exc:
+        schema.validate(df)
+
+    msg = str(exc.value)
+    assert "... and" not in msg
+


### PR DESCRIPTION
Fixes #577

`format_vectorized_error_message` joins all failure cases into the error
string with no limit. On large DataFrames this produces multi-MB messages
that can freeze terminals and flood logs.

This adds a `_MAX_FAILURE_CASES_IN_MESSAGE` cap (matching the existing
`_MAX_CATEGORIES_IN_MESSAGE` pattern) to truncate the message to the
first 10 cases. The full `failure_cases` DataFrame on `SchemaError` is
not affected.

### Changes
- `pandera/backends/pandas/error_formatters.py`: truncate failure cases
  in error message string
- `tests/pandas/test_errors.py`: two tests covering truncation and
  no-truncation paths