### PR TITLE
Fix parenthesized @dataframe_parser() decorator form

### DIFF
--- a/pandera/api/dataframe/model_components.py
+++ b/pandera/api/dataframe/model_components.py
@@ -423,4 +423,6 @@ def dataframe_parser(_fn=None, **parser_kwargs) -> ClassParser:
         )
         return parser_method
 
-    return _wrapper(_fn)  # type: ignore
+    if _fn:
+        return _wrapper(_fn)  # type: ignore
+    return _wrapper

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -115,6 +115,33 @@ def test_parser_called_once():
     assert n_calls == 1
 
 
+def test_dataframe_parser_parenthesized_form():
+    """``@dataframe_parser()`` and ``@dataframe_parser(**kwargs)`` should work
+    like the bare ``@dataframe_parser``, matching ``dataframe_check``."""
+    data = pd.DataFrame({"col": [1.0, 4.0, 9.0]})
+    expected = pd.DataFrame({"col": [2.0, 8.0, 18.0]})
+
+    class DFModel(pa.DataFrameModel):
+        col: float
+
+        @pa.dataframe_parser()
+        @classmethod
+        def double(cls, df: pd.DataFrame) -> pd.DataFrame:
+            return df * 2
+
+    assert_frame_equal(DFModel.validate(data), expected)
+
+    class DFModelWithKwargs(pa.DataFrameModel):
+        col: float
+
+        @pa.dataframe_parser(description="double the frame")
+        @classmethod
+        def double(cls, df: pd.DataFrame) -> pd.DataFrame:
+            return df * 2
+
+    assert_frame_equal(DFModelWithKwargs.validate(data), expected)
+
+
 def test_parser_with_coercion():
     """Make sure that parser is applied before coercion."""
 


### PR DESCRIPTION
The parenthesized and keyword forms of the dataframe-level parser decorator crash at class-definition time:

```python
import pandera.pandas as pa

class M(pa.DataFrameModel):
    a: float

    @pa.dataframe_parser()          # also fails with @pa.dataframe_parser(description="...")
    @classmethod
    def double(cls, df):
        return df * 2
# TypeError: 'classmethod' object is not callable
```

The bare `@pa.dataframe_parser` form works, and the sibling `@pa.dataframe_check(...)` supports exactly this parenthesized/keyword form, so the two decorators are inconsistent.

### Root cause

`dataframe_parser(_fn=None, **parser_kwargs)` ends with an unconditional `return _wrapper(_fn)`. When it is called with parentheses, `_fn` is `None`, so `_wrapper(None)` runs immediately; `_to_function_and_classmethod(None)` produces `classmethod(None)`, and the decorator machinery then tries to call that classmethod object with the actual method, raising `TypeError: 'classmethod' object is not callable`.

`dataframe_check` has the correct guard (`if _fn: return _wrapper(_fn)` else `return _wrapper`); `dataframe_parser` looks copy-pasted from it (same `_fn=None` default, same `# type: ignore`) but the `if _fn:` guard was dropped.

### Fix

Guard on `_fn` exactly like `dataframe_check`. The bare `@dataframe_parser` form keeps working (`_fn` is the function, truthy), and the parenthesized / keyword forms now correctly return the wrapper so the parser is registered.

### Test

Adds `test_dataframe_parser_parenthesized_form` to `tests/pandas/test_parsers.py`, defining a `DataFrameModel` with `@dataframe_parser()` and `@dataframe_parser(description=...)` and asserting the parser is applied. It fails before the change (`TypeError`) and passes after; the full `tests/pandas/test_parsers.py` (18 tests) passes and ruff is clean.

Commit is DCO signed off.