### PR TITLE
Fix optional and nullable fields validation in PydanticModel

### DIFF
--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -66,16 +66,23 @@ class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
         if not self.columns and isinstance(
             self.dtype, pandas_engine.PydanticModel
         ):
+            fields_meta = self.dtype.fields_metadata
             self.columns = {
-                name: self._build_pydantic_column(name)
+                name: self._build_pydantic_column(
+                    name,
+                    required=fields_meta.get(name, {}).get("required", True),
+                    nullable=fields_meta.get(name, {}).get("nullable", False),
+                )
                 for name in self.dtype.column_names
             }
 
     @staticmethod
-    def _build_pydantic_column(name: str):
+    def _build_pydantic_column(
+        name: str, required: bool = True, nullable: bool = False
+    ):
         from pandera.api.pandas.components import Column
 
-        return Column(None, name=name)
+        return Column(None, name=name, required=required, nullable=nullable)
 
     @_DataFrameSchema.dtype.setter  # type: ignore[attr-defined]
     def dtype(self, value: PandasDtypeInputTypes) -> None:

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1435,6 +1435,39 @@ class PydanticModel(DataType):
             for name, field in self.type.__fields__.items()  # type: ignore[attr-defined]
         ]
 
+    @property
+    def fields_metadata(self) -> dict[str, dict[str, bool]]:
+        """Return field properties (required and nullable) keyed by alias."""
+        import typing
+
+        metadata = {}
+        if PYDANTIC_V2:
+            for name, field in self.type.model_fields.items():  # type: ignore[attr-defined]
+                alias = field.alias or name
+                required = field.is_required()
+                ann = field.annotation
+                origin = typing.get_origin(ann)
+                args = typing.get_args(ann)
+                nullable = False
+                if ann is typing.Any or ann is type(None) or ann is None:
+                    nullable = True
+                elif origin is typing.Union or (
+                    hasattr(typing, "UnionType") and origin is typing.UnionType
+                ):
+                    nullable = type(None) in args or None in args
+                metadata[alias] = {
+                    "required": required,
+                    "nullable": nullable,
+                }
+        else:
+            for name, field in self.type.__fields__.items():  # type: ignore[attr-defined]
+                alias = field.alias or name
+                metadata[alias] = {
+                    "required": getattr(field, "required", True),
+                    "nullable": getattr(field, "allow_none", False),
+                }
+        return metadata
+
     def _check_column_names(
         self,
         data_container: PandasObject,

--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1438,6 +1438,7 @@ class PydanticModel(DataType):
     @property
     def fields_metadata(self) -> dict[str, dict[str, bool]]:
         """Return field properties (required and nullable) keyed by alias."""
+        import types
         import typing
 
         metadata = {}
@@ -1452,7 +1453,7 @@ class PydanticModel(DataType):
                 if ann is typing.Any or ann is type(None) or ann is None:
                     nullable = True
                 elif origin is typing.Union or (
-                    hasattr(typing, "UnionType") and origin is typing.UnionType
+                    hasattr(types, "UnionType") and origin is types.UnionType
                 ):
                     nullable = type(None) in args or None in args
                 metadata[alias] = {

--- a/tests/pandas/test_pydantic_dtype.py
+++ b/tests/pandas/test_pydantic_dtype.py
@@ -161,7 +161,9 @@ def test_pydantic_model_validates_empty_dataframe_with_aliases():
         name: str = Field(alias="Name")
         amount: float = Field(alias="Amount in local currency")
 
-    schema = pa.DataFrameSchema(dtype=PydanticModel(Row), coerce=True, strict=True)
+    schema = pa.DataFrameSchema(
+        dtype=PydanticModel(Row), coerce=True, strict=True
+    )
     data = pd.DataFrame(columns=["Name", "Amount in local currency"])
     validated = schema.validate(data)
     assert validated.columns.tolist() == [
@@ -169,3 +171,30 @@ def test_pydantic_model_validates_empty_dataframe_with_aliases():
         "Amount in local currency",
     ]
     assert validated.empty
+
+
+def test_pydantic_model_optional_and_nullable_fields():
+    """Optional and nullable fields in Pydantic model should be optional/nullable in schema."""
+
+    class Book(BaseModel):
+        title: str
+        rating: int | None = None
+
+    schema = pa.DataFrameSchema(
+        dtype=PydanticModel(Book),
+        coerce=True,
+    )
+
+    # test 1: optional field missing in dataframe
+    df_without_rating = pd.DataFrame({"title": ["Dune", "Foundation"]})
+    validated_without_rating = schema.validate(df_without_rating)
+    assert validated_without_rating.columns.tolist() == ["title", "rating"]
+    assert pd.isna(validated_without_rating["rating"]).all()
+
+    # test 2: optional field containing null values
+    df_with_null_rating = pd.DataFrame(
+        {"title": ["Dune", "Foundation"], "rating": [None, None]}
+    )
+    validated_with_null_rating = schema.validate(df_with_null_rating)
+    assert validated_with_null_rating.columns.tolist() == ["title", "rating"]
+    assert pd.isna(validated_with_null_rating["rating"]).all()


### PR DESCRIPTION
This PR fixes a bug where DataFrame validation fails on optional/nullable fields in a PydanticModel because columns built dynamically during DataFrameSchema.__init__ defaulted to required=True and nullable=False. By extracting metadata from the pydantic model's fields, we now correctly map their required and nullable attributes.