### PR TITLE
fix: Repair coerce and parser options for xarray Datasets

### DIFF
--- a/pandera/backends/xarray/container.py
+++ b/pandera/backends/xarray/container.py
@@ -585,7 +585,6 @@ class DataArraySchemaBackend(XarraySchemaBackend):
         _parent_strict_coords: bool | str,
     ) -> list[CoreCheckResult]:
         results: list[CoreCheckResult] = []
-        coord_da = parent.coords[coord_name]
         parent_dims = set(parent.dims)
 
         if isinstance(spec, Coordinate):
@@ -648,8 +647,8 @@ class DataArraySchemaBackend(XarraySchemaBackend):
                 )
             sub = c.to_data_array_schema(coord_name)
             try:
-                self.validate(
-                    coord_da,
+                parent.coords[coord_name] = self.validate(
+                    parent.coords[coord_name],
                     sub,
                     lazy=True,
                     inplace=True,
@@ -1176,7 +1175,7 @@ class DatasetSchemaBackend(XarraySchemaBackend):
                 sub = copy.copy(spec.to_data_array_schema(logical))
             sub = sub.set_name(actual)
             try:
-                da_backend.validate(
+                ds[actual] = da_backend.validate(
                     ds[actual],
                     sub,
                     head=head,

--- a/tests/xarray/test_data_array_schema.py
+++ b/tests/xarray/test_data_array_schema.py
@@ -76,7 +76,8 @@ def test_strict_coords():
         schema_bad.validate(da_extra)
 
 
-def test_coords_coerced():
+@pytest.mark.parametrize("inplace", [False, True])
+def test_coords_coerced(inplace):
     da = xr.DataArray(
         np.zeros(2),
         dims=("x",),
@@ -85,10 +86,13 @@ def test_coords_coerced():
     schema = DataArraySchema(
         coords={"x": Coordinate(dtype=np.int16, coerce=True)},
     )
-    out = schema.validate(da)
+    out = schema.validate(da, inplace=inplace)
 
     assert out.coords["x"].dtype == np.int16
-    assert da.coords["x"].dtype == np.float32
+    if inplace:
+        assert da.coords["x"].dtype == np.int16
+    else:
+        assert da.coords["x"].dtype == np.float32
 
 
 def test_data_check_and_lazy():
@@ -109,12 +113,27 @@ def test_schema_only_skips_data_checks():
         schema.validate(da)
 
 
-def test_coerce_dtype():
+@pytest.mark.parametrize(
+    "inplace",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Known bug: inplace coercion is not supported"
+            ),
+        ),
+    ],
+)
+def test_coerce_dtype(inplace):
     da = xr.DataArray(np.array([1.0, 2.0]), dims=("x",))
     schema = DataArraySchema(dtype=np.int64, coerce=True)
-    out = schema.validate(da)
+    out = schema.validate(da, inplace=inplace)
     assert np.issubdtype(out.dtype, np.integer)
-    assert np.issubdtype(da.dtype, np.floating)
+    if inplace:
+        assert np.issubdtype(da.dtype, np.integer)
+    else:
+        assert np.issubdtype(da.dtype, np.floating)
 
 
 def test_sizes_and_shape_mutually_exclusive():
@@ -298,26 +317,45 @@ def test_lazy_validation_respects_n_failure_cases_in_error_message():
     assert "7" not in err
 
 
-def test_parser_runs():
+@pytest.mark.parametrize(
+    "inplace",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Known bug: inplace parser is not supported"
+            ),
+        ),
+    ],
+)
+def test_parser_runs(inplace):
 
     da = xr.DataArray(np.array([1.0, 2.0]), dims=("x",))
     schema = DataArraySchema(parsers=Parser(lambda x: x * 2))
     original = da.copy(deep=True)
-    out = schema.validate(da)
+    out = schema.validate(da, inplace=inplace)
     assert float(out.max().item()) == 4.0
-    xr.testing.assert_identical(da, original)
+    if inplace:
+        xr.testing.assert_identical(da, out)
+    else:
+        xr.testing.assert_identical(da, original)
 
 
-def test_parser_runs_on_coords():
+@pytest.mark.parametrize("inplace", [False, True])
+def test_parser_runs_on_coords(inplace):
 
     da = xr.DataArray(np.zeros(2), dims=("x",), coords={"x": [1.0, 2.0]})
     schema = DataArraySchema(
         coords={"x": Coordinate(parsers=[Parser(lambda x: x * 2)])}
     )
     original = da.copy(deep=True)
-    out = schema.validate(da)
+    out = schema.validate(da, inplace=inplace)
     assert float(out.coords["x"].max().item()) == 4.0
-    xr.testing.assert_identical(da, original)
+    if inplace:
+        xr.testing.assert_identical(da, out)
+    else:
+        xr.testing.assert_identical(da, original)
 
 
 def test_chunked_data_checks_skipped_by_default():

--- a/tests/xarray/test_data_array_schema.py
+++ b/tests/xarray/test_data_array_schema.py
@@ -6,6 +6,7 @@ import pytest
 xr = pytest.importorskip("xarray")
 
 import pandera.errors
+from pandera.api.parsers import Parser
 from pandera.xarray import Check, Coordinate, DataArraySchema
 
 
@@ -75,6 +76,21 @@ def test_strict_coords():
         schema_bad.validate(da_extra)
 
 
+def test_coords_coerced():
+    da = xr.DataArray(
+        np.zeros(2),
+        dims=("x",),
+        coords={"x": ("x", np.arange(2, dtype=np.float32))},
+    )
+    schema = DataArraySchema(
+        coords={"x": Coordinate(dtype=np.int16, coerce=True)},
+    )
+    out = schema.validate(da)
+
+    assert out.coords["x"].dtype == np.int16
+    assert da.coords["x"].dtype == np.float32
+
+
 def test_data_check_and_lazy():
     da = xr.DataArray(np.array([1.0, 5.0, 3.0]), dims=("x",))
     schema = DataArraySchema(checks=Check(lambda x: x.max() < 4))
@@ -98,6 +114,7 @@ def test_coerce_dtype():
     schema = DataArraySchema(dtype=np.int64, coerce=True)
     out = schema.validate(da)
     assert np.issubdtype(out.dtype, np.integer)
+    assert np.issubdtype(da.dtype, np.floating)
 
 
 def test_sizes_and_shape_mutually_exclusive():
@@ -282,12 +299,25 @@ def test_lazy_validation_respects_n_failure_cases_in_error_message():
 
 
 def test_parser_runs():
-    from pandera.api.parsers import Parser
 
     da = xr.DataArray(np.array([1.0, 2.0]), dims=("x",))
     schema = DataArraySchema(parsers=Parser(lambda x: x * 2))
+    original = da.copy(deep=True)
     out = schema.validate(da)
     assert float(out.max().item()) == 4.0
+    xr.testing.assert_identical(da, original)
+
+
+def test_parser_runs_on_coords():
+
+    da = xr.DataArray(np.zeros(2), dims=("x",), coords={"x": [1.0, 2.0]})
+    schema = DataArraySchema(
+        coords={"x": Coordinate(parsers=[Parser(lambda x: x * 2)])}
+    )
+    original = da.copy(deep=True)
+    out = schema.validate(da)
+    assert float(out.coords["x"].max().item()) == 4.0
+    xr.testing.assert_identical(da, original)
 
 
 def test_chunked_data_checks_skipped_by_default():
@@ -490,6 +520,40 @@ class TestDataArrayCheckMethods:
         schema = DataArraySchema(coords={"y": Coordinate()})
         results = backend.check_coords(da, schema)
         assert any(not r.passed for r in results)
+
+    def test_check_coords_dtype_pass(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DataArraySchema(
+            coords={"x": Coordinate(dtype=np.int16)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert all(r.passed for r in results) or not results
+
+    def test_check_coords_dtype_fail(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DataArraySchema(
+            coords={"x": Coordinate(dtype=np.float32)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert any(not r.passed for r in results)
+
+    def test_coerce_coord_dtype(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DataArraySchema(
+            coords={"x": Coordinate(dtype=np.float32, coerce=True)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert all(r.passed for r in results) or not results
+        assert ds.coords["x"].dtype == np.float32
 
     def test_check_strict_coords_pass(self, backend):
         da = xr.DataArray(

--- a/tests/xarray/test_dataset_schema.py
+++ b/tests/xarray/test_dataset_schema.py
@@ -35,7 +35,8 @@ def test_data_vars_and_coords():
     schema.validate(ds)
 
 
-def test_data_vars_and_coords_coerced():
+@pytest.mark.parametrize("inplace", [False, True])
+def test_data_vars_and_coords_coerced(inplace):
     ds = xr.Dataset(
         {
             "a": (["x"], np.zeros(3, dtype=np.float32)),
@@ -50,17 +51,23 @@ def test_data_vars_and_coords_coerced():
         },
         coords={"x": Coordinate(dtype=np.int16, coerce=True)},
     )
-    out = schema.validate(ds)
+    out = schema.validate(ds, inplace=inplace)
 
     assert out.data_vars["a"].dtype == np.int16
     assert out.data_vars["b"].dtype == np.float64
     assert out.coords["x"].dtype == np.int16
-    assert ds.data_vars["a"].dtype == np.float32
-    assert ds.data_vars["b"].dtype == np.float32
-    assert ds.coords["x"].dtype == np.float32
+    if inplace:
+        assert ds.data_vars["a"].dtype == np.int16
+        assert ds.data_vars["b"].dtype == np.float64
+        assert ds.coords["x"].dtype == np.int16
+    else:
+        assert ds.data_vars["a"].dtype == np.float32
+        assert ds.data_vars["b"].dtype == np.float32
+        assert ds.coords["x"].dtype == np.float32
 
 
-def test_data_vars_and_coords_parsed():
+@pytest.mark.parametrize("inplace", [False, True])
+def test_data_vars_and_coords_parsed(inplace):
     ds = xr.Dataset(
         {
             "a": (["x"], np.zeros(3, dtype=np.float32)),
@@ -76,12 +83,15 @@ def test_data_vars_and_coords_parsed():
         coords={"x": Coordinate(parsers=[Parser(np.square)])},
     )
     original = ds.copy(deep=True)
-    out = schema.validate(ds)
+    out = schema.validate(ds, inplace=inplace)
 
     assert (out.data_vars["a"] == 1.0).all().item()
     assert (out.data_vars["b"] == 1.0).all().item()
     assert out.coords["x"].max().item() == 4.0
-    xr.testing.assert_identical(ds, original)
+    if inplace:
+        xr.testing.assert_identical(ds, out)
+    else:
+        xr.testing.assert_identical(ds, original)
 
 
 def test_optional_default_fill():

--- a/tests/xarray/test_dataset_schema.py
+++ b/tests/xarray/test_dataset_schema.py
@@ -11,6 +11,7 @@ from pandera.xarray import (
     Coordinate,
     DatasetSchema,
     DataVar,
+    Parser,
 )
 
 
@@ -32,6 +33,55 @@ def test_data_vars_and_coords():
         sizes={"x": 3},
     )
     schema.validate(ds)
+
+
+def test_data_vars_and_coords_coerced():
+    ds = xr.Dataset(
+        {
+            "a": (["x"], np.zeros(3, dtype=np.float32)),
+            "b": (["x"], np.ones(3, dtype=np.float32)),
+        },
+        coords={"x": np.arange(3, dtype=np.float32)},
+    )
+    schema = DatasetSchema(
+        data_vars={
+            "a": DataVar(dtype=np.int16, dims=("x",), coerce=True),
+            "b": DataVar(dtype=np.float64, dims=("x",), coerce=True),
+        },
+        coords={"x": Coordinate(dtype=np.int16, coerce=True)},
+    )
+    out = schema.validate(ds)
+
+    assert out.data_vars["a"].dtype == np.int16
+    assert out.data_vars["b"].dtype == np.float64
+    assert out.coords["x"].dtype == np.int16
+    assert ds.data_vars["a"].dtype == np.float32
+    assert ds.data_vars["b"].dtype == np.float32
+    assert ds.coords["x"].dtype == np.float32
+
+
+def test_data_vars_and_coords_parsed():
+    ds = xr.Dataset(
+        {
+            "a": (["x"], np.zeros(3, dtype=np.float32)),
+            "b": (["x"], np.ones(3, dtype=np.float32)),
+        },
+        coords={"x": np.arange(3, dtype=np.float32)},
+    )
+    schema = DatasetSchema(
+        data_vars={
+            "a": DataVar(parsers=[Parser(xr.ones_like)]),
+            "b": DataVar(),
+        },
+        coords={"x": Coordinate(parsers=[Parser(np.square)])},
+    )
+    original = ds.copy(deep=True)
+    out = schema.validate(ds)
+
+    assert (out.data_vars["a"] == 1.0).all().item()
+    assert (out.data_vars["b"] == 1.0).all().item()
+    assert out.coords["x"].max().item() == 4.0
+    xr.testing.assert_identical(ds, original)
 
 
 def test_optional_default_fill():
@@ -309,6 +359,63 @@ class TestDatasetCheckMethods:
         results = backend.check_coords(ds, schema)
         assert any(not r.passed for r in results)
 
+    def test_check_coords_dtype_pass(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar()},
+            coords={"x": Coordinate(dtype=np.int16)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert all(r.passed for r in results) or not results
+
+    def test_check_coords_dtype_fail(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar()},
+            coords={"x": Coordinate(dtype=np.float32)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert any(not r.passed for r in results)
+
+    def test_check_coords_dtype_coerced(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.int16)},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar()},
+            coords={"x": Coordinate(dtype=np.float32, coerce=True)},
+        )
+        results = backend.check_coords(ds, schema)
+        assert all(r.passed for r in results) or not results
+        assert ds.coords["x"].dtype == np.float32
+
+    def test_check_coords_parser(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2))},
+            coords={"x": np.arange(2, dtype=np.float32)},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar()},
+            coords={
+                "x": Coordinate(
+                    dtype=np.float32,
+                    coerce=False,
+                    parsers=Parser(lambda da: da + np.float32(1.0)),
+                )
+            },
+        )
+        results = backend.check_coords(ds, schema)
+        assert all(r.passed for r in results) or not results
+        assert ds.coords["x"].dtype == np.float32
+        assert ds.coords["x"].max().item() == np.float32(2.0)
+
     def test_check_strict_coords_pass(self, backend):
         ds = xr.Dataset(
             {"a": (["x"], np.zeros(2))},
@@ -388,6 +495,65 @@ class TestDatasetCheckMethods:
             ds, schema, {"a": "a", "b": "b"}
         )
         assert not results
+
+    def test_check_data_vars_dtype_pass(self, backend):
+        ds = xr.Dataset({"a": (["x"], np.zeros(2, dtype=np.int16))})
+        schema = DatasetSchema(
+            data_vars={"a": DataVar(dtype=np.int16)},
+        )
+        logical_to_actual = {"a": "a"}
+        results = backend.run_schema_component_checks(
+            ds, schema, logical_to_actual
+        )
+        assert all(r.passed for r in results) or not results
+
+    def test_check_data_vars_dtype_fail(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2, dtype=np.int16))},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar(dtype=np.float32)},
+        )
+        logical_to_actual = {"a": "a"}
+        results = backend.run_schema_component_checks(
+            ds, schema, logical_to_actual
+        )
+        assert any(not r.passed for r in results)
+
+    def test_check_data_vars_dtype_coerced(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.zeros(2, dtype=np.int16))},
+        )
+        schema = DatasetSchema(
+            data_vars={"a": DataVar(dtype=np.float32, coerce=True)},
+        )
+        logical_to_actual = {"a": "a"}
+        results = backend.run_schema_component_checks(
+            ds, schema, logical_to_actual
+        )
+        assert all(r.passed for r in results) or not results
+        assert ds.data_vars["a"].dtype == np.float32
+
+    def test_check_data_vars_parser(self, backend):
+        ds = xr.Dataset(
+            {"a": (["x"], np.arange(2, dtype=np.int16))},
+        )
+        schema = DatasetSchema(
+            data_vars={
+                "a": DataVar(
+                    dtype=np.float32,
+                    coerce=False,
+                    parsers=Parser(lambda da: da + np.float32(1.0)),
+                )
+            },
+        )
+        logical_to_actual = {"a": "a"}
+        results = backend.run_schema_component_checks(
+            ds, schema, logical_to_actual
+        )
+        assert all(r.passed for r in results) or not results
+        assert ds.data_vars["a"].dtype == np.float32
+        assert ds.data_vars["a"].max().item() == np.float32(2.0)
 
     def test_check_data_var_alignment_pass(self, backend):
         ds = xr.Dataset(


### PR DESCRIPTION
The `coerce` and `parsers` arguments for data vars and coordinates in a `DatasetSchema` did not work as expected. They could cause validation to succeed, but did not alter the Dataset or its coordinates.

For example, the following example

```py
from pandera.xarray import Coordinate, DatasetSchema, DataVar, Parser
from xarray import Dataset
import numpy as np

ds = Dataset(
    {
        "a": (["x"], np.zeros(3, dtype=np.int32)),
    },
    coords={"x": np.arange(3, dtype=np.int32)},
)
schema = DatasetSchema(
    data_vars={
        "a": DataVar(dtype=np.float64, dims=("x",), coerce=True),
    },
    coords={"x": Coordinate(parsers=[Parser(np.square)])},
)
out = schema.validate(ds)
print(out)
```

yields

```text
<xarray.Dataset> Size: 24B
Dimensions:  (x: 3)
Coordinates:
  * x        (x) int32 12B 0 1 2
Data variables:
    a        (x) int32 12B 0 0 0
```

The coordinate should have been squared and the data variable should have been converted to a float. Without `coerce=True` argument, validation would have failed.

The issue is inside the `DatasetSchemaBackend` class. When the data variables and coordinates are validated, the result is discarded instead of being assigned back to the original object. The fix was pretty simple.

The `DataArraySchemaBackend` class does not have the same problem, but it has a different one. Coercion and parsers work for both the data and the coordinates, but the data is not modified in place in place when `inplace=True`. I couldn't come up with a simple fix for this (or at least not quickly).

I wrote some tests that would have failed before my change, and similar tests for `DataArraySchema` as well. Some of the tests run both with `inplace=True` and `inplace=False`, but I've had to mark them as xfail for `DataArraySchema`.
