### PR TITLE
Add pandas and numpy to the io and all extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ hypotheses = [
     "scipy",
 ]
 io = [
+    "numpy >= 1.24.4",
+    "pandas >= 2.1.1",
     "pyyaml >= 5.1",
 ]
 frictionless = [
@@ -120,6 +122,7 @@ all = [
     "polars >= 0.20.0",
     "xarray >= 2024.10.0",
     "numpy >= 1.24.4",
+    "pandas >= 2.1.1",
     "narwhals >= 1.26.0",
 ]
 


### PR DESCRIPTION
Fixes #2127.

## Problem

The `io` module unconditionally uses the pandas engine (`pandera/io/pandas_io.py` imports `pandera.engines.pandas_engine` and friends at module level), but:

- the `io` extra only declares `pyyaml`, and
- the `all` extra declares `numpy` but not `pandas`.

As the issue notes, this is an oversight from when `pandas`/`numpy` moved from core dependencies into the `pandera[pandas]` extra — a bare `pip install pandera[io]` (or `pandera[all]`) produces an environment where `pandera.io` fails to import.

## Change

Add `numpy >= 1.24.4` and `pandas >= 2.1.1` to the `io` extra, and `pandas >= 2.1.1` to the `all` extra (which already had numpy) — the same version pins as the existing `pandas` extra, so nothing new is introduced.

Validated the edited `pyproject.toml` parses (`tomllib`) and that the pins mirror the `pandas` extra exactly.