### PR TITLE
fix(io): format dataframe-level checks in to_script

### DIFF
--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -838,7 +838,7 @@ def to_script(dataframe_schema, path_or_buf=None, *, minimal: bool = True):
 
     script = SCRIPT_TEMPLATE.format(
         columns=column_str,
-        checks=statistics["checks"],
+        checks=_format_checks(statistics["checks"]),
         index=index,
         dtype=dataframe_schema.dtype,
         coerce=dataframe_schema.coerce,

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1547,6 +1547,28 @@ def test_to_script(index):
         assert schema == schema_to_write
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="skipping due to issues with opening file names for temp files.",
+)
+def test_to_script_dataframe_level_checks():
+    """Test that dataframe-level checks survive a to_script round trip."""
+    schema_to_write = pandera.DataFrameSchema(
+        {"a": pandera.Column(int)},
+        checks=[pandera.Check.gt(0)],
+    )
+
+    local_dict = {}
+    # pylint: disable=exec-used
+    exec(schema_to_write.to_script(minimal=False), globals(), local_dict)
+    schema = local_dict["schema"]
+
+    assert schema == schema_to_write
+    schema.validate(pd.DataFrame({"a": [1, 2]}))
+    with pytest.raises(pandera.errors.SchemaError):
+        schema.validate(pd.DataFrame({"a": [-1]}))
+
+
 def test_to_script_lambda_check():
     """Test writing DataFrameSchema to a script with lambda check."""
     schema1 = pandera.DataFrameSchema(


### PR DESCRIPTION
### Problem

`to_script(minimal=False)` produces a script that runs fine and looks correct, but the schema it rebuilds is unusable — **every** `validate()` call on it raises `TypeError: 'dict' object is not callable`, including on data the original schema accepts:

```python
import pandas as pd
from pandera.pandas import DataFrameSchema, Column, Check

schema = DataFrameSchema({"a": Column(int)}, checks=[Check.gt(0)])
ns = {}
exec(schema.to_script(minimal=False), ns)
rt = ns["schema"]

print(rt.checks)
# [{'min_value': 0, 'options': {'check_name': 'greater_than', ...}}]   <- dicts, not Checks
print(schema == rt)
# False

schema.validate(pd.DataFrame({"a": [5]}))   # passes, as it should
rt.validate(pd.DataFrame({"a": [5]}))       # SchemaError: Error while executing check
                                            # function: TypeError("'dict' object is not callable")
```

Column-level checks round-trip correctly, so the two paths disagree:

```python
s2 = DataFrameSchema({"a": Column(int, Check.gt(0))})   # same check, column level
ns2 = {}; exec(s2.to_script(minimal=False), ns2)
print(ns2["schema"].columns["a"].checks)   # [<Check greater_than: greater_than(0)>]
print(s2 == ns2["schema"])                 # True
```

The failure is quiet at the point of corruption: the generated script is valid Python and the `DataFrameSchema(...)` call succeeds. It only surfaces later, as a confusing `TypeError` from inside validation that gives no hint that `to_script` was the culprit.

### Cause

In `to_script` the column path formats its checks, but the dataframe-level path passes the raw statistics list straight into the template — 19 lines apart in the same function:

```python
column_code = COLUMN_TEMPLATE.format(
    checks=_format_checks(properties["checks"]),   # line 820 — formatted
    ...
)
...
script = SCRIPT_TEMPLATE.format(
    checks=statistics["checks"],                   # line 841 — raw dicts
    ...
)
```

Every other caller of the template data (`_format_index`, `_format_column_minimal`, the column path) goes through `_format_checks`; this one line is the exception.

### Fix

Format dataframe-level checks the same way the column path does. `_format_checks(None)` already returns `"None"`, so schemas without dataframe-level checks are unaffected.

After the fix, `rt.checks` is `[<Check greater_than: greater_than(0)>]`, `schema == rt` is `True`, and the round-tripped schema accepts and rejects exactly what the original does.

### Testing

- Added `test_to_script_dataframe_level_checks` to `tests/io/test_pandas_io.py`. The existing `test_to_script` asserts the right invariant (`schema == schema_to_write`) but its `_create_schema()` fixture defines only column checks, so this path had no coverage. Verified the new test fails before the fix and passes after.
- `tests/io/` → 73 passed. The 5 `test_frictionless_*` failures are pre-existing: they fail identically on an unmodified `main` in my environment because `frictionless` isn't installed, and are unrelated to this change.
- `tests/pandas/test_schema_statistics.py` + `tests/pandas/test_schema_inference.py` → 80 passed, 1 skipped (`to_script` goes through `get_dataframe_schema_statistics`).
- `ruff check` (the linter CI runs) and `ruff format --check` clean on both changed files.

### Note on #2402

Heads-up that #2402 moves `to_script`/`SCRIPT_TEMPLATE`/`_format_checks` into `pandera/io/common_io.py` and carries `checks=statistics["checks"]` across unchanged, so the bug would survive that refactor. Happy to rebase onto it, or to re-send against `common_io.py` instead if you'd rather land #2402 first — whichever is less work for you.

### AI disclosure

Prepared with AI assistance (Claude Code). I reproduced the bug against the unmodified library, verified the fix and the test locally, and take responsibility for the change.
