### PR TITLE
fix: handle scalar groupby keys in _format_groupby_input

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -1,7 +1,7 @@
 """Data validation check definition."""
 
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 from typing import (
     Any,
     Optional,
@@ -21,7 +21,7 @@ class Check(BaseCheck):
     def __init__(
         self,
         check_fn: Callable,
-        groups: Union[str, list[str]] | None = None,
+        groups: Union[str, list[Hashable]] | None = None,
         groupby: Union[str, list[str], Callable] | None = None,
         ignore_na: bool = True,
         element_wise: bool = False,
@@ -214,7 +214,7 @@ class Check(BaseCheck):
         self.groupby = groupby
         if isinstance(groups, str):
             groups = [groups]
-        self.groups: list[str] | None = groups
+        self.groups: list[Hashable] | None = groups
 
         self.statistics = statistics or check_kwargs or {}
         self.statistics_args = [*self.statistics.keys()]

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -46,7 +46,7 @@ class PandasCheckBackend(BaseCheckBackend):
     @staticmethod
     def _format_groupby_input(
         groupby_obj: GroupbyObject,
-        groups: list[str] | None,
+        groups: list[Hashable] | None,
     ) -> dict[Hashable, pd.Series] | dict[Hashable, pd.DataFrame]:
         """Format groupby object into dict of groups to Series or DataFrame.
 

--- a/pandera/backends/pandas/checks.py
+++ b/pandera/backends/pandas/checks.py
@@ -58,11 +58,17 @@ class PandasCheckBackend(BaseCheckBackend):
         # pandas groupby objects instead of dicts.
         if groups is None:
             return {
-                (k if isinstance(k, bool) else k[0] if len(k) == 1 else k): v
+                (
+                    k
+                    if isinstance(k, bool) or not isinstance(k, tuple)
+                    else k[0]
+                    if len(k) == 1
+                    else k
+                ): v
                 for k, v in groupby_obj  # type: ignore[union-attr]
             }
         group_keys = {
-            k[0] if len(k) == 1 else k
+            k if not isinstance(k, tuple) else k[0] if len(k) == 1 else k
             for k, _ in groupby_obj  # type: ignore[union-attr]
         }
         invalid_groups = [g for g in groups if g not in group_keys]

--- a/pandera/backends/pyspark/checks.py
+++ b/pandera/backends/pyspark/checks.py
@@ -1,5 +1,6 @@
 """Check backend for pyspark."""
 
+from collections.abc import Hashable
 from functools import partial
 from typing import Optional, Union
 
@@ -43,7 +44,7 @@ class PySparkCheckBackend(BaseCheckBackend):
     @staticmethod
     def _format_groupby_input(
         groupby_obj: GroupbyObject,
-        groups: list[str] | None,
+        groups: list[Hashable] | None,
     ) -> dict[str, PySparkDataFrameTypes]:  # pragma: no cover
         raise NotImplementedError
 

--- a/tests/pandas/test_checks.py
+++ b/tests/pandas/test_checks.py
@@ -103,9 +103,7 @@ def test_check_groupby_scalar_keys() -> None:
     """Regression test for issue #1235: groupby with a single string column
     whose values are non-string scalars (e.g. integers) should not raise
     TypeError from calling len() on a scalar group key."""
-    df = pd.DataFrame(
-        {"group": [1, 1, 2, 2], "val": [10, 20, 30, 40]}
-    )
+    df = pd.DataFrame({"group": [1, 1, 2, 2], "val": [10, 20, 30, 40]})
 
     # groupby as a plain string (not a list) produces scalar keys
     schema = DataFrameSchema(

--- a/tests/pandas/test_checks.py
+++ b/tests/pandas/test_checks.py
@@ -99,6 +99,48 @@ def test_check_groupby() -> None:
             schema.validate(df)
 
 
+def test_check_groupby_scalar_keys() -> None:
+    """Regression test for issue #1235: groupby with a single string column
+    whose values are non-string scalars (e.g. integers) should not raise
+    TypeError from calling len() on a scalar group key."""
+    df = pd.DataFrame(
+        {"group": [1, 1, 2, 2], "val": [10, 20, 30, 40]}
+    )
+
+    # groupby as a plain string (not a list) produces scalar keys
+    schema = DataFrameSchema(
+        {
+            "group": Column(Int),
+            "val": Column(
+                Int,
+                Check(
+                    lambda d: all(s.gt(0).all() for s in d.values()),
+                    groupby="group",
+                ),
+            ),
+        }
+    )
+    result = schema.validate(df)
+    assert isinstance(result, pd.DataFrame)
+
+    # Also test with groups filter on scalar keys
+    schema_with_groups = DataFrameSchema(
+        {
+            "group": Column(Int),
+            "val": Column(
+                Int,
+                Check(
+                    lambda d: all(s.gt(0).all() for s in d.values()),
+                    groupby="group",
+                    groups=[1],
+                ),
+            ),
+        }
+    )
+    result2 = schema_with_groups.validate(df)
+    assert isinstance(result2, pd.DataFrame)
+
+
 def test_check_groupby_multiple_columns() -> None:
     """Tests uses of groupby to specify dependencies between one column and a
     number of other columns, including error handling."""


### PR DESCRIPTION
## Summary

Fixes #1235.

When `Check.groupby` is a plain string (e.g. `groupby="group"`), pandas produces **scalar** group keys (e.g. integers) rather than tuples. The existing code in `_format_groupby_input` unconditionally calls `len(k)` and `k[0]` on group keys, which raises `TypeError` for non-sequence scalars like `int` or `float`.

## Root Cause

`pandas.DataFrame.groupby("col")` yields scalar keys, whereas `groupby(["col"])` yields single-element tuples. The code only handled the tuple case.

## Fix

Check `isinstance(k, tuple)` before attempting `len()`/indexing. Non-tuple (scalar) keys are passed through directly. This applies to both the `groups is None` path and the `group_keys` computation.

## Test

Added `test_check_groupby_scalar_keys` regression test covering:
- String groupby with integer group keys (the reported bug)
- String groupby with `groups` filter on scalar keys

All existing groupby tests continue to pass.

## AI Disclosure

AI-assisted debugging/initial draft/testing with human review of the diff and test scope (per the contribution workflow).