### PR TITLE
fix(api): raise informative TypeError for non-dataframe validate() input

### DIFF
--- a/pandera/api/pandas/container.py
+++ b/pandera/api/pandas/container.py
@@ -14,7 +14,7 @@ else:
     from typing import Self
 
 from pandera.api.dataframe.container import DataFrameSchema as _DataFrameSchema
-from pandera.api.pandas.types import PandasDtypeInputTypes
+from pandera.api.pandas.types import PandasDtypeInputTypes, is_table_or_field
 from pandera.config import get_config_context
 from pandera.engines import pandas_engine
 from pandera.errors import BackendNotFoundError
@@ -148,6 +148,19 @@ class DataFrameSchema(_DataFrameSchema[pd.DataFrame]):
         """
         if not get_config_context().validation_enabled:
             return check_obj
+
+        # Fail early with an informative error for non-dataframe inputs.
+        # Without this guard, backend dispatch raises an opaque
+        # ``BackendNotFoundError`` (or ``AttributeError``) instead of clearly
+        # communicating that a dataframe-like object was expected. This mirrors
+        # the ``is_field`` guard in ``SeriesSchema.validate``. Field-like
+        # objects (e.g. ``pd.Series``) are permitted here because
+        # ``MultiIndex`` (a ``DataFrameSchema`` subclass) reuses this method to
+        # validate the index of a ``SeriesSchema``.
+        if not is_table_or_field(check_obj):
+            raise TypeError(
+                f"expected pd.DataFrame, got {type(check_obj)}"
+            )
 
         # NOTE: Move this into its own schema-backend variant. This is where
         # the benefits of separating the schema spec from the backend

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -119,6 +119,24 @@ def test_dataframe_schema() -> None:
         schema.validate(df.assign(a=[1.7, 2.3, 3.1]))
 
 
+@pytest.mark.parametrize(
+    "invalid_input",
+    [1, 1.0, "foo", ["a", "b"], {"a": 1}, (1, 2), None, int],
+)
+def test_dataframe_schema_validate_non_dataframe_raises_typeerror(
+    invalid_input,
+) -> None:
+    """Passing a non-dataframe object to ``validate`` should raise an
+    informative ``TypeError`` rather than an opaque ``BackendNotFoundError``.
+
+    See https://github.com/unionai-oss/pandera/issues/467. This mirrors the
+    ``is_field`` guard already present in ``SeriesSchema.validate``.
+    """
+    schema = DataFrameSchema({"a": Column(float)})
+    with pytest.raises(TypeError, match="expected pd.DataFrame"):
+        schema.validate(invalid_input)
+
+
 def test_dataframe_single_element_coerce() -> None:
     """Test that coercing a single element dataframe works correctly."""
     schema = DataFrameSchema({"x": Column(int, coerce=True)})


### PR DESCRIPTION
## Summary

Closes #467.

Calling `DataFrameSchema.validate()` with a non-dataframe argument (e.g. an
`int`) raised an opaque `BackendNotFoundError` — the backend registry lookup
failed before any human-readable check could run. This was also inconsistent
with `SeriesSchema.validate()`, which already raises a clear
`TypeError: expected pd.Series, got <type>` via its `is_field` guard.

This PR adds the analogous guard to `DataFrameSchema.validate()`:

```python
if not is_table_or_field(check_obj):
    raise TypeError(f"expected pd.DataFrame, got {type(check_obj)}")
```

`is_table_or_field` (rather than `is_table`) is used deliberately: `MultiIndex`
subclasses `DataFrameSchema` and reuses this method to validate a
`SeriesSchema`'s index, where it receives a `pd.Series`. The guard still
rejects plain Python objects (int/float/str/list/dict/tuple/None/classes) and
still accepts dask/modin/pyspark/geopandas dataframes.

## Test plan

- New parametrized regression test
  `test_dataframe_schema_validate_non_dataframe_raises_typeerror` covering 8
  invalid input types.
- `tests/pandas/test_schemas.py` and `tests/pandas/test_decorators.py` pass
  (276 passed). Full `tests/pandas` shows only pre-existing `pyarrow`-related
  failures, unaffected by this change.
