### PR TITLE
fix: _get_fn_argnames crashes on functions with no positional args

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -70,6 +70,9 @@ def _get_fn_argnames(fn: Callable) -> list[str]:
 
     arg_spec_args = inspect.getfullargspec(fn).args
 
+    if not arg_spec_args:
+        return arg_spec_args
+
     first_arg_is_self = arg_spec_args[0] == "self"
     first_arg_is_cls = arg_spec_args[0] == "cls"
     is_py_newer_than_39 = sys.version_info[:2] >= (3, 9)

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -1892,3 +1892,33 @@ def test_check_types_catches_inplace_mutation():
     df = DataFrame[InSchema]({"id": [1], "name": ["foo"]})
     with pytest.raises(errors.SchemaError):
         mutate_after_typing(df)
+
+
+def test_get_fn_argnames_keyword_only_args():
+    """Regression test: _get_fn_argnames should not crash on functions
+    with only keyword-only arguments or no positional arguments."""
+    from pandera.decorators import _get_fn_argnames
+
+    # keyword-only args only
+    def kwonly_fn(*, df, out):
+        pass
+
+    assert _get_fn_argnames(kwonly_fn) == []
+
+    # *args only
+    def varargs_fn(*args):
+        pass
+
+    assert _get_fn_argnames(varargs_fn) == []
+
+    # **kwargs only
+    def kwargs_fn(**kwargs):
+        pass
+
+    assert _get_fn_argnames(kwargs_fn) == []
+
+    # mixed: no positional, only *args and keyword-only
+    def mixed_fn(*args, key=None):
+        pass
+
+    assert _get_fn_argnames(mixed_fn) == []


### PR DESCRIPTION
## Summary

Fixes #2422.

`_get_fn_argnames()` unconditionally accesses `arg_spec_args[0]` to check for `self`/`cls`, but functions with only keyword-only arguments, `*args`, or `**kwargs` produce an empty `args` list from `inspect.getfullargspec()`, causing `IndexError`.

## Changes

- **`pandera/decorators.py`**: Added early return when `arg_spec_args` is empty, before the `[0]` access.
- **`tests/pandas/test_decorators.py`**: Added `test_get_fn_argnames_keyword_only_args` regression test covering keyword-only, `*args`-only, `**kwargs`-only, and mixed signatures.

## Reproduction

```python
from pandera.decorators import _get_fn_argnames

def process(*, df, output_col):
    pass

_get_fn_argnames(process)  # Before: IndexError; After: []
```