### PR TITLE
fix: bind self correctly in check_input when an arg is passed by keyword

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -228,7 +228,10 @@ def check_input(
 
             sig = inspect.signature(_unwrap_fn(wrapped))
             is_method = [*sig.parameters][0] in ("self", "cls")
-            if is_method and len(args) == len(sig.parameters) - 1:
+            if (
+                is_method
+                and len(args) + len(kwargs) == len(sig.parameters) - 1
+            ):
                 pos_args = sig.bind_partial(None, *args).arguments
             else:
                 pos_args = sig.bind_partial(*args).arguments

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -363,6 +363,23 @@ def test_check_input_on_fn_with_kwarg():
     fn_with_check_input(df, kwarg=True)
 
 
+def test_check_input_on_method_with_keyword_arg():
+    """Test that a method still binds ``self`` correctly when one of the
+    remaining arguments is passed by keyword."""
+    schema = DataFrameSchema({"col": Column(Int)})
+
+    class Example:
+        # pylint: disable=missing-function-docstring,no-self-use
+        @check_input(schema, "df")
+        def method(self, df, other):
+            return df
+
+    df = pd.DataFrame({"col": [1]})
+    example = Example()
+    pd.testing.assert_frame_equal(example.method(df, "foo"), df)
+    pd.testing.assert_frame_equal(example.method(df, other="foo"), df)
+
+
 def test_check_io() -> None:
     # pylint: disable=too-many-locals
     """Test that check_io correctly validates/invalidates data."""


### PR DESCRIPTION
Closes #1997.

`check_input`'s wrapper rebinds a bound method's signature with a `None` placeholder for `self` when `self` is missing from `args`, but the guard compared `len(args)` to `len(sig.parameters) - 1`. Passing any of the remaining arguments by keyword made that count fall short, so the placeholder was skipped and `self` was bound to the schema argument — validation then ran on the instance and raised `BackendNotFoundError`. Counting keyword arguments too makes the placeholder apply regardless of how the arguments are passed.

Regression test added in `tests/pandas/test_decorators.py`; it fails with the reported `BackendNotFoundError` without the fix and passes with it.
