### PR TITLE
fix(pyspark): disable AQE in tests to stop native-thread exhaustion on macOS CI

### DIFF
--- a/tests/pyspark/conftest.py
+++ b/tests/pyspark/conftest.py
@@ -23,15 +23,8 @@ def spark_env_vars():
     os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
     # Disable Adaptive Query Execution process-wide. AQE materializes each
     # query stage asynchronously via cached thread pools (``shuffle-exchange``
-    # / ``ResultQueryStageExecution``). Across the hundreds of pandas-on-Spark
-    # operations in this suite these accumulate into thousands of native
-    # threads in the long-lived session, eventually exceeding the macOS
-    # per-process thread limit and crashing the JVM ("unable to create native
-    # thread") -- which then surfaces as ConnectionRefusedError in every
-    # subsequent test. pandas-on-Spark (``pyspark.pandas``) builds its own
-    # default session via ``getOrCreate()`` that bypasses the ``spark``
-    # fixture, so set the config via PYSPARK_SUBMIT_ARGS to cover it too. AQE
-    # only affects query planning/performance, not validation results.
+    # / ``ResultQueryStageExecution``), leading to ConnectionRefusedError in every
+    # subsequent test. AQE only affects query planning/performance, not validation results.
     submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "")
     if "spark.sql.adaptive.enabled" not in submit_args:
         conf = "--conf spark.sql.adaptive.enabled=false"

--- a/tests/pyspark/conftest.py
+++ b/tests/pyspark/conftest.py
@@ -21,6 +21,23 @@ def spark_env_vars():
     """Sets environment variables for pyspark."""
     os.environ["SPARK_LOCAL_IP"] = "127.0.0.1"
     os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
+    # Disable Adaptive Query Execution process-wide. AQE materializes each
+    # query stage asynchronously via cached thread pools (``shuffle-exchange``
+    # / ``ResultQueryStageExecution``). Across the hundreds of pandas-on-Spark
+    # operations in this suite these accumulate into thousands of native
+    # threads in the long-lived session, eventually exceeding the macOS
+    # per-process thread limit and crashing the JVM ("unable to create native
+    # thread") -- which then surfaces as ConnectionRefusedError in every
+    # subsequent test. pandas-on-Spark (``pyspark.pandas``) builds its own
+    # default session via ``getOrCreate()`` that bypasses the ``spark``
+    # fixture, so set the config via PYSPARK_SUBMIT_ARGS to cover it too. AQE
+    # only affects query planning/performance, not validation results.
+    submit_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "")
+    if "spark.sql.adaptive.enabled" not in submit_args:
+        conf = "--conf spark.sql.adaptive.enabled=false"
+        os.environ["PYSPARK_SUBMIT_ARGS"] = (
+            f"{conf} {submit_args}" if submit_args else f"{conf} pyspark-shell"
+        )
 
 
 @pytest.fixture(scope="session")
@@ -30,6 +47,9 @@ def spark() -> SparkSession:
     """
     builder = SparkSession.builder
     builder = builder.config("spark.sql.ansi.enabled", False)
+    # Disable Adaptive Query Execution to avoid unbounded native-thread
+    # growth over the life of this session-scoped fixture (see spark_env_vars).
+    builder = builder.config("spark.sql.adaptive.enabled", False)
     # Workaround for Java 17+ security manager issues with Hadoop file system
     # This is needed for PySpark 4.0+ when using Java 17+
     if PYSPARK_VERSION >= version.parse("4.0.0"):
@@ -51,6 +71,9 @@ def spark_connect() -> SparkSession:
     os.environ["SPARK_LOCAL_REMOTE"] = "sc://localhost"
     builder = SparkSession.builder
     builder = builder.config("spark.sql.ansi.enabled", False)
+    # Disable Adaptive Query Execution to avoid unbounded native-thread
+    # growth over the life of this session-scoped fixture (see spark_env_vars).
+    builder = builder.config("spark.sql.adaptive.enabled", False)
     # Workaround for Java 17+ security manager issues with Hadoop file system
     # This is needed for PySpark 4.0+ when using Java 17+
     if PYSPARK_VERSION >= version.parse("4.0.0"):


### PR DESCRIPTION
## Problem

The pyspark unit tests intermittently fail on the macOS CI runner (observed on `python-3.10 macos-latest`; `python-3.11 macos` and all ubuntu jobs happened to pass) with a cascade of:

```
ConnectionRefusedError: [Errno 61] Connection refused
```

across ~20 tests in `tests/pyspark/test_schemas_on_pyspark_pandas.py`.

## Root cause

The `ConnectionRefusedError`s are collateral — the Spark driver JVM crashes *earlier* in the run (during `test_index_dtypes[MultiIndex-True-str]`) with:

```
py4j.protocol.Py4JNetworkError: Answer from Java side is empty
java.lang.OutOfMemoryError: unable to create native thread:
    possibly out of memory or process/resource limits reached
```

Once the JVM is dead, every subsequent test that touches Spark fails with connection-refused.

The thread exhaustion comes from **Adaptive Query Execution** (default-on in Spark 4.x). AQE materializes each query stage asynchronously via cached thread pools. A live thread dump of the running suite showed the leak clearly:

```
 925 "ResultQueryStageExecution-"
 923 "shuffle-exchange-"
 ...
```

Across the hundreds of pandas-on-Spark operations in this suite, the long-lived session accumulates these into thousands of native threads (measured climbing past **2500**), eventually crossing the macOS per-process thread limit (`kern.num_taskthreads`) and killing the driver JVM. `ulimit` tuning does not help because this is a per-process kernel thread cap, not `RLIMIT_NPROC`.

## Fix

Disable AQE for the pyspark test sessions:
- in the `spark` and `spark_connect` session-scoped fixtures, and
- process-wide via `PYSPARK_SUBMIT_ARGS`, because `pyspark.pandas` builds its **own** default session with `getOrCreate()` that bypasses the fixtures.

AQE only affects query planning/performance, not validation results.

## Validation

Reproduced and verified locally (pyspark 4.2.0, Java 17, macOS ARM, py3.10), instrumenting JVM thread counts:

| | JVM thread peak | `shuffle-exchange` + `ResultQueryStageExecution` |
|---|---|---|
| Before (AQE on) | climbs past **2578** | ~1850 |
| After (AQE off) | bounded **~300–640** | **0** |

Full `tests/pyspark/` suite after the fix: **998 passed, 251 skipped, no `ConnectionRefusedError`, no JVM crash**. (The only local failures were 4 `ImportError: ... requires 'pyyaml'` from my scratch venv missing pyyaml — unrelated to this change and installed in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)