### PR TITLE
fix(io): deserialize parametrized Decimal dtypes from yaml/json

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -577,8 +577,10 @@ class Decimal(DataType, dtypes.Decimal):
     supported by the Python :py:class:`decimal.Decimal` class.
     """
 
-    _exp: decimal.Decimal = dataclasses.field(init=False)
-    _ctx: decimal.Context = dataclasses.field(init=False)
+    # attributes derived from precision, scale, and rounding, so they are
+    # excluded from comparisons: decimal.Context doesn't implement __eq__.
+    _exp: decimal.Decimal = dataclasses.field(init=False, compare=False)
+    _ctx: decimal.Context = dataclasses.field(init=False, compare=False)
 
     def __init__(
         self,

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import enum
 import json
+import re
 import warnings
 from collections.abc import Mapping
 from functools import partial
@@ -311,13 +312,35 @@ def _deserialize_check_stats(check, serialized_check_stats, dtype=None):
     return check_instance
 
 
+_DECIMAL_DTYPE_PATTERN = re.compile(
+    r"Decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", re.IGNORECASE
+)
+
+
+def _deserialize_dtype(serialized_dtype):
+    """Deserialize a dtype, supporting the string representation of
+    parametrized dtypes that the engine doesn't recognize as aliases,
+    e.g. ``"Decimal(28, 0)"``. GH#1165
+    """
+    try:
+        return pandas_engine.Engine.dtype(serialized_dtype)
+    except TypeError:
+        if isinstance(serialized_dtype, str):
+            match = _DECIMAL_DTYPE_PATTERN.fullmatch(serialized_dtype)
+            if match:
+                return pandas_engine.Decimal(
+                    precision=int(match.group(1)), scale=int(match.group(2))
+                )
+        raise
+
+
 def _deserialize_component_stats(serialized_component_stats):
     serialized_component_stats = dict(serialized_component_stats)
     unflatten_component_checks_dict(serialized_component_stats)
 
     dtype = serialized_component_stats.get("dtype")
     if dtype:
-        dtype = pandas_engine.Engine.dtype(dtype)
+        dtype = _deserialize_dtype(dtype)
 
     description = serialized_component_stats.get("description")
     title = serialized_component_stats.get("title")

--- a/pandera/io/pandas_io.py
+++ b/pandera/io/pandas_io.py
@@ -321,17 +321,19 @@ def _deserialize_dtype(serialized_dtype):
     """Deserialize a dtype, supporting the string representation of
     parametrized dtypes that the engine doesn't recognize as aliases,
     e.g. ``"Decimal(28, 0)"``. GH#1165
+
+    Parametrized dtype strings are handled before falling back to
+    :meth:`Engine.dtype`, since the exception raised for unrecognized
+    strings varies across numpy/pandas versions (e.g. numpy raises
+    ``ValueError`` for strings containing commas).
     """
-    try:
-        return pandas_engine.Engine.dtype(serialized_dtype)
-    except TypeError:
-        if isinstance(serialized_dtype, str):
-            match = _DECIMAL_DTYPE_PATTERN.fullmatch(serialized_dtype)
-            if match:
-                return pandas_engine.Decimal(
-                    precision=int(match.group(1)), scale=int(match.group(2))
-                )
-        raise
+    if isinstance(serialized_dtype, str):
+        match = _DECIMAL_DTYPE_PATTERN.fullmatch(serialized_dtype)
+        if match:
+            return pandas_engine.Decimal(
+                precision=int(match.group(1)), scale=int(match.group(2))
+            )
+    return pandas_engine.Engine.dtype(serialized_dtype)
 
 
 def _deserialize_component_stats(serialized_component_stats):

--- a/tests/io/test_pandas_io.py
+++ b/tests/io/test_pandas_io.py
@@ -1410,6 +1410,28 @@ def test_io_yaml_roundtrip_preserves_drop_invalid_rows():
     assert restored == schema
 
 
+@pytest.mark.skipif(
+    SKIP_YAML_TESTS,
+    reason="pyyaml >= 5.1.0 required",
+)
+def test_io_roundtrip_decimal_dtype():
+    """Test yaml/json roundtrip of parametrized Decimal dtypes, GH#1165."""
+    schema = pandera.DataFrameSchema(
+        columns={
+            "default": pandera.Column(pandera_base.dtypes.Decimal),
+            "parametrized": pandera.Column(pandas_engine.Decimal(10, 2)),
+        }
+    )
+
+    restored = schema.from_yaml(schema.to_yaml())
+    assert restored.columns["parametrized"].dtype == pandas_engine.Decimal(
+        10, 2
+    )
+    assert restored == schema
+
+    assert schema.from_json(schema.to_json()) == schema
+
+
 def test_io_json_with_multiindex_column_labels():
     """Test JSON serialization for schemas with tuple column labels."""
     import json


### PR DESCRIPTION
Fixes #1165

## Description

`to_yaml`/`to_json` serialize a parametrized decimal column as `str(dtype)`, e.g. `"Decimal(28, 0)"`, but `from_yaml`/`from_json` can't load that string back because the engine only recognizes the plain `decimal` alias:

```python
import pandera as pa
from pandera.engines import pandas_engine

schema = pa.DataFrameSchema(
    {"amount": pa.Column(pandas_engine.Decimal(28, 0))}
)
pa.DataFrameSchema.from_yaml(schema.to_yaml())  # raises TypeError
```

Deserialization now recognizes the `Decimal(precision, scale)` string form and reconstructs the parametrized dtype. I also excluded `Decimal`'s derived `_exp`/`_ctx` fields from dataclass comparison (`decimal.Context` doesn't implement `__eq__`), so two dtypes with the same parameters compare equal and the restored schema equals the original.

One limitation: `rounding` isn't part of the string representation, so it still doesn't survive a round-trip.

Added a regression test covering the yaml and json round-trip of a default and a parametrized `Decimal` column. The full `tests/` run is green locally.