### PR TITLE
fix(pandas): apply parsers to Index fields and schema components

### DIFF
--- a/pandera/api/dataframe/model_components.py
+++ b/pandera/api/dataframe/model_components.py
@@ -78,6 +78,7 @@ class FieldInfo(BaseFieldInfo):
         self,
         dtype: Any,
         checks: CheckArg | None = None,
+        parsers: ParserArg | None = None,
         name: str | None = None,
     ) -> dict[str, Any]:
         """Create a schema_components.Index from a field."""
@@ -88,6 +89,7 @@ class FieldInfo(BaseFieldInfo):
             coerce=self.coerce,
             name=name,
             checks=checks,
+            parsers=parsers,
             title=self.title,
             description=self.description,
             default=self.default,

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -208,6 +208,7 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                     field.index_properties(
                         dtype,
                         checks=field_checks,
+                        parsers=field_parsers,
                         name=field_name,
                     )
                     if field

--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -318,7 +318,9 @@ class IndexBackend(ArraySchemaBackend):
 
         error_handler = ErrorHandler(lazy)
 
-        if schema.coerce:
+        # if the index has parsers, defer coercion to the array backend,
+        # which runs parsers before coercing
+        if schema.coerce and not schema.parsers:
             try:
                 check_obj.index = schema.coerce_dtype(check_obj.index)
             except SchemaError as exc:
@@ -340,6 +342,8 @@ class IndexBackend(ArraySchemaBackend):
                 inplace=inplace,
             )
             assert is_field(_validated_obj)
+            if schema.parsers:
+                check_obj.index = pd.Index(_validated_obj)
         except SchemaError as exc:
             error_handler.collect_error(
                 get_error_category(exc.reason_code),

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -786,7 +786,13 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
 
         if schema.dtype is not None:
             obj = _try_coercion(_coerce_df_dtype, obj)
-        if schema.index is not None and (schema.index.coerce or schema.coerce):
+        if (
+            schema.index is not None
+            and (schema.index.coerce or schema.coerce)
+            # coercion of an index with parsers is deferred to index-level
+            # validation so that parsers run before coercion
+            and not getattr(schema.index, "parsers", None)
+        ):
             index_schema = copy.deepcopy(schema.index)
             if schema.coerce:
                 # coercing at the dataframe-level should apply index coercion

--- a/tests/pandas/test_parsers.py
+++ b/tests/pandas/test_parsers.py
@@ -12,7 +12,7 @@ from pandera.api.pandas.array import SeriesSchema
 from pandera.api.pandas.container import DataFrameSchema
 from pandera.api.parsers import Parser
 from pandera.engines.pandas_engine import PANDAS_3_0_0_PLUS
-from pandera.typing import Series
+from pandera.typing import Index, Series
 
 
 def test_dataframe_schema_parse() -> None:
@@ -310,3 +310,59 @@ def test_column_parser_with_inferred_schema_coercion():
         [-13123.0, -12.0, np.nan], name="col1", dtype="float64"
     )
     pd.testing.assert_series_equal(validated["col1"], expected)
+
+
+def test_parser_on_dataframe_model_index_field():
+    """``@pa.parser`` should be applied to fields annotated as Index
+    (issue #1684)."""
+
+    class Model(pa.DataFrameModel):
+        idx: Index[int]
+        col: Series[int]
+
+        class Config:
+            coerce = True
+
+        @pa.parser("idx")
+        @classmethod
+        def double(cls, series: pd.Series) -> pd.Series:
+            return series * 2
+
+        @pa.parser("col")
+        @classmethod
+        def triple(cls, series: pd.Series) -> pd.Series:
+            return series * 3
+
+    df = pd.DataFrame({"col": [1, 2, 3]}, index=pd.Index([1, 2, 3]))
+    validated = Model.validate(df)
+    assert validated.index.tolist() == [2, 4, 6]
+    assert validated["col"].tolist() == [3, 6, 9]
+
+
+def test_index_parser():
+    """Parsers on an Index schema component should transform the index."""
+    schema = DataFrameSchema(
+        columns={"col": pa.Column(int)},
+        index=pa.Index(int, parsers=Parser(lambda s: s * 2), name="idx"),
+    )
+    df = pd.DataFrame(
+        {"col": [1, 2, 3]}, index=pd.Index([1, 2, 3], name="idx")
+    )
+    validated = schema.validate(df)
+    assert validated.index.tolist() == [2, 4, 6]
+    assert validated.index.name == "idx"
+
+
+def test_index_parser_output_needs_coercion():
+    """Index parsers should run before dtype coercion."""
+    schema = DataFrameSchema(
+        columns={"col": pa.Column(int)},
+        index=pa.Index(
+            float,
+            parsers=Parser(lambda s: s.str.replace(",", ".")),
+            coerce=True,
+        ),
+    )
+    df = pd.DataFrame({"col": [1, 2]}, index=pd.Index(["1,5", "2,5"]))
+    validated = schema.validate(df)
+    assert validated.index.tolist() == [1.5, 2.5]


### PR DESCRIPTION
Fixes #1684

## Problem

`@pa.parser` on a field annotated as `Index` is silently ignored:

```python
import pandas as pd
import pandera.pandas as pa
from pandera.typing import Index, Series

class Model(pa.DataFrameModel):
    idx: Index[int]
    col: Series[int]

    @pa.parser("idx")
    @classmethod
    def double(cls, series):
        return series * 2

df = pd.DataFrame({"col": [1, 2, 3]}, index=pd.Index([1, 2, 3]))
print(Model.validate(df).index.tolist())  # [1, 2, 3], parser never ran
```

Two things cause this. `FieldInfo.index_properties` never forwards the field's parsers, so `Index` components built from a `DataFrameModel` don't have them at all. And even with `parsers` passed directly to `pa.Index`, the index backend validates a series copy of the index and discards the parsed result, while coercion runs before parsers, so a parser that cleans raw values into a coercible form never gets a chance (the same ordering issue #2047 fixed for columns).

This forwards `parsers` in `FieldInfo.index_properties`, writes the validated series back to `check_obj.index` in `IndexBackend` when the schema has parsers, and defers index coercion (index-level and dataframe-level) to the array backend when parsers are present, so they run before dtype coercion like they do for columns. Added regression tests in `tests/pandas/test_parsers.py` for the model `Index` field case from the issue, parsers on a `pa.Index` inside a `DataFrameSchema`, and an index parser whose output needs coercion.