### PR TITLE
ci: add actionlint workflow and pre-commit hook

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+self-hosted-runner:
+  labels: []
+
+# ShellCheck rules disabled inside run: blocks.
+# Each `run:` block is checked through ShellCheck; suppress noisy rules here.
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore:
+      - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
+      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
+      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download actionlint
+        id: download
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Run actionlint
+        run: |
+          ./actionlint -color
+        shell: bash

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -188,10 +188,6 @@ jobs:
         pandas-version: ["2.3.3", "3.0.0"]
         pydantic-version: ["1.10.11", "2.12.3"]
         exclude:
-          - pandas-version: "2.1.1"
-            python-version: "3.13"
-          - pandas-version: "2.1.1"
-            python-version: "3.14"
           - pydantic-version: "1.10.11"
             python-version: "3.14"
           - pandas-version: "3.0.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,7 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
## What

Adds [actionlint](https://github.com/rhysd/actionlint) — a static checker for GitHub Actions workflow files — via two mechanisms:

- **`.github/actionlint.yaml`** — configuration: ShellCheck enabled, with the four rules most likely to generate false positives in GitHub Actions `run:` blocks suppressed (`SC1091`, `SC2086`, `SC2129`, `SC2155`).
- **`.github/workflows/actionlint.yml`** — dedicated CI workflow, triggered on changes to `.github/workflows/**` and the config file, with minimal `contents: read` permissions and concurrency control.
- **`.pre-commit-config.yaml`** — adds the `actionlint` hook at `v1.7.7` so contributors catch issues locally before pushing.

## Why

The project has two active workflow files (`ci-tests.yml`, `publish.yml`) with no actionlint coverage. Actionlint catches Actions-specific mistakes (invalid context references, deprecated syntax, missing permissions) that standard YAML linters miss.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.