### PR TITLE
Support itemsize-parameterized numpy dtypes in the pandas engine

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -265,7 +265,14 @@ class Engine(
                 if isinstance(np_or_pd_dtype, np.dtype):
                     # cast alias to platform-agnostic dtype
                     # e.g.: np.intc -> np.int32
-                    common_np_dtype = np.dtype(np_or_pd_dtype.name)
+                    try:
+                        common_np_dtype = np.dtype(np_or_pd_dtype.name)
+                    except TypeError:
+                        # Itemsize-parameterized dtypes encode their width in
+                        # ``name`` in a form ``np.dtype`` cannot parse back,
+                        # e.g. np.dtype("S16").name == "bytes128". Their scalar
+                        # type is already platform-agnostic, so use it as-is.
+                        common_np_dtype = np_or_pd_dtype
                     np_or_pd_dtype = common_np_dtype.type
 
             return engine.Engine.dtype(cls, np_or_pd_dtype)

--- a/tests/pandas/test_pandas_engine.py
+++ b/tests/pandas/test_pandas_engine.py
@@ -884,3 +884,53 @@ def test_pandas_arrow_struct_dtype(data, expected_output):
             assert (
                 failure_case["failure_case"] == expected_value["failure_case"]
             )
+
+
+@pytest.mark.parametrize(
+    "numpy_dtype, scalar_type",
+    [
+        (np.dtype("S16"), np.bytes_),
+        (np.dtype("S1"), np.bytes_),
+        (np.dtype("U16"), np.str_),
+        (np.dtype("U100"), np.str_),
+    ],
+)
+def test_itemsize_parameterized_numpy_dtype(numpy_dtype, scalar_type):
+    """Itemsize-parameterized numpy dtypes resolve like their scalar type.
+
+    ``np.dtype("S16").name`` is ``"bytes128"``, which ``np.dtype`` cannot parse
+    back, so normalizing through ``name`` used to raise
+    ``TypeError: data type 'bytes128' not understood``. See
+    https://github.com/unionai-oss/pandera/issues/1270
+    """
+    assert pandas_engine.Engine.dtype(
+        numpy_dtype
+    ) == pandas_engine.Engine.dtype(scalar_type)
+
+
+def test_itemsize_parameterized_numpy_dtype_validates():
+    """A schema declared with a sized numpy dtype validates matching data."""
+    schema = pa.DataFrameSchema({"a": pa.Column(np.dtype("S16"))})
+    df = pd.DataFrame({"a": np.array([b"ab", b"cd"], dtype="S16")})
+    assert schema.validate(df).shape == (2, 1)
+
+
+@pytest.mark.parametrize(
+    "alias, expected_alias_of",
+    [
+        (np.intc, np.int32),
+        (np.uintc, np.uint32),
+        (np.longlong, np.int64),
+        (np.ulonglong, np.uint64),
+    ],
+)
+def test_platform_alias_numpy_dtype_still_normalized(alias, expected_alias_of):
+    """Platform-specific aliases must still normalize to fixed-width dtypes.
+
+    This is the behavior the ``name`` round-trip exists for, and it is not
+    reproduced by using ``np.dtype.type`` directly: ``np.dtype("longlong").type``
+    is ``np.longlong``, not ``np.int64``.
+    """
+    assert pandas_engine.Engine.dtype(alias).type == np.dtype(
+        expected_alias_of
+    )


### PR DESCRIPTION
Fixes #1270

Declaring a column with a sized numpy dtype raised a `TypeError` naming a dtype the user never wrote:

```python
pa.DataFrameSchema({"a": pa.Column(np.dtype("S16"))})
TypeError: data type 'bytes128' not understood
```

`Engine.dtype` normalizes platform-specific aliases by round-tripping the dtype through its `name`, so that e.g. `np.intc` becomes `np.int32`. That works for fixed-width numeric dtypes, whose `name` is itself a valid dtype string, but not for itemsize-parameterized ones: `np.dtype("S16").name` is `"bytes128"` and `np.dtype("U16").name` is `"str512"` -- neither parses back.

This falls back to the dtype itself when the name does not round-trip. Its scalar type is already platform-agnostic, so the subsequent `.type` lookup resolves as it does for the unsized spelling: `np.dtype("S16")` now resolves the same as `bytes`, and `np.dtype("U16")` the same as `np.str_`.

Worth noting: using `np_or_pd_dtype.type` directly instead of the round-trip would be simpler, but it silently regresses the normalization this code exists for -- `np.dtype("longlong").type` is `np.longlong`, not `np.int64`. So the round-trip is kept and only guarded.

The issue reports this for bytes; it affects sized unicode (`U16`) the same way. Void (`V8`) remains unsupported by the engine, but now surfaces pandera's own "not understood by Engine" error rather than a numpy parse error.

## Test plan

Added to `tests/pandas/test_pandas_engine.py`:

- `test_itemsize_parameterized_numpy_dtype` -- `S16`/`S1`/`U16`/`U100` resolve like their scalar type
- `test_itemsize_parameterized_numpy_dtype_validates` -- a schema declared with `np.dtype("S16")` validates real data
- `test_platform_alias_numpy_dtype_still_normalized` -- `intc`/`uintc`/`longlong`/`ulonglong` still normalize (guards the regression described above)

5 of these fail on `main` and all pass with this change. The full `test_pandas_engine.py`, `test_numpy_engine.py`, `test_engine.py` and `test_dtypes.py` suites pass (887 tests). `ruff check`, `ruff format` and `codespell` are clean.