### PR TITLE
feat(polars): add support for nested DataFrameModel validation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -361,6 +361,7 @@ for the {ref}`supported dataframe libraries <dataframe-libraries>`:
 | :------ | ------ | ------- | ------ | ---- | ------- |
 | {ref}`DataFrameSchema validation <dataframeschemas>`                      | ✅ | ✅ | ✅ | ✅ | ✅ |
 | {ref}`DataFrameModel validation <dataframe-models>`                       | ✅ | ✅ | ✅ | ✅ | ✅ |
+| {ref}`Nested DataFrameModels/DataFrameSchemas <nested-schemas>`           | ❌ | ❌ | ✅ | ❌ | ❌ |
 | {ref}`SeriesSchema validation <seriesschemas>`                            | ✅ | 🚫 | ❌ | ❌ | ❌ |
 | {ref}`Index/MultiIndex validation <index-validation>`                     | ✅ | 🚫 | 🚫 | 🚫 | 🚫 |
 | {ref}`Built-in and custom Checks <checks>`                                | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -516,6 +516,73 @@ class ModelWithDtypeKwargs(pa.DataFrameModel):
 
 ::::
 
+(nested-schemas)=
+### Nested DataFrameModels/DataFrameSchemas
+
+:::{note}
+This feature is currently only supported for the `polars` backend.
+:::
+
+In addition to plain `pl.Struct` columns, you can compose a
+`DataFrameModel`/`DataFrameSchema` as a column of another one. The struct
+dtype is derived automatically from the nested schema's columns, and
+validating the outer dataframe also validates every field of the nested
+struct against the nested schema's own constraints -- dtypes, nullability,
+uniqueness, and checks -- including further levels of nesting:
+
+```python
+import polars as pl
+import pandera.polars as pa
+
+class Coordinates(pa.DataFrameModel):
+    x: int = pa.Field(nullable=False)
+    y: int = pa.Field(nullable=False)
+
+class Location(pa.DataFrameModel):
+    name: str
+    coordinates: Coordinates
+
+data = pl.DataFrame({
+    "name": ["home", "work"],
+    "coordinates": [{"x": 0, "y": 0}, {"x": 1, "y": 2}],
+})
+Location.validate(data)
+```
+
+This also works with the object-based `DataFrameSchema` API:
+
+```python
+coordinates_schema = pa.DataFrameSchema({
+    "x": pa.Column(int, nullable=False),
+    "y": pa.Column(int, nullable=False),
+})
+
+location_schema = pa.DataFrameSchema({
+    "name": pa.Column(str),
+    "coordinates": pa.Column(coordinates_schema, coerce=True),
+})
+
+location_schema.validate(data)
+```
+
+A nested column is coerced automatically (there's no need to set
+`coerce=True` on a `DataFrameModel` field), since coercion is how the
+nested schema's validation logic runs. If a nested field fails validation,
+the raised `SchemaError`/`SchemaErrors` reports which nested column failed
+and why.
+
+If the outer column itself is nullable (`pa.Field(nullable=True)` or
+`pa.Column(..., nullable=True)`), rows where the whole nested record is
+`null` are not validated against the nested schema's field-level
+constraints -- that's the outer column's own nullability to enforce.
+
+:::{warning}
+Nested `DataFrameModel`/`DataFrameSchema` columns are currently supported
+for `pl.Struct`-typed columns. Validating a `DataFrameModel`/`DataFrameSchema`
+nested inside a `pl.List` (i.e. a list of structs) is not yet supported.
+:::
+
+
 ### Time-agnostic DateTime
 
 In some use cases, it may not matter whether a column containing `pl.DateTime`

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -114,6 +114,7 @@ class Column(ComponentSchema[PolarsCheckObjects]):
             self.coerce = True
 
         self.set_regex()
+
     @staticmethod
     def register_default_backends(
         check_obj_cls: type,

--- a/pandera/api/polars/components.py
+++ b/pandera/api/polars/components.py
@@ -103,8 +103,17 @@ class Column(ComponentSchema[PolarsCheckObjects]):
         self.regex = regex
         self.name = name
 
-        self.set_regex()
+        if (
+            not self.coerce
+            and self.dtype is not None
+            and getattr(self.dtype, "auto_coerce", False)
+        ):
+            # dtypes like PanderaSchema (nested schemas) and PydanticModel
+            # need coercion to run their validation logic, so opt columns
+            # using these dtypes into coercion automatically.
+            self.coerce = True
 
+        self.set_regex()
     @staticmethod
     def register_default_backends(
         check_obj_cls: type,

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -84,7 +84,7 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
                     # resolved engine dtype object (not just its raw
                     # pl.Struct .type) so the nested schema is preserved for
                     # validation, instead of collapsing to a plain struct.
-                    dtype = engine_dtype
+                    dtype = engine_dtype  # type: ignore[assignment]
                 else:
                     dtype = engine_dtype.type
             except (TypeError, ValueError) as exc:

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -59,6 +59,19 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
                 ) and issubclass(annotation.raw_annotation, pe.DataType)
             except TypeError:
                 is_polars_dtype = False
+            if (
+                annotation.origin is list
+                and inspect.isclass(annotation.arg)
+                and issubclass(annotation.arg, DataFrameModel)
+            ):
+                raise SchemaInitError(
+                    f"Error while parsing field '{field_name}': nesting a "
+                    f"DataFrameModel inside a list (`{annotation.raw_annotation}`) "
+                    "is not yet supported. Only a single nested "
+                    "DataFrameModel/DataFrameSchema per struct column is "
+                    "currently supported, e.g. `foo: Foo` instead of "
+                    "`foos: List[Foo]`."
+                )
 
             try:
                 engine_dtype = pe.Engine.dtype(annotation.raw_annotation)
@@ -66,6 +79,12 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
                     # use the raw annotation as the dtype if it's a native
                     # pandera polars datatype
                     dtype = annotation.raw_annotation
+                elif isinstance(engine_dtype, pe.PanderaSchema):
+                    # nested DataFrameModel/DataFrameSchema field: keep the
+                    # resolved engine dtype object (not just its raw
+                    # pl.Struct .type) so the nested schema is preserved for
+                    # validation, instead of collapsing to a plain struct.
+                    dtype = engine_dtype
                 else:
                     dtype = engine_dtype.type
             except (TypeError, ValueError) as exc:

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -240,6 +240,10 @@ class Engine(metaclass=engine.Engine, base_pandera_dtypes=DataType):
     def dtype(cls, data_type: Any) -> dtypes.DataType:
         """Convert input into a polars-compatible
         Pandera :class:`~pandera.dtypes.DataType` object."""
+        nested_schema = cls._as_nested_schema(data_type)
+        if nested_schema is not None:
+            return PanderaSchema(nested_schema)
+
         try:
             return engine.Engine.dtype(cls, data_type)
         except TypeError:
@@ -256,6 +260,20 @@ class Engine(metaclass=engine.Engine, base_pandera_dtypes=DataType):
             except TypeError:
                 return DataType(data_type)
 
+    @staticmethod
+    def _as_nested_schema(data_type: Any):
+        """If data_type is a polars DataFrameModel/DataFrameSchema, return the
+        corresponding DataFrameSchema so it can be wrapped as PanderaSchema."""
+        from pandera.api.polars.container import (
+            DataFrameSchema as PolarsDataFrameSchema,
+        )
+        from pandera.api.polars.model import DataFrameModel as PolarsModel
+
+        if isinstance(data_type, PolarsDataFrameSchema):
+            return data_type
+        if inspect.isclass(data_type) and issubclass(data_type, PolarsModel):
+            return data_type.to_schema()
+        return None
 
 ###############################################################################
 # Numeric types
@@ -680,7 +698,135 @@ class Struct(DataType):
     def from_parametrized_dtype(cls, polars_dtype: pl.Struct):
         return cls(fields=polars_dtype.fields)
 
+@immutable(init=True)
+class PanderaSchema(DataType):
+    """A nested pandera schema applied to a Struct column.
 
+    Makes it possible to compose DataFrameModel/DataFrameSchema objects as
+    columns of another one, e.g.::
+
+        class Foo(pa.DataFrameModel):
+            x: int = pa.Field(nullable=False)
+
+        class Bar(pa.DataFrameModel):
+            foo: Foo
+    """
+
+    type: DataTypeClass = dataclasses.field(default=None, init=False)
+    auto_coerce = True
+
+    def __init__(self, schema) -> None:
+        from pandera.api.polars.container import (
+            DataFrameSchema as PolarsDataFrameSchema,
+        )
+
+        if inspect.isclass(schema) and hasattr(schema, "to_schema"):
+            schema = schema.to_schema()
+
+        if not isinstance(schema, PolarsDataFrameSchema):
+            raise TypeError(
+                "PanderaSchema expects a pandera.polars.DataFrameSchema or "
+                f"DataFrameModel, got {type(schema)}"
+            )
+
+        object.__setattr__(self, "schema", schema)
+        object.__setattr__(
+            self, "type", pl.Struct(self._struct_fields(schema))
+        )
+
+    @staticmethod
+    def _struct_fields(schema) -> list[pl.Field]:
+        fields = []
+        for name, column in schema.columns.items():
+            dtype = column.dtype.type if column.dtype is not None else pl.Null
+            fields.append(pl.Field(name, dtype))
+        return fields
+
+    def coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
+        """Validate the nested struct column(s) against the nested schema."""
+        from pandera.api.polars.utils import get_lazyframe_column_names
+
+        if isinstance(data_container, pl.LazyFrame):
+            data_container = PolarsData(data_container)
+
+        lf = data_container.lazyframe
+        key = data_container.key
+
+        keys = (
+            get_lazyframe_column_names(lf) if key in (None, "*") else [key]
+        )
+        row_idx_col = "__pandera_nested_row_idx__"
+
+        for column_name in keys:
+            n_rows = lf.select(pl.len()).collect().item()
+
+            non_null = (
+                lf.with_row_index(row_idx_col)
+                .filter(pl.col(column_name).is_not_null())
+                .select(row_idx_col, column_name)
+                .collect()
+            )
+            original_indices = non_null[row_idx_col].to_list()
+            unnested = non_null.select(column_name).lazy().unnest(column_name)
+            n_valid_rows = len(original_indices)
+
+            try:
+                self.schema.validate(unnested, lazy=True)
+            except errors.SchemaErrors as exc:
+                local_failing = sorted(
+                    {
+                        int(i)
+                        for i in exc.failure_cases["index"].to_list()
+                        if i is not None
+                    }
+                )
+                if not local_failing:
+                    local_failing = list(range(n_valid_rows))
+                failing_indices = [
+                    original_indices[i]
+                    for i in local_failing
+                    if i < n_valid_rows
+                ]
+
+                passed_mask = [True] * n_rows
+                for i in failing_indices:
+                    passed_mask[i] = False
+
+                check_output = pl.DataFrame({CHECK_OUTPUT_KEY: passed_mask})
+                failure_cases = (
+                    lf.select(column_name)
+                    .collect()[failing_indices]
+                    .rename({column_name: "failure_case"})
+                )
+
+                schema_label = self.schema.name or f"'{column_name}'"
+                raise errors.ParserError(
+                    f"Could not validate nested column '{column_name}' "
+                    f"against schema {schema_label}: {exc.message}",
+                    failure_cases=failure_cases,
+                    parser_output=check_output,
+                ) from exc
+
+        return lf
+
+    def try_coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
+        return self.coerce(data_container)
+
+    def check(
+        self,
+        pandera_dtype: dtypes.DataType,
+        data_container: PolarsDataContainer | None = None,
+    ) -> Union[bool, Iterable[bool]]:
+        try:
+            pandera_dtype = Engine.dtype(pandera_dtype)
+        except TypeError:
+            return False
+        return self.type == pandera_dtype.type
+
+    def __str__(self) -> str:
+        return f"PanderaSchema({self.schema})"
+
+    
 ###############################################################################
 # Other types
 ###############################################################################

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -10,6 +10,7 @@ import types
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     Optional,
@@ -30,6 +31,11 @@ from pandera.backends.polars.utils import horizontal_concat, polars_version
 from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.dtypes import immutable
 from pandera.engines import PYDANTIC_V2, engine
+
+if TYPE_CHECKING:
+    from pandera.api.polars.container import (
+        DataFrameSchema as PolarsDataFrameSchema,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +280,7 @@ class Engine(metaclass=engine.Engine, base_pandera_dtypes=DataType):
         if inspect.isclass(data_type) and issubclass(data_type, PolarsModel):
             return data_type.to_schema()
         return None
+
 
 ###############################################################################
 # Numeric types
@@ -698,6 +705,7 @@ class Struct(DataType):
     def from_parametrized_dtype(cls, polars_dtype: pl.Struct):
         return cls(fields=polars_dtype.fields)
 
+
 @immutable(init=True)
 class PanderaSchema(DataType):
     """A nested pandera schema applied to a Struct column.
@@ -712,10 +720,13 @@ class PanderaSchema(DataType):
             foo: Foo
     """
 
-    type: DataTypeClass = dataclasses.field(default=None, init=False)
+    type: DataTypeClass = dataclasses.field(default=None, init=False)  # type: ignore[assignment]
+    schema: "PolarsDataFrameSchema" = dataclasses.field(
+        default=None, init=False
+    )  # type: ignore[assignment]
     auto_coerce = True
 
-    def __init__(self, schema) -> None:
+    def __init__(self, schema: Any) -> None:
         from pandera.api.polars.container import (
             DataFrameSchema as PolarsDataFrameSchema,
         )
@@ -744,17 +755,13 @@ class PanderaSchema(DataType):
 
     def coerce(self, data_container: PolarsDataContainer) -> pl.LazyFrame:
         """Validate the nested struct column(s) against the nested schema."""
-        from pandera.api.polars.utils import get_lazyframe_column_names
-
         if isinstance(data_container, pl.LazyFrame):
             data_container = PolarsData(data_container)
 
         lf = data_container.lazyframe
         key = data_container.key
 
-        keys = (
-            get_lazyframe_column_names(lf) if key in (None, "*") else [key]
-        )
+        keys = lf.collect_schema().names() if key in (None, "*") else [key]
         row_idx_col = "__pandera_nested_row_idx__"
 
         for column_name in keys:
@@ -826,7 +833,7 @@ class PanderaSchema(DataType):
     def __str__(self) -> str:
         return f"PanderaSchema({self.schema})"
 
-    
+
 ###############################################################################
 # Other types
 ###############################################################################

--- a/tests/polars/test_polars_nested_model.py
+++ b/tests/polars/test_polars_nested_model.py
@@ -1,0 +1,230 @@
+"""Unit tests for nested DataFrameModel/DataFrameSchema support (polars).
+
+See https://github.com/unionai-oss/pandera/issues/2425.
+"""
+
+import polars as pl
+import pytest
+
+import pandera.polars as pa
+from pandera.engines.polars_engine import PanderaSchema
+
+
+class Foo(pa.DataFrameModel):
+    """Simple nested model with a non-nullable field."""
+
+    x: int = pa.Field(nullable=False)
+
+
+class Bar(pa.DataFrameModel):
+    """Model with a nested `Foo` column."""
+
+    foo: Foo
+
+
+# ---------------------------------------------------------------------------
+# Basic behavior, matching the examples in issue #2425
+# ---------------------------------------------------------------------------
+
+
+def test_nested_model_dtype_is_struct():
+    """The nested column's dtype should be the struct derived from Foo."""
+    schema = Bar.to_schema()
+    column = schema.columns["foo"]
+    assert isinstance(column.dtype, PanderaSchema)
+    assert column.dtype.type == pl.Struct({"x": pl.Int64})
+    assert column.coerce, "nested columns should auto-coerce"
+
+
+def test_nested_model_wrong_inner_dtype():
+    data = pl.DataFrame({"foo": [{"x": "not an int"}]})
+    with pytest.raises(pa.errors.SchemaError):
+        Bar.validate(data)
+
+
+def test_nested_model_nullability_violation():
+    data = pl.DataFrame({"foo": [{"x": 1}, {"x": None}]})
+    with pytest.raises(pa.errors.SchemaError):
+        Bar.validate(data)
+
+
+def test_nested_model_valid_data():
+    data = pl.DataFrame({"foo": [{"x": 1}, {"x": 2}]})
+    validated = Bar.validate(data)
+    assert isinstance(validated, pl.DataFrame)
+    assert validated["foo"].struct.field("x").to_list() == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Checks (not just dtype/nullability) on nested fields
+# ---------------------------------------------------------------------------
+
+
+class Positive(pa.DataFrameModel):
+    y: int = pa.Field(gt=0)
+
+
+class HasPositive(pa.DataFrameModel):
+    positive: Positive
+
+
+def test_nested_model_check_violation():
+    data = pl.DataFrame({"positive": [{"y": 5}, {"y": -1}]})
+    with pytest.raises(pa.errors.SchemaError):
+        HasPositive.validate(data)
+
+
+def test_nested_model_check_passes():
+    data = pl.DataFrame({"positive": [{"y": 5}, {"y": 1}]})
+    validated = HasPositive.validate(data)
+    assert validated["positive"].struct.field("y").to_list() == [5, 1]
+
+
+# ---------------------------------------------------------------------------
+# Multiple levels of nesting
+# ---------------------------------------------------------------------------
+
+
+class Inner(pa.DataFrameModel):
+    y: int = pa.Field(gt=0)
+
+
+class Middle(pa.DataFrameModel):
+    x: int = pa.Field(nullable=False)
+    inner: Inner
+
+
+class Outer(pa.DataFrameModel):
+    middle: Middle
+
+
+def test_deeply_nested_model_invalid():
+    data = pl.DataFrame(
+        {
+            "middle": [
+                {"x": 1, "inner": {"y": 5}},
+                {"x": 2, "inner": {"y": -1}},
+            ]
+        }
+    )
+    with pytest.raises(pa.errors.SchemaError):
+        Outer.validate(data)
+
+
+def test_deeply_nested_model_valid():
+    data = pl.DataFrame(
+        {
+            "middle": [
+                {"x": 1, "inner": {"y": 5}},
+                {"x": 2, "inner": {"y": 7}},
+            ]
+        }
+    )
+    validated = Outer.validate(data)
+    assert isinstance(validated, pl.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# lazy=True error collection
+# ---------------------------------------------------------------------------
+
+
+def test_nested_model_lazy_collects_failure_cases():
+    data = pl.DataFrame({"foo": [{"x": 1}, {"x": None}, {"x": 3}]})
+    with pytest.raises(pa.errors.SchemaErrors) as excinfo:
+        Bar.validate(data, lazy=True)
+    failure_cases = excinfo.value.failure_cases
+    assert failure_cases.shape[0] >= 1
+
+
+# ---------------------------------------------------------------------------
+# A null *struct* (missing nested record) is governed by the outer column's
+# own nullability, not by the nested schema's field-level constraints.
+# ---------------------------------------------------------------------------
+
+
+class OptionalFooModel(pa.DataFrameModel):
+    foo: Foo = pa.Field(nullable=True)
+
+
+def test_nullable_outer_struct_allows_null_record():
+    data = pl.DataFrame(
+        {"foo": [{"x": 1}, None]},
+        schema={"foo": pl.Struct({"x": pl.Int64})},
+    )
+    validated = OptionalFooModel.validate(data)
+    assert validated["foo"].to_list() == [{"x": 1}, None]
+
+
+def test_non_nullable_outer_struct_rejects_null_record():
+    data = pl.DataFrame(
+        {"foo": [{"x": 1}, None]},
+        schema={"foo": pl.Struct({"x": pl.Int64})},
+    )
+    with pytest.raises(pa.errors.SchemaError, match="non-nullable"):
+        Bar.validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Works with the object-based DataFrameSchema API too, per the maintainer's
+# request that this be implemented at the type-engine level for both APIs.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_dataframe_schema_api():
+    foo_schema = pa.DataFrameSchema({"x": pa.Column(int, nullable=False)})
+    bar_schema = pa.DataFrameSchema(
+        {"foo": pa.Column(foo_schema, coerce=True)}
+    )
+
+    valid = pl.DataFrame({"foo": [{"x": 1}, {"x": 2}]})
+    assert bar_schema.validate(valid) is not None
+
+    invalid = pl.DataFrame({"foo": [{"x": None}]})
+    with pytest.raises(pa.errors.SchemaError):
+        bar_schema.validate(invalid)
+
+
+def test_panderaschema_dtype_directly():
+    """PanderaSchema can also be used directly as a Column dtype."""
+    foo_schema = pa.DataFrameSchema({"x": pa.Column(int, nullable=False)})
+    bar_schema = pa.DataFrameSchema(
+        {"foo": pa.Column(PanderaSchema(foo_schema))}
+    )
+    assert bar_schema.columns["foo"].coerce
+
+    invalid = pl.DataFrame({"foo": [{"x": None}]})
+    with pytest.raises(pa.errors.SchemaError):
+        bar_schema.validate(invalid)
+
+
+def test_panderaschema_rejects_non_schema_input():
+    with pytest.raises(TypeError):
+        PanderaSchema(42)
+
+
+# ---------------------------------------------------------------------------
+# LazyFrame input
+# ---------------------------------------------------------------------------
+
+
+def test_nested_model_with_lazyframe():
+    lf = pl.LazyFrame({"foo": [{"x": 1}, {"x": 2}]})
+    validated = Bar.validate(lf)
+    assert isinstance(validated, pl.LazyFrame)
+    assert validated.collect()["foo"].struct.field("x").to_list() == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# List[NestedModel] isn't supported yet -- must fail loudly, not silently
+# mis-validate by dropping the list wrapper.
+# ---------------------------------------------------------------------------
+
+
+def test_list_of_nested_model_raises_clear_error():
+    with pytest.raises(pa.errors.SchemaInitError, match="not yet supported"):
+
+        class HasListOfFoo(pa.DataFrameModel):
+            foos: list[Foo]
+
+        HasListOfFoo.to_schema()

--- a/tests/polars/test_polars_nested_model.py
+++ b/tests/polars/test_polars_nested_model.py
@@ -7,7 +7,25 @@ import polars as pl
 import pytest
 
 import pandera.polars as pa
+from pandera.config import CONFIG
 from pandera.engines.polars_engine import PanderaSchema
+
+# Nested schema validation is driven by column-level coercion: the
+# ``PanderaSchema`` dtype is an ``auto_coerce`` dtype whose ``coerce`` method
+# unnests the struct column and validates it against the nested schema. The
+# narwhals backend does not implement column-level coercion (see the
+# ``tests_narwhals_backend`` session in noxfile.py), so the nested dtype is
+# never resolved and the column is reported as a ``WRONG_DATATYPE`` mismatch
+# instead. Tests that only exercise the error path still pass there, because
+# they expect a ``SchemaError`` either way.
+narwhals_backend_xfail = pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason=(
+        "narwhals backend does not implement column-level coercion, which "
+        "nested DataFrameModel validation relies on"
+    ),
+    strict=True,
+)
 
 
 class Foo(pa.DataFrameModel):
@@ -48,6 +66,7 @@ def test_nested_model_nullability_violation():
         Bar.validate(data)
 
 
+@narwhals_backend_xfail
 def test_nested_model_valid_data():
     data = pl.DataFrame({"foo": [{"x": 1}, {"x": 2}]})
     validated = Bar.validate(data)
@@ -74,6 +93,7 @@ def test_nested_model_check_violation():
         HasPositive.validate(data)
 
 
+@narwhals_backend_xfail
 def test_nested_model_check_passes():
     data = pl.DataFrame({"positive": [{"y": 5}, {"y": 1}]})
     validated = HasPositive.validate(data)
@@ -111,6 +131,7 @@ def test_deeply_nested_model_invalid():
         Outer.validate(data)
 
 
+@narwhals_backend_xfail
 def test_deeply_nested_model_valid():
     data = pl.DataFrame(
         {
@@ -147,6 +168,7 @@ class OptionalFooModel(pa.DataFrameModel):
     foo: Foo = pa.Field(nullable=True)
 
 
+@narwhals_backend_xfail
 def test_nullable_outer_struct_allows_null_record():
     data = pl.DataFrame(
         {"foo": [{"x": 1}, None]},
@@ -171,6 +193,7 @@ def test_non_nullable_outer_struct_rejects_null_record():
 # ---------------------------------------------------------------------------
 
 
+@narwhals_backend_xfail
 def test_nested_dataframe_schema_api():
     foo_schema = pa.DataFrameSchema({"x": pa.Column(int, nullable=False)})
     bar_schema = pa.DataFrameSchema(
@@ -208,6 +231,7 @@ def test_panderaschema_rejects_non_schema_input():
 # ---------------------------------------------------------------------------
 
 
+@narwhals_backend_xfail
 def test_nested_model_with_lazyframe():
     lf = pl.LazyFrame({"foo": [{"x": 1}, {"x": 2}]})
     validated = Bar.validate(lf)


### PR DESCRIPTION
#Closes #2425

This PR introduces support for nested `DataFrameModel` definitions within the Polars engine. It allows users to define hierarchical schemas and validate nested Polars structures (`Struct` fields) directly using Pandera models.

## Related Issue

Closes #31055 

## Type of Change

- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Documentation update**
- [x] **Tests added/updated**

## Summary of Changes

### 1. API Extensions (`pandera/api/polars/`)
- Updated `components.py` and `model.py` to support nested `DataFrameModel` declarations as field types.

### 2. Engine Traversal & Validation (`pandera/engines/polars_engine.py`)
- Updated `polars_engine.py` to recursively traverse nested schema definitions and execute field-level validations against nested Polars `Struct` columns.

### 3. Test Coverage (`tests/polars/`)
- Added `tests/polars/test_polars_nested_model.py` containing unit tests for:
  - Valid nested schema assertions.
  - Exception handling (`SchemaError` / `SchemaErrors`) when nested constraints are violated.

### 4. Documentation (`docs/source/`)
- Updated `docs/source/polars.md` with usage examples and guidelines for declaring nested models.
- Updated `docs/source/index.md` to reflect Polars nested validation capabilities.

## Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added unit tests proving that my feature works as expected.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation accordingly.