### PR TITLE
doc: Fix "list" type annotation

### DIFF
--- a/docs/source/notebooks/try_pandera.ipynb
+++ b/docs/source/notebooks/try_pandera.ipynb
@@ -325,7 +325,7 @@
     "@pa.check_types(lazy=True)\n",
     "def transform_data(\n",
     "    data: DataFrame[Schema],\n",
-    "    expiry: List[datetime],\n",
+    "    expiry: list[datetime],\n",
     ") -> DataFrame[TransformedSchema]:\n",
     "    return data.assign(expiryy=expiry)  # typo bug: 🐛\n",
     "\n",


### PR DESCRIPTION
Type annotation was outdated

```
NameError                                 Traceback (most recent call last)
[/tmp/ipykernel_2651/346488536.py](https://localhost:8080/#) in <cell line: 0>()
      2 def transform_data(
      3     data: DataFrame[Schema],
----> 4     expiry: List[datetime],
      5 ) -> DataFrame[TransformedSchema]:
      6     return data.assign(expiryy=expiry)  # typo bug: 🐛

NameError: name 'List' is not defined
```