### PR TITLE
fix(polars): exclude explicit columns from regex alias selectors (#2343)

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -1,6 +1,7 @@
 """Validation backend for polars DataFrameSchema."""
 
 import copy
+import re
 import traceback
 import warnings
 from collections.abc import Callable
@@ -302,6 +303,13 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                 columns[col_name] = Column(schema.dtype, name=str(col_name))
 
         schema_components = []
+        # Names of explicit (non-regex) columns in this schema. A regex
+        # ``alias=...`` field must not also govern these columns (issue #2343).
+        explicit_column_names = {
+            name
+            for name, c in columns.items()
+            if not getattr(c, "regex", False)
+        }
         for col_name, col in columns.items():
             if (
                 col.required  # type: ignore
@@ -319,6 +327,24 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                 # disable coercion at the schema component level since the
                 # dataframe-level schema already coerced it.
                 col.coerce = False  # type: ignore
+                # If this component is a regex selector that would also match
+                # any explicit (non-regex) column, expand it into one
+                # non-regex component per non-explicit match so explicit
+                # columns are left to their own schema (issue #2343).
+                if getattr(col, "regex", False) and explicit_column_names:
+                    matched_names = [
+                        name
+                        for name in get_lazyframe_column_names(check_obj)
+                        if name not in explicit_column_names
+                        and re.fullmatch(col.name or "", name)
+                    ]
+                    if matched_names:
+                        col.regex = False
+                        col.name = matched_names[0]
+                        for extra_name in matched_names[1:]:
+                            extra = copy.deepcopy(col)
+                            extra.name = extra_name
+                            schema_components.append(extra)
                 schema_components.append(col)
 
         return schema_components
@@ -508,6 +534,14 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
 
         lf_columns = get_lazyframe_column_names(obj)
 
+        # Names of explicit (non-regex) columns in this schema. A regex
+        # ``alias=...`` field must not coerce these columns (issue #2343).
+        explicit_column_names = {
+            name
+            for name, c in schema.columns.items()
+            if not getattr(c, "regex", False)
+        }
+
         try:
             if schema.dtype is not None:
                 obj = getattr(schema.dtype, coerce_fn)(obj)
@@ -525,9 +559,13 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                             # a coercion failure reports the concrete column
                             # name instead of the regex pattern (issue #2363,
                             # mirroring the check path fixed in #2221).
-                            matched_columns = get_lazyframe_column_names(
-                                obj.select(pl.col(col_schema.selector))
-                            )
+                            matched_columns = [
+                                name
+                                for name in get_lazyframe_column_names(
+                                    obj.select(pl.col(col_schema.selector))
+                                )
+                                if name not in explicit_column_names
+                            ]
                             for matched_column in matched_columns:
                                 obj = getattr(col_schema.dtype, coerce_fn)(
                                     PolarsData(obj, matched_column)

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -332,11 +332,15 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                 # non-regex component per non-explicit match so explicit
                 # columns are left to their own schema (issue #2343).
                 if getattr(col, "regex", False) and explicit_column_names:
-                    matched_names = [
+                    all_matched_names = [
                         name
                         for name in get_lazyframe_column_names(check_obj)
+                        if re.fullmatch(col.name or "", name)
+                    ]
+                    matched_names = [
+                        name
+                        for name in all_matched_names
                         if name not in explicit_column_names
-                        and re.fullmatch(col.name or "", name)
                     ]
                     if matched_names:
                         col.regex = False
@@ -345,6 +349,29 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                             extra = copy.deepcopy(col)
                             extra.name = extra_name
                             schema_components.append(extra)
+                    elif all_matched_names:
+                        # All regex matches were explicit columns, so there is
+                        # nothing left for this component to govern. Mirror
+                        # the required/optional no-match semantics of the
+                        # component path.
+                        if col.required:
+                            raise SchemaError(
+                                schema=col,
+                                data=check_obj,
+                                message=(
+                                    f"Column regex name='{col.name}' did not "
+                                    "match any non-explicit columns in the "
+                                    "dataframe."
+                                ),
+                                failure_cases=get_lazyframe_column_names(
+                                    check_obj
+                                ),
+                                check=f"no_regex_column_match('{col.name}')",
+                                reason_code=(
+                                    SchemaErrorReason.INVALID_COLUMN_NAME
+                                ),
+                            )
+                        continue
                 schema_components.append(col)
 
         return schema_components

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -33,6 +33,11 @@ def _to_lazy(df: PolarsFrame) -> pl.LazyFrame:
         return df
 
 
+def get_lazyframe_column_names(df: PolarsFrame) -> list[str]:
+    """Return the column names of a polars DataFrame or LazyFrame."""
+    return df.collect_schema().names()
+
+
 def _to_frame_kind(lf: pl.LazyFrame, kind: type[PolarsFrame]) -> PolarsFrame:
     if issubclass(kind, pl.DataFrame):
         return lf.collect()

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -499,6 +499,12 @@ def test_isin_check_lazy_validation_no_deprecation_warning(
     assert exc_info.value.failure_cases["failure_case"].to_list() == ["z"]
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="Narwhals backend does not exclude explicit columns from regex "
+    "aliases (issue #2343)",
+    strict=True,
+)
 def test_alias_regex_does_not_override_explicit_column_dtype() -> None:
     """Issue #2343 regression test.
 
@@ -525,7 +531,19 @@ def test_alias_regex_does_not_override_explicit_column_dtype() -> None:
     assert out.schema["index_column"] == pl.Int64
     assert out.schema["this_must_become_string"] == pl.String
 
+    # A frame containing only the explicit column must not let the alias
+    # govern it: the required alias raises its own no-match error instead
+    # of validating index_column against the alias dtype.
+    with pytest.raises(SchemaError, match="did not match any non-explicit"):
+        Model.validate(pl.DataFrame({"index_column": [1.0]}))
 
+
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="Narwhals backend does not exclude explicit columns from regex "
+    "aliases (issue #2343)",
+    strict=True,
+)
 def test_alias_regex_still_coerces_dynamic_unmatched_columns() -> None:
     """Issue #2343 companion test.
 
@@ -542,14 +560,15 @@ def test_alias_regex_still_coerces_dynamic_unmatched_columns() -> None:
         index_column: Series[int]
         anything_else: Series[str] = Field(alias=r".*", regex=True)
 
-    df = pl.DataFrame(
+    # Lazy variant: exercises the same fix on the lazy validation path.
+    df = pl.LazyFrame(
         {
             "index_column": [1.0],
             "this_must_become_string": [1.0],
         }
     )
 
-    out = Model.validate(df)
+    out = Model.validate(df).collect()
     # The unmatched column must be coerced to String by the alias path.
     assert out.schema["this_must_become_string"] == pl.String
     # And the explicit column must keep its declared Int64 dtype.

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -499,6 +499,63 @@ def test_isin_check_lazy_validation_no_deprecation_warning(
     assert exc_info.value.failure_cases["failure_case"].to_list() == ["z"]
 
 
+def test_alias_regex_does_not_override_explicit_column_dtype() -> None:
+    """Issue #2343 regression test.
+
+    When a model declares an explicit column alongside a regex ``alias=...``
+    field, the alias must not coerce the explicit column to its own dtype.
+    """
+    from pandera.typing.polars import Series
+
+    class Model(DataFrameModel):
+        class Config:
+            coerce = True
+
+        index_column: Series[int]
+        anything_else: Series[str] = Field(alias=r".*", regex=True)
+
+    df = pl.DataFrame(
+        {
+            "index_column": [1.0],
+            "this_must_become_string": [1.0],
+        }
+    )
+
+    out = Model.validate(df)
+    assert out.schema["index_column"] == pl.Int64
+    assert out.schema["this_must_become_string"] == pl.String
+
+
+def test_alias_regex_still_coerces_dynamic_unmatched_columns() -> None:
+    """Issue #2343 companion test.
+
+    A regex ``alias=...`` must still govern columns that are not declared
+    explicitly in the model, even when the alias's regex is broad enough to
+    also match explicit columns.
+    """
+    from pandera.typing.polars import Series
+
+    class Model(DataFrameModel):
+        class Config:
+            coerce = True
+
+        index_column: Series[int]
+        anything_else: Series[str] = Field(alias=r".*", regex=True)
+
+    df = pl.DataFrame(
+        {
+            "index_column": [1.0],
+            "this_must_become_string": [1.0],
+        }
+    )
+
+    out = Model.validate(df)
+    # The unmatched column must be coerced to String by the alias path.
+    assert out.schema["this_must_become_string"] == pl.String
+    # And the explicit column must keep its declared Int64 dtype.
+    assert out.schema["index_column"] == pl.Int64
+
+
 def test_nullable_check_lazy_validation_no_deprecation_warning(
     simulate_polars_1_42_1,
 ):


### PR DESCRIPTION
### Why

Issue #2343: with `coerce=True`, a broad regex alias such as `Field(alias=r".*", regex=True)` also selects explicitly declared model columns, coercing them to the alias's dtype before their own dtype is validated (e.g. an explicit `index_column: Series[int]` is coerced to `String`, failing with `SchemaError: expected column 'index_column' to have type Int64, got String`).

The fix makes the alias selector mutually exclusive with explicit fields (explicit columns keep their own schema, and the alias governs only the remaining columns).

### What

Two changes in `pandera/backends/polars/container.py`:

1. `collect_schema_components`: regex aliases are expanded into per-column non-regex components, excluding explicitly declared columns. When the regex matches only explicit columns, required aliases raise the component path's "did not match any non-explicit columns" error and optional aliases are skipped.
2. `_coerce_dtype_helper`: explicitly declared columns are filtered out of the regex coercion match set.

Both changes are needed because the alias's schema component validates dtypes independently of coercion. Two regression tests added in `tests/polars/test_polars_model.py` (eager + lazy), `xfail`-marked for the narwhals backend, which does not implement the exclusion.

Scope: Polars backend only; pandas and narwhals have the same issue and are left as follow-up.

### Acceptance criteria

- [x] Tests added (2 regression tests, eager + lazy)
- [x] Existing tests pass (tests/polars: 447; nox Polars 1.33.1/0.20.0: 389 each)
- [x] Style checks pass (scoped prek); commits DCO-signed

Closes #2343 