### PR TITLE
Report integer coercion overflow instead of wrapping silently

### DIFF
--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -19,6 +19,33 @@ from pandera.engines.type_aliases import PandasObject
 from pandera.system import FLOAT_128_AVAILABLE
 
 
+def _check_integer_overflow(original: Any, coerced: Any) -> None:
+    """Raise if an integer-to-integer coercion silently wrapped around.
+
+    numpy integer casts wrap on overflow, so ``astype`` "succeeds" while
+    changing the value (``300`` to ``int8`` gives ``44``, ``-1`` to ``uint8``
+    gives ``255``). Only integer-to-integer casts are checked: float-to-integer
+    truncation is an intentional, documented cast.
+    """
+    original_kind = getattr(getattr(original, "dtype", None), "kind", None)
+    coerced_kind = getattr(getattr(coerced, "dtype", None), "kind", None)
+    if original_kind not in ("i", "u") or coerced_kind not in ("i", "u"):
+        return
+    if len(original) == 0:
+        return
+
+    # Compare against the target's bounds rather than round-tripping: a
+    # round-trip cannot detect every wrap (-1 -> uint64 -> int64 is -1 again).
+    # Reducing first keeps this to two passes, and int() is exact for the
+    # arbitrary-precision comparison against uint64 bounds.
+    info = np.iinfo(np.dtype(coerced.dtype))
+    if int(np.min(original)) < info.min or int(np.max(original)) > info.max:
+        raise OverflowError(
+            f"Cannot coerce {original.dtype} to {coerced.dtype}: value(s) "
+            f"outside [{info.min}, {info.max}] would wrap around."
+        )
+
+
 @immutable(init=True)
 class DataType(dtypes.DataType):
     """Base `DataType` for boxing Numpy data types."""
@@ -53,6 +80,7 @@ class DataType(dtypes.DataType):
         if type(data_container).__module__.startswith("modin.pandas"):
             # NOTE: this is a hack to enable catching of errors in modin
             coerced.__str__()
+        _check_integer_overflow(data_container, coerced)
         return coerced
 
     def coerce_value(self, value: Any) -> Any:

--- a/pandera/engines/numpy_engine.py
+++ b/pandera/engines/numpy_engine.py
@@ -38,8 +38,15 @@ def _check_integer_overflow(original: Any, coerced: Any) -> None:
     # round-trip cannot detect every wrap (-1 -> uint64 -> int64 is -1 again).
     # Reducing first keeps this to two passes, and int() is exact for the
     # arbitrary-precision comparison against uint64 bounds.
+    #
+    # Use the container's own bound .min()/.max() methods rather than the
+    # np.min()/np.max() free functions: numpy's reduction dispatch calls
+    # obj.min(axis=..., out=..., **kwargs) under the hood, which modin and
+    # pyspark.pandas Series don't support, raising unrelated errors that get
+    # reported as coercion failures. The bound methods work uniformly across
+    # numpy arrays, pandas, modin, and pyspark.pandas.
     info = np.iinfo(np.dtype(coerced.dtype))
-    if int(np.min(original)) < info.min or int(np.max(original)) > info.max:
+    if int(original.min()) < info.min or int(original.max()) > info.max:
         raise OverflowError(
             f"Cannot coerce {original.dtype} to {coerced.dtype}: value(s) "
             f"outside [{info.min}, {info.max}] would wrap around."

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -1223,3 +1223,48 @@ def test_direct_pyarrow_engine_import_registers_pyarrow_dtypes():
         )
     finally:
         engine.Engine._registry[pandas_engine.Engine] = registry_snapshot
+
+
+@pytest.mark.parametrize(
+    "values, target_dtype",
+    [
+        ([1, 2, 300], "int8"),
+        ([-1], "uint8"),
+        ([70000], "int16"),
+        ([-1], "uint64"),
+    ],
+)
+def test_coerce_integer_overflow_is_reported(values, target_dtype):
+    """Integer coercion that would wrap around is a coercion failure.
+
+    numpy integer casts wrap silently, so ``astype`` "succeeds" while changing
+    the value (300 -> int8 gives 44, -1 -> uint8 gives 255).
+    """
+    schema = pa.DataFrameSchema({"a": pa.Column(target_dtype, coerce=True)})
+    with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+        schema.validate(pd.DataFrame({"a": values}))
+
+
+def test_coerce_integer_overflow_does_not_bypass_checks():
+    """A wrapped value must not pass a check the original value violated."""
+    schema = pa.DataFrameSchema(
+        {"a": pa.Column("int8", checks=pa.Check.le(100), coerce=True)}
+    )
+    with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+        schema.validate(pd.DataFrame({"a": [1, 2, 300]}))
+
+
+@pytest.mark.parametrize(
+    "values, target_dtype, expected",
+    [
+        ([1, 2, 3], "int8", [1, 2, 3]),
+        ([1.7, 2.9], "int64", [1, 2]),
+        (["1", "2"], "int64", [1, 2]),
+        ([True, False], "int64", [1, 0]),
+    ],
+)
+def test_coerce_valid_integer_conversions_still_work(values, target_dtype, expected):
+    """Legitimate coercions are unaffected: widening, float truncation,
+    string parsing and bool conversion all still succeed."""
+    schema = pa.DataFrameSchema({"a": pa.Column(target_dtype, coerce=True)})
+    assert schema.validate(pd.DataFrame({"a": values}))["a"].tolist() == expected

--- a/tests/pandas/test_dtypes.py
+++ b/tests/pandas/test_dtypes.py
@@ -1263,8 +1263,28 @@ def test_coerce_integer_overflow_does_not_bypass_checks():
         ([True, False], "int64", [1, 0]),
     ],
 )
-def test_coerce_valid_integer_conversions_still_work(values, target_dtype, expected):
+def test_coerce_valid_integer_conversions_still_work(
+    values, target_dtype, expected
+):
     """Legitimate coercions are unaffected: widening, float truncation,
     string parsing and bool conversion all still succeed."""
     schema = pa.DataFrameSchema({"a": pa.Column(target_dtype, coerce=True)})
-    assert schema.validate(pd.DataFrame({"a": values}))["a"].tolist() == expected
+    assert (
+        schema.validate(pd.DataFrame({"a": values}))["a"].tolist() == expected
+    )
+
+
+def test_coerce_empty_integer_column_is_not_an_overflow():
+    """An empty integer column has no values to wrap, so coercion succeeds.
+
+    The bounds check reduces with ``.min()``/``.max()``, which are
+    undefined on an empty container: pandas returns ``nan``, and
+    ``int(nan)`` raises. Without the empty guard that surfaces as a
+    spurious coercion failure.
+    """
+    schema = pa.DataFrameSchema({"a": pa.Column("int8", coerce=True)})
+    validated = schema.validate(
+        pd.DataFrame({"a": pd.Series([], dtype="int64")})
+    )
+    assert validated.empty
+    assert validated["a"].dtype == "int8"


### PR DESCRIPTION
Fixes #2442

### Problem

numpy integer casts wrap on overflow, so `astype` "succeeds" while changing the value. With `coerce=True` that turns validation into a silent rewrite:

```python
schema = DataFrameSchema({"a": Column("int8", coerce=True)})
schema.validate(pd.DataFrame({"a": [1, 2, 300]}))["a"].tolist()
# [1, 2, 44]

DataFrameSchema({"a": Column("uint8", coerce=True)}).validate(pd.DataFrame({"a": [-1]}))["a"].tolist()
# [255]
```

The part that makes this worse than a missing check: the wrapped value then **passes checks the original violated**, so the caller gets back a frame certified as valid containing a number that was never in their data.

```python
Column("int8", checks=Check.le(100), coerce=True)   # 300 -> 44 -> passes le(100)
```

It was also asymmetric — an *unparseable* value already failed loudly (`"x"` to int64 raises), while a value that parses but can't be represented was rewritten in silence.

### Change

After an integer-to-integer cast, compare the source values against the target dtype's bounds and raise `OverflowError`. `try_coerce()` already turns that into the normal `DATATYPE_COERCION` failure cases, so the error surfaces through the existing machinery with no new error type.

Two details worth calling out:

**Bounds, not a round-trip.** I first implemented this as "cast back and compare", which is the obvious approach — and it silently misses cases, because `-1 -> uint64 -> int64` is `-1` again. Comparing against `np.iinfo` bounds is exact. `int()` on the reduced min/max makes the comparison against `uint64`'s upper bound exact too, where a numpy comparison would itself overflow. Cost is two reductions, no extra copy.

**Scope: integer-to-integer only.** Float-to-integer truncation (`1.7 -> 1`) is an intentional, documented cast and is untouched, as are string parsing and bool conversion — that's the line the issue asked about, and this is the conservative side of it. Happy to widen it if you'd prefer.

### Tests

Added to `tests/pandas/test_dtypes.py`:

- `test_coerce_integer_overflow_is_reported` — `300 -> int8`, `-1 -> uint8`, `70000 -> int16`, `-1 -> uint64`
- `test_coerce_integer_overflow_does_not_bypass_checks` — the `le(100)` scenario above
- `test_coerce_valid_integer_conversions_still_work` — widening, float truncation, string parsing, bool conversion all still succeed

```
$ pytest tests/pandas/test_dtypes.py tests/pandas/test_schemas.py -q
1 failed, 709 passed, 12 skipped, 1 xfailed
```

The single failure is `test_direct_pyarrow_engine_import_registers_pyarrow_dtypes`, which fails identically on an unmodified tree here (pyarrow engine not importable in my env) — unrelated to this change.
