### PR TITLE
docs: fix duplicated "the" typos in Check and Hypothesis docstrings

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -65,7 +65,7 @@ class Check(BaseCheck):
             callable is passed, the expected signature is: ``Callable[
             [pd.DataFrame], pd.core.groupby.DataFrameGroupBy]``
 
-            The the case of ``Column`` checks, this function has access to the
+            In the case of ``Column`` checks, this function has access to the
             entire dataframe, but ``Column.name`` is selected from this
             DataFrameGroupby object so that a SeriesGroupBy object is passed
             into ``check_fn``.

--- a/pandera/api/hypotheses.py
+++ b/pandera/api/hypotheses.py
@@ -238,7 +238,7 @@ class Hypothesis(Check):
 
         :example:
 
-        The the built-in class method to do a two-sample t-test.
+        Use the built-in class method to do a two-sample t-test.
 
         >>> import pandas as pd
         >>> import pandera.pandas as pa


### PR DESCRIPTION
Fixes two duplicated-word typos ("The the") in public API docstrings that render in the API reference.

- `pandera/api/checks.py`: `Check.__init__` `groupby` param — "The the case of ``Column`` checks" → "In the case of ``Column`` checks".
- `pandera/api/hypotheses.py`: `two_sample_ttest` example caption — "The the built-in class method to do a two-sample t-test." → "Use the built-in class method to do a two-sample t-test."

Documentation-only; no code or behavior changes, and no doctest lines are affected.