### PR TITLE
Add a backend-neutral `FieldType[T]` typing contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ The nox `tests` session maps extras to test directories: `extra=None` runs
 
 - **Ruff:** Linting (`I`, `UP` rules) and formatting. Line length: 79.
 - **isort:** Import sorting (line length 79).
-- **mypy:** Static type checking (v1.10.0). Config in `mypy.ini`.
+- **mypy:** Static type checking (v1.19.1). Config in `mypy.ini`.
 - **pyupgrade:** Python 3.9+ syntax upgrades.
 - **flynt:** f-string conversion.
 - **codespell:** Spell checking.

--- a/adrs/20260819-01-dataframe-model-column-typing.md
+++ b/adrs/20260819-01-dataframe-model-column-typing.md
@@ -1,0 +1,123 @@
+# ADR 20260819-01: Use FieldType for static DataFrameModel fields
+
+- Status: Approved
+- Date: 2026-08-19
+
+## Context
+
+`DataFrameModel` fields have two deliberately different lives. At runtime,
+Pandera replaces the class attribute with a field descriptor whose class-level
+value is the column name (`str`). In static analysis, a checker sees the
+field's annotation as the attribute type. With native backend annotations such
+as Polars' `pl.List`, using a schema field as a column name can therefore
+produce a false positive even though the runtime behavior is correct.
+
+The existing mypy plugin can compensate for this in mypy, but a
+checker-specific plugin cannot provide the same contract to other checkers
+such as `ty`. The public typing API needs a backend-neutral descriptor layer,
+distinct from each backend's runtime `pa.Field` function.
+
+## Decision
+
+Pandera exposes the typing-only `pandera.typing.FieldType` descriptor. Its
+first generic argument is the dtype consumed by the runtime model parser, and
+additional arguments may carry a backend-specific `pa.Field(...)` object and
+any dtype parameters:
+
+```python
+from pandera.typing import FieldType
+import polars as pl
+import pandera.polars as pa
+
+
+class Schema(pa.DataFrameModel):
+    values: FieldType[pl.List, pa.Field()]
+    nullable_field: FieldType[int | None, pa.Field()]
+    optional_field: FieldType[int] | None
+```
+
+The assignment form is also supported and keeps value expressions out of type
+arguments for static checkers:
+
+```python
+class Schema(pa.DataFrameModel):
+    field: FieldType[int] = pa.Field(gt=0)
+```
+
+`FieldType[T]` models class-level access as `str` while retaining `T` as the
+schema dtype. It is typing-only and must not be instantiated; the backend
+runtime `pa.Field(...)` function remains the source of field checks and
+metadata. An explicit assignment takes precedence over metadata supplied in
+`FieldType`.
+
+Field metadata is represented by `FieldType` metadata or the assignment form,
+rather than requiring an outer `typing.Annotated` wrapper. Existing
+`Annotated` support for backend dtype parameters remains independent of this
+descriptor contract.
+
+The shared parser extracts the dtype and field metadata before constructing
+backend-specific schema components. All supported DataFrameModel backends
+use the same descriptor and preserve the existing field checks, aliases,
+requiredness, and nullability behavior.
+
+## Consequences
+
+### Positive
+
+- Generic checkers can accept `Schema.field` where a `str` column name is
+  expected without a checker-specific plugin.
+- The descriptor name is backend-neutral and does not collide conceptually
+  with `pandera.polars.Field`, `pandera.pandas.Field`, or other runtime
+  `Field` functions.
+- Field metadata can sit beside the dtype in a concise declaration, while
+  assignment-based declarations remain available.
+- The runtime parser owns one contract across pandas, Polars, Ibis, PyArrow,
+  PySpark, and xarray-compatible model infrastructure.
+
+### Negative
+
+- `FieldType` is a Pandera-specific typing construct that users must learn.
+- A generic checker may reject a value expression such as `pa.Field()` inside
+  a type argument even though Pandera can parse it at runtime; the assignment
+  form is the checker-friendly spelling in that case.
+- The parser must distinguish dtype parameters from field metadata and must
+  preserve explicit assignment precedence.
+
+## Alternatives considered
+
+### Add a backend-neutral FieldType descriptor
+
+The original proposal introduced a typing-only descriptor named `Column`,
+but `FieldType` is more future-proof alongside xarray and TensorDict support
+and clearly separates the typing layer from backend runtime `Field` objects.
+
+### Require a checker-specific plugin
+
+An analyzer-specific plugin could teach one checker about Pandera's runtime
+descriptor, but it would not provide the same contract to `ty` and other
+checkers. The public descriptor keeps the bridge backend-neutral and plugin
+free.
+
+### Use only `typing.Annotated`
+
+`Annotated[T, ...]` preserves the underlying `T` for generic static analysis,
+so it cannot by itself prevent the false positive when a model attribute is
+used as a column name. It remains useful for dtype metadata, but it is not the
+static descriptor layer.
+
+### Keep only assignment-based `Field()` declarations
+
+Assignment remains supported and is the most checker-friendly spelling, but
+it does not provide the concise metadata-bearing annotation proposed by the
+maintainer. `FieldType` supports both forms.
+
+## Implementation status
+
+The implementation preserves the `FieldType[T]` no-plugin static contract,
+`FieldType` metadata and assignment precedence, and the presence/nullability
+rules in ADR 20260819-02 across supported DataFrameModel backends.
+
+## References
+
+- [Pydantic fields documentation](https://docs.pydantic.dev/latest/concepts/fields/)
+- [Pandera PR #2255](https://github.com/pandera-dev/pandera/pull/2255)

--- a/adrs/20260819-02-dataframe-model-optionality.md
+++ b/adrs/20260819-02-dataframe-model-optionality.md
@@ -1,0 +1,137 @@
+# ADR 20260819-02: Separate column presence from value nullability
+
+- Status: Approved
+- Date: 2026-08-19
+
+## Context
+
+Pandera has two different concepts that are easy to conflate:
+
+- whether a declared column must be present in the input data; and
+- whether values in a present column may be null.
+
+The annotation contract should make the distinction visible. `None` inside a
+dtype describes value nullability, while an outer `| None` on the typing-only
+`FieldType` descriptor describes optional field presence. `Field(required=...)`
+and `Field(nullable=...)` remain explicit overrides.
+
+## Decision
+
+DataFrameModel fields use the following meanings:
+
+```python
+from pandera.typing import FieldType
+
+
+class Schema(pa.DataFrameModel):
+    required: int
+    nullable_values: int | None
+    optional_presence: FieldType[int] | None
+```
+
+When the static descriptor is needed for every field, the equivalent forms
+are:
+
+```python
+class StaticSchema(pa.DataFrameModel):
+    required: FieldType[int]
+    nullable_values: FieldType[int | None]
+    optional_presence: FieldType[int] | None
+```
+
+Field metadata can be supplied as additional `FieldType` metadata or through
+assignment:
+
+```python
+class MetadataSchema(pa.DataFrameModel):
+    checked: FieldType[int, pa.Field(gt=0)]
+    assigned: FieldType[int] = pa.Field(description="assigned")
+```
+
+The meanings are:
+
+| Annotation | Schema meaning |
+| --- | --- |
+| `T` or `FieldType[T]` | Required column; non-nullable by default |
+| `T \| None` or `FieldType[T \| None]` | Required column whose values may be null |
+| `FieldType[T] \| None` | Column may be absent from the input data |
+
+`pandera.typing.FieldType[T]` is typing-only and does not replace the runtime
+backend `pa.Field(...)` function. Explicit `required` and `nullable` values
+override inference independently, and an explicit assignment takes precedence
+over metadata supplied in `FieldType`.
+
+The annotation parser retains outer-union optionality for generic model
+containers used by runtime decorators. It separately records field-presence
+optionality for schema annotations so that `check_types` can accept an
+optional model argument without making a required schema field optional.
+
+`Field(required=...)` is optional so that an omitted value does not override
+the annotation's inferred presence. When supplied, it takes precedence over
+the annotation. Likewise, an explicit `Field(nullable=...)` takes precedence
+over nullability inferred from `T | None`.
+
+The established `Optional[Series[T]]` spelling remains supported for
+backwards compatibility and continues to mean optional column presence. This
+legacy wrapper is distinct from a bare `T | None` annotation. Optional index
+annotations remain invalid where the backend has historically rejected them.
+
+## Consequences
+
+### Positive
+
+- Presence and value nullability can be stated independently.
+- `FieldType[T]` gives generic checkers the class-level `str` descriptor
+  contract without a checker-specific plugin.
+- Field metadata remains concise and backend-neutral.
+- Existing `Series[T]` declarations and explicit `Field(nullable=...)`
+  overrides remain supported.
+
+### Negative
+
+- Users must distinguish a bare `T | None` from `FieldType[T] | None` and the
+  legacy `Optional[Series[T]]` spelling.
+- The `FieldType` implementation must track whether `required` and `nullable`
+  were explicitly supplied so omitted values do not override inference.
+- Backend parsers must apply the same rules consistently.
+
+## Alternatives considered
+
+### Use Annotated metadata for presence
+
+This was the earlier metadata-carrier design, but the maintainer-approved
+`FieldType` descriptor is more concise and also models the class-level access
+needed by generic static checkers. `Annotated` remains available for existing
+dtype-parameter syntax, but is not required for field metadata here.
+
+### Use an earlier descriptor and an outer union for presence
+
+The original proposal used `Column[T | None]` for nullable values and
+`Column[T] | None` for optional presence. The future-proof `FieldType` name
+preserves that descriptor idea while differentiating it from backend runtime
+`Field` functions.
+
+### Make nullable metadata the only nullable spelling
+
+This keeps all metadata in `Field`, but loses the conventional type-level
+meaning of `T | None`. The annotation form remains the primary way to express
+value nullability, with explicit `Field(nullable=...)` as an override.
+
+### Use only required metadata and keep T | None as presence optional
+
+This would preserve the old interpretation for bare dtype annotations, but
+would make `None` mean different things depending on whether it describes a
+dtype or a field declaration. The contract reserves bare `T | None` for
+nullable values and uses `FieldType[T] | None` for optional presence.
+
+## Implementation status
+
+Tests cover required fields, nullable values, optional presence, explicit
+nullable/required overrides, `FieldType` metadata, assignment precedence, the
+legacy `Optional[Series[T]]` compatibility path, and optional runtime model
+arguments.
+
+## References
+
+- [Pydantic fields documentation](https://docs.pydantic.dev/latest/concepts/fields/)
+- [Pandera PR #2255](https://github.com/pandera-dev/pandera/pull/2255)

--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -457,6 +457,26 @@ class SchemaExplicitWins(pa.DataFrameModel):
 SchemaExplicitWins.to_schema().columns["value"].description
 ```
 
+You can also embed field metadata with {data}`typing.Annotated`:
+
+```{code-cell} python
+from typing import Annotated
+
+
+class AnnotatedSchema(pa.DataFrameModel):
+    value: Annotated[int, pa.Field(gt=0, description="A positive value")]
+
+
+AnnotatedSchema.to_schema().columns["value"].description
+```
+
+This syntax is valid at runtime and may be convenient when you prefer standard
+typing constructs. Its trade-off is that `Annotated` preserves the underlying
+`int` annotation for static analysis; it does not provide the class-level `str`
+descriptor contract. If model fields are not passed to string-taking APIs, this
+limitation may not matter. If `ty` is part of your tooling, use `FieldType`
+instead.
+
 `FieldType[T]` supplies the static descriptor contract: class-level access is
 a `str`, while `T` remains the dtype Pandera parses at runtime. It is not the
 runtime metadata function and must not be instantiated. Existing bare dtypes,

--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -27,8 +27,10 @@ explicitly converted to a {class}`~pandera.api.pandas.container.DataFrameSchema`
 :::{note}
 Due to current limitations in the pandas library (see discussion
 [here](https://github.com/pandera-dev/pandera/issues/253#issuecomment-665338337)),
-`pandera` annotations are only used for **run-time** validation and has
+`pandera` annotations are primarily used for **run-time** validation and have
 limited support for static-type checkers like [mypy](http://mypy-lang.org/).
+The typing-only {py:class}`pandera.typing.FieldType` descriptor also models
+class-level column-name access for generic checkers such as `ty`.
 See the {ref}`Mypy Integration <mypy-integration>` for more details.
 :::
 
@@ -110,7 +112,7 @@ class InputSchema(pa.DataFrameModel):
     day: int = pa.Field(ge=0, le=365, coerce=True)
 ```
 
-### Reusing Field objects
+## Reusing Field objects
 
 To define reusable `Field` definitions, you need to use `functools.partial`.
 This makes sure that each field attribute is bound to a unique `Field` instance.
@@ -405,85 +407,107 @@ class SchemaFieldDatetimeTZDtype(pa.DataFrameModel):
 Schema.to_schema()
 ```
 
-### Embedding `Field` metadata in `Annotated`
+### Field metadata and static field names
 
-You can also embed a {func}`~pandera.api.dataframe.model_components.Field`
-directly inside {data}`typing.Annotated` to attach field-level metadata —
-such as `description`, `title`, `unique`, checks (`ge`, `le`, `isin`,
-etc.), or custom `metadata` — without having to provide an explicit `=
-pa.Field(...)` assignment. This is useful when you want the type
-annotation itself to fully describe the column.
+Use the typing-only {py:class}`pandera.typing.FieldType` descriptor when a
+generic checker such as `ty` needs to accept a model field as a column name.
+The backend-specific `pa.Field(...)` object can be supplied as additional
+`FieldType` metadata:
 
 ```{code-cell} python
-from typing import Annotated
-
 import pandas as pd
 import pandera.pandas as pa
+from pandera.typing import FieldType
 
 
 class Schema(pa.DataFrameModel):
-    name: Annotated[str, pa.Field(description="Name of the person")]
-    age: Annotated[int, pa.Field(ge=0, description="Age of the person")]
-    month: Annotated[int, pa.Field(ge=1, le=12)]
-    identifier: Annotated[int, pa.Field(unique=True, title="Identifier")]
+    name: FieldType[str, pa.Field(description="Name of the person")]
+    age: FieldType[int, pa.Field(ge=0, description="Age of the person")]
+    month: FieldType[int, pa.Field(ge=1, le=12)]
+    identifier: FieldType[int, pa.Field(unique=True, title="Identifier")]
 
 
 schema = Schema.to_schema()
 schema.columns["name"].description
 ```
 
-```{code-cell} python
-schema.columns["month"].checks
-```
-
-When the annotation also carries dtype parameters (e.g.
-`Annotated[pd.DatetimeTZDtype, "ns", "est"]`), you can still append a
-`Field` at the end:
+For parameterized dtypes, use the checker-friendly assignment form to pass
+`dtype_kwargs`:
 
 ```{code-cell} python
 class SchemaWithDtypeParamsAndField(pa.DataFrameModel):
-    ts: Annotated[
-        pd.DatetimeTZDtype, "ns", "est", pa.Field(description="Timestamp")
-    ]
+    ts: FieldType[pd.DatetimeTZDtype] = pa.Field(
+        dtype_kwargs={"unit": "ns", "tz": "EST"},
+        description="Timestamp",
+    )
 ```
 
-If both an embedded `Field` and an explicit assignment are provided,
-the explicit assignment takes precedence:
+The assignment form is the checker-friendly spelling: it keeps the value
+expression out of the type argument while preserving metadata precedence:
+
+The `FieldType[T, pa.Field(...)]` form is also accepted by Pandera's runtime
+parser. Generic checkers may reject the function call inside the type argument,
+so use assignment when running `ty`.
 
 ```{code-cell} python
 class SchemaExplicitWins(pa.DataFrameModel):
-    value: Annotated[int, pa.Field(description="from annotated")] = (
-        pa.Field(description="from assignment")
-    )
+    value: FieldType[int] = pa.Field(description="from assignment")
 
 
 SchemaExplicitWins.to_schema().columns["value"].description
 ```
 
-## Required Columns
+`FieldType[T]` supplies the static descriptor contract: class-level access is
+a `str`, while `T` remains the dtype Pandera parses at runtime. It is not the
+runtime metadata function and must not be instantiated. Existing bare dtypes,
+`Series[T]`, and `Annotated` forms used for dtype parameters remain supported.
 
-By default all columns specified in the schema are {ref}`required<required>`, meaning
-that if a column is missing in the input DataFrame an exception will be
-thrown. If you want to make a column optional, annotate it with {data}`typing.Optional`.
+## Required columns
+
+By default all columns specified in the schema are {ref}`required<required>`
+and non-nullable, meaning that a missing column or a null value raises an
+exception. Put `None` inside `FieldType[...]` to allow null values, and use an
+outer `| None` or `required=False` metadata to allow the column itself to be
+missing.
 
 ```{code-cell} python
-from typing import Optional
-
 import pandas as pd
 import pandera.pandas as pa
-from pandera.typing import Series
+from pandera.typing import FieldType
 
 
 class Schema(pa.DataFrameModel):
-    a: Series[str]
-    b: Optional[Series[int]]
+    required: str
+    nullable: FieldType[int | None]
+    optional: FieldType[float] | None
 
-df = pd.DataFrame({"a": ["2001", "2002", "2003"]})
+df = pd.DataFrame(
+    {
+        "required": ["2001", "2002", "2003"],
+        "nullable": pd.Series([1, None, 3], dtype="Int64"),
+    }
+)
 Schema.validate(df)
 ```
 
-`Optional` means that a field may be absent from the input DataFrame. It
-does not add the field during validation. To add missing fields, use
+The meanings are:
+
+| Annotation | Column required? | Values nullable? |
+| ---------- | ---------------- | ---------------- |
+| `T` | Yes | No |
+| `T | None` | Yes | Yes |
+| `FieldType[T] | None` | No | No |
+
+The same meanings apply to `FieldType[T, pa.Field(...)]`. An explicit
+`required` or `nullable` argument in `pa.Field` overrides the inferred value
+without changing the other dimension. Explicit assignment also takes
+precedence over metadata supplied in `FieldType`.
+
+An explicit `pa.Field(nullable=...)` setting takes precedence over the
+nullability inferred from the annotation. Existing
+`Optional[Series[T]]` annotations remain supported for optional column
+presence. An optional field does not get added during validation. To add
+missing fields, use
 {ref}`add_missing_columns=True <adding-missing-columns>` in the model
 `Config` with required fields that specify a `default` value or
 `nullable=True`.
@@ -516,7 +540,7 @@ def transform(df: DataFrame[BaseSchema]) -> DataFrame[FinalSchema]:
 transform(df)
 ```
 
-### Multiple Inheritance
+### Multiple inheritance
 
 Multiple inheritance is also supported, making it easy to compose schemas from
 reusable "mixin" models without repeating yourself. For this to work, each of

--- a/docs/source/ibis.md
+++ b/docs/source/ibis.md
@@ -279,29 +279,32 @@ The ``time_zone_agnostic`` argument for the timestamp data type is not yet
 supported in the Ibis integration.
 :::
 
-### Embedding `Field` metadata in `Annotated`
+### Field metadata for typed model fields
 
-You can also embed a {func}`~pandera.api.dataframe.model_components.Field`
-directly inside {data}`typing.Annotated` to attach column-level metadata
-— such as `description`, `title`, `unique`, checks (`ge`, `le`, `isin`,
-…), or custom `metadata` — without providing an explicit `= pa.Field(...)`
-assignment. This works for plain types as well as parameterized Ibis
-dtypes:
+You can embed a backend-specific `pa.Field(...)` object as additional metadata
+in the typing-only {py:class}`pandera.typing.FieldType` descriptor. This
+attaches column-level metadata such as `description`, `title`, `unique`,
+checks such as `ge`, `le`, and `isin`, or custom `metadata` without a separate
+assignment. For parameterized Ibis dtypes, use the checker-friendly assignment
+form to pass `dtype_kwargs`:
+
+These metadata-in-type-argument examples are runtime syntax. When checking a
+model with `ty`, use `FieldType[T] = pa.Field(...)` so the type argument contains
+only types.
 
 ```{code-cell} python
-from typing import Annotated
-
 import ibis.expr.datatypes as dt
+from pandera.typing import FieldType
 
 
 class ProductsModel(pa.DataFrameModel):
-    name: Annotated[str, pa.Field(description="Product name")]
-    price: Annotated[float, pa.Field(ge=0.0, description="Unit price")]
-    sku: Annotated[int, pa.Field(unique=True, title="SKU")]
-    # parameterized dtypes can be combined with FieldInfo
-    created_at: Annotated[
-        dt.Timestamp, "UTC", 6, True, pa.Field(description="Created at")
-    ]
+    name: FieldType[str, pa.Field(description="Product name")]
+    price: FieldType[float, pa.Field(ge=0.0, description="Unit price")]
+    sku: FieldType[int, pa.Field(unique=True, title="SKU")]
+    created_at: FieldType[dt.Timestamp] = pa.Field(
+        dtype_kwargs={"timezone": "UTC", "scale": 6, "nullable": True},
+        description="Created at",
+    )
 
 
 schema = ProductsModel.to_schema()

--- a/docs/source/mypy_integration.md
+++ b/docs/source/mypy_integration.md
@@ -27,6 +27,47 @@ plugins = pandera.mypy
 Mypy static type-linting is supported for only pandas dataframes.
 :::
 
+## Static DataFrameModel field names with ty
+
+`DataFrameModel` replaces field attributes with column-name descriptors at
+runtime. Plain dtype annotations are treated as the dtype by a generic static
+checker, so they do not by themselves prevent a `ty` false positive when a
+field is passed to an API expecting a `str`.
+
+Use the backend-neutral, typing-only
+{py:class}`pandera.typing.FieldType` descriptor when that static contract is
+needed:
+
+```python
+import polars as pl
+import pandera.polars as pa
+from pandera.typing import FieldType
+
+
+class Schema(pa.DataFrameModel):
+    values: FieldType[pl.List] = pa.Field()
+    nullable: FieldType[int | None] = pa.Field()
+    optional: FieldType[int] | None
+
+
+def accepts_name(name: str) -> str:
+    return name
+
+
+accepts_name(Schema.values)  # accepted by ty without a Pandera plugin
+```
+
+`FieldType[T]` models class-level access as `str` and leaves `T` available to
+Pandera's runtime parser. It is not instantiated. The backend-specific
+`pa.Field(...)` remains the runtime metadata object, either as the assigned
+value shown above or as an additional `FieldType` metadata argument:
+`FieldType[T, pa.Field(...)]`. Because generic checkers may reject calls inside
+type arguments, use the assignment form shown above when running `ty`. The
+descriptor does not change the required, nullable, optional-presence,
+explicit-override, or legacy
+`Optional[Series[T]]` semantics documented in the
+{ref}`DataFrameModel guide <dataframe-models>`.
+
 :::{warning}
 This functionality is experimental 🧪. Since the
 [pandas-stubs](https://github.com/pandas-dev/pandas-stubs) type stub

--- a/docs/source/polars.md
+++ b/docs/source/polars.md
@@ -567,26 +567,33 @@ class DateTimeModel(pa.DataFrameModel):
 
 ::::
 
-### Embedding `Field` metadata in `Annotated`
+### Field metadata for typed model fields
 
-You can also embed a {func}`~pandera.api.dataframe.model_components.Field`
-directly inside {data}`typing.Annotated` to attach column-level metadata
-— such as `description`, `title`, `unique`, checks (`ge`, `le`, `isin`,
-…), or custom `metadata` — without providing an explicit `= pa.Field(...)`
-assignment. This works for plain types as well as parameterized polars
-dtypes:
+You can embed a backend-specific `pa.Field(...)` object as additional metadata
+in the typing-only {py:class}`pandera.typing.FieldType` descriptor. This
+attaches column-level metadata such as `description`, `title`, `unique`,
+checks such as `ge`, `le`, and `isin`, or custom `metadata` without a separate
+assignment. For parameterized polars dtypes, use the checker-friendly
+assignment form to pass `dtype_kwargs`:
+
+These metadata-in-type-argument examples are runtime syntax. When checking a
+model with `ty`, use `FieldType[T] = pa.Field(...)` so the type argument contains
+only types.
 
 ```{testcode} polars
 import polars as pl
+from pandera.typing import FieldType
+from pandera.engines import polars_engine as pe
 
 
 class ProductsModel(pa.DataFrameModel):
-    name: Annotated[str, pa.Field(description="Product name")]
-    price: Annotated[float, pa.Field(ge=0.0, description="Unit price")]
-    sku: Annotated[int, pa.Field(unique=True, title="SKU")]
-    created_at: Annotated[
-        pl.Datetime, "ms", "UTC", pa.Field(description="Created timestamp")
-    ]
+    name: FieldType[str, pa.Field(description="Product name")]
+    price: FieldType[float, pa.Field(ge=0.0, description="Unit price")]
+    sku: FieldType[int, pa.Field(unique=True, title="SKU")]
+    created_at: FieldType[pe.DateTime] = pa.Field(
+        dtype_kwargs={"time_unit": "ms", "time_zone": "UTC"},
+        description="Created timestamp",
+    )
 
 
 schema = ProductsModel.to_schema()

--- a/docs/source/pyspark_sql.md
+++ b/docs/source/pyspark_sql.md
@@ -354,29 +354,34 @@ PanderaSchema.get_metadata()
 This feature is available for `pyspark.sql` and `pandas` both.
 :::
 
-## Embedding `Field` metadata in `Annotated`
+## Field metadata for typed model fields
 
-You can also embed a {func}`~pandera.api.dataframe.model_components.Field`
-directly inside {data}`typing.Annotated` to attach column-level metadata
-— such as `description`, `title`, checks (`gt`, `ge`, `le`, `isin`, …),
-or custom `metadata` — without providing an explicit `= pa.Field(...)`
-assignment. This works for plain `pyspark.sql.types` as well as
-parameterized ones:
+You can embed a backend-specific `pa.Field(...)` object as additional metadata
+in the typing-only {py:class}`pandera.typing.FieldType` descriptor. This
+attaches column-level metadata such as `description`, `title`, and checks such
+as `gt`, `ge`, `le`, and `isin`, or custom `metadata` without a separate
+assignment.
+This works for plain `pyspark.sql.types` as well as parameterized ones:
+
+These metadata-in-type-argument examples are runtime syntax. When checking a
+model with `ty`, use `FieldType[T] = pa.Field(...)` so the type argument contains
+only types.
 
 ```{code-cell} python
-from typing import Annotated
-
 import pyspark.sql.types as T
+from pandera.typing import FieldType
 
 
 class ProductsModel(DataFrameModel):
-    product_id: Annotated[T.IntegerType, pa.Field(title="Product ID")]
-    product_name: Annotated[
+    product_id: FieldType[T.IntegerType, pa.Field(title="Product ID")]
+    product_name: FieldType[
         T.StringType, pa.Field(description="Product name")
     ]
-    price: Annotated[T.DoubleType, pa.Field(gt=0.0, description="Unit price")]
+    price: FieldType[
+        T.DoubleType, pa.Field(gt=0.0, description="Unit price")
+    ]
     # parameterized dtypes can be combined with FieldInfo
-    list_price: Annotated[
+    list_price: FieldType[
         T.DecimalType, 20, 5, pa.Field(description="Listed price")
     ]
 

--- a/docs/source/reference/dataframe_models.rst
+++ b/docs/source/reference/dataframe_models.rst
@@ -54,6 +54,7 @@ Pandas
    pandera.typing.DataFrame
    pandera.typing.Series
    pandera.typing.Index
+   pandera.typing.FieldType
 
 Geopandas
 *********

--- a/environment.yml
+++ b/environment.yml
@@ -55,7 +55,7 @@ dependencies:
   - pandas >= 2.1.1
   - isort >= 5.7.0
   - joblib
-  - mypy = 1.10.0
+  - mypy = 1.19.1
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/pandera/api/base/model_components.py
+++ b/pandera/api/base/model_components.py
@@ -37,6 +37,9 @@ class BaseFieldInfo:
         "checks",
         "parses",
         "nullable",
+        "nullable_explicit",
+        "required",
+        "required_explicit",
         "unique",
         "coerce",
         "regex",
@@ -55,6 +58,8 @@ class BaseFieldInfo:
         checks: CheckArg | None = None,
         parses: ParserArg | None = None,
         nullable: bool = False,
+        nullable_explicit: bool = False,
+        required: bool | None = None,
         unique: bool = False,
         coerce: bool = False,
         regex: bool = False,
@@ -69,6 +74,9 @@ class BaseFieldInfo:
         self.checks = to_checklist(checks)
         self.parses = to_parserlist(parses)
         self.nullable = nullable
+        self.nullable_explicit = nullable_explicit
+        self.required = required if required is not None else True
+        self.required_explicit = required is not None
         self.unique = unique
         self.coerce = coerce
         self.regex = regex

--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -65,25 +65,32 @@ GENERIC_SCHEMA_CACHE: dict[
 
 
 def _dtype_metadata(annotation: AnnotationInfo) -> tuple[Any, ...]:
-    """Return ``annotation.metadata`` with any ``FieldInfo`` entries removed.
+    """Return dtype metadata with any ``FieldInfo`` entries removed.
 
-    ``Annotated`` types can carry a ``FieldInfo`` alongside dtype parameters
-    (e.g. ``Annotated[Decimal, 19, 4, pa.Field(...)]``). The FieldInfo is
-    consumed elsewhere and must not be forwarded as a dtype argument.
+    ``Annotated`` and ``FieldType`` annotations can carry a ``FieldInfo``
+    alongside dtype parameters. The FieldInfo is consumed elsewhere and must
+    not be forwarded as a dtype argument.
     """
     metadata = annotation.metadata or ()
     return tuple(item for item in metadata if not isinstance(item, FieldInfo))
 
 
-def _extract_annotated_field_info(annotation: Any) -> FieldInfo | None:
-    """Return the first ``FieldInfo`` embedded in an ``Annotated`` annotation.
+def _extract_field_info(annotation: Any) -> FieldInfo | None:
+    """Return the first ``FieldInfo`` embedded in an annotation.
 
-    Returns ``None`` if the annotation is not an ``Annotated`` type or has no
-    embedded ``FieldInfo``. The returned instance is copied so that mutating
-    the model's class attribute does not affect the original.
+    This handles both ``typing.Annotated`` metadata and the additional
+    metadata arguments accepted by ``pandera.typing.FieldType``. The returned
+    instance is copied so that mutating the model's class attribute does not
+    affect the original.
     """
+    if isinstance(annotation, FieldInfo):
+        return copy.deepcopy(annotation)
     metadata = getattr(annotation, "__metadata__", None)
     if not metadata:
+        for arg in typing.get_args(annotation):
+            field_info = _extract_field_info(arg)
+            if field_info is not None:
+                return field_info
         return None
     for item in metadata:
         if isinstance(item, FieldInfo):
@@ -288,15 +295,21 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
             cls.Config = type("Config", (cls.Config,), {"name": cls.__name__})
 
         super().__init_subclass__(**kwargs)
-        subclass_annotations = inspect.get_annotations(cls)
+        # Evaluate postponed annotations so metadata embedded in a
+        # ``FieldType`` alias is available while installing the descriptor.
+        # Fall back to the unevaluated annotations when a forward reference
+        # is not resolvable until schema collection.
+        try:
+            subclass_annotations = inspect.get_annotations(cls, eval_str=True)
+        except (NameError, TypeError):
+            subclass_annotations = inspect.get_annotations(cls)
 
         for field_name, annotation in subclass_annotations.items():
             if _is_field(field_name) and field_name not in cls.__dict__:
-                # No explicit Field assignment. If the annotation is an
-                # ``Annotated`` type that embeds a FieldInfo (e.g.
-                # ``Annotated[str, pa.Field(...)]``), use that FieldInfo so
-                # its metadata (description, title, etc.) is preserved.
-                field = _extract_annotated_field_info(annotation) or Field()
+                # No explicit Field assignment. If the annotation embeds a
+                # FieldInfo in ``Annotated`` or ``FieldType`` metadata, use
+                # it so its metadata is preserved.
+                field = _extract_field_info(annotation) or Field()
                 field.__set_name__(cls, field_name)
                 setattr(cls, field_name, field)
 
@@ -328,8 +341,13 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
         for field, (annot_info, field_info) in cls._collect_fields().items():
             if isinstance(annot_info.arg, TypeVar):
                 if annot_info.arg in param_dict:
-                    raw_annot = annot_info.origin[param_dict[annot_info.arg]]  # type: ignore
-                    if annot_info.optional:
+                    raw_dtype: Any = param_dict[annot_info.arg]
+                    raw_annot = (
+                        annot_info.origin[raw_dtype]  # type: ignore
+                        if annot_info.origin is not None
+                        else raw_dtype
+                    )
+                    if annot_info.nullable or annot_info.optional:
                         raw_annot = Optional[raw_annot]  # noqa: UP045
                     extra["__annotations__"][field] = raw_annot
                     extra[field] = copy.deepcopy(field_info)
@@ -463,7 +481,14 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
                     + f"not a '{type(field)}.'"
                 )
 
-            fields[field.name] = (AnnotationInfo(annotation), field)
+            annotation_info = AnnotationInfo(annotation)
+            if annotation_info.is_field and annotation_info.arg is None:
+                raise SchemaInitError(
+                    f"Invalid annotation '{field_name}: {annotation}'. "
+                    "pandera.typing.FieldType must be parameterized as "
+                    "FieldType[T]."
+                )
+            fields[field.name] = (annotation_info, field)
         return fields
 
     @classmethod

--- a/pandera/api/dataframe/model_components.py
+++ b/pandera/api/dataframe/model_components.py
@@ -54,13 +54,16 @@ class FieldInfo(BaseFieldInfo):
         dtype: Any,
         checks: CheckArg | None = None,
         parsers: ParserArg | None = None,
+        nullable: bool = False,
         required: bool = True,
         name: str | None = None,
     ) -> dict[str, Any]:
         """Create a schema_components.Column from a field."""
+        nullable = self.nullable if self.nullable_explicit else nullable
+        required = self.required if self.required_explicit else required
         return self._get_schema_properties(
             dtype,
-            nullable=self.nullable,
+            nullable=nullable,
             unique=self.unique,
             coerce=self.coerce,
             regex=self.regex,
@@ -79,12 +82,14 @@ class FieldInfo(BaseFieldInfo):
         dtype: Any,
         checks: CheckArg | None = None,
         parsers: ParserArg | None = None,
+        nullable: bool = False,
         name: str | None = None,
     ) -> dict[str, Any]:
         """Create a schema_components.Index from a field."""
+        nullable = self.nullable if self.nullable_explicit else nullable
         return self._get_schema_properties(
             dtype,
-            nullable=self.nullable,
+            nullable=nullable,
             unique=self.unique,
             coerce=self.coerce,
             name=name,
@@ -142,7 +147,8 @@ def Field(
     ] = None,
     str_matches: str | None = None,
     str_startswith: str | None = None,
-    nullable: bool = False,
+    nullable: bool | None = None,
+    required: bool | None = None,
     unique: bool = False,
     coerce: bool = False,
     regex: bool = False,
@@ -198,6 +204,7 @@ def Field(
     :param str_startswith: Check that the column/index starts with a substring.
         See :func:`~pandera.api.checks.Check.str_startswith` for more information.
     :param nullable: Whether or not the column/index can contain null values.
+    :param required: Whether or not the column is allowed to be missing.
     :param unique: Whether column values should be unique.
     :param coerce: coerces the data type if ``True``.
     :param regex: whether or not the field name or alias is a regex pattern.
@@ -250,7 +257,9 @@ def Field(
 
     return FieldInfo(
         checks=checks or None,
-        nullable=nullable,
+        nullable=nullable if nullable is not None else False,
+        nullable_explicit=nullable is not None,
+        required=required,
         unique=unique,
         coerce=coerce,
         regex=regex,

--- a/pandera/api/ibis/model.py
+++ b/pandera/api/ibis/model.py
@@ -15,7 +15,10 @@ from pandera.api.checks import Check
 from pandera.api.dataframe.model import (
     DataFrameModel as _DataFrameModel,
 )
-from pandera.api.dataframe.model import _dtype_metadata, get_dtype_kwargs
+from pandera.api.dataframe.model import (
+    _dtype_metadata,
+    get_dtype_kwargs,
+)
 from pandera.api.dataframe.model_components import FieldInfo
 from pandera.api.ibis.components import Column
 from pandera.api.ibis.container import DataFrameSchema
@@ -108,7 +111,8 @@ class DataFrameModel(_DataFrameModel[ibis.Table, DataFrameSchema]):
                 column_kwargs = (
                     field.column_properties(
                         dtype,
-                        required=not annotation.optional,
+                        nullable=annotation.nullable,
+                        required=not annotation.is_optional_field,
                         checks=field_checks,
                         name=field_name,
                     )

--- a/pandera/api/pandas/model.py
+++ b/pandera/api/pandas/model.py
@@ -10,7 +10,10 @@ from pandera.api.checks import Check
 from pandera.api.dataframe.model import (
     DataFrameModel as _DataFrameModel,
 )
-from pandera.api.dataframe.model import _dtype_metadata, get_dtype_kwargs
+from pandera.api.dataframe.model import (
+    _dtype_metadata,
+    get_dtype_kwargs,
+)
 from pandera.api.dataframe.model_components import FieldInfo
 from pandera.api.pandas.components import Column, Index, MultiIndex
 from pandera.api.pandas.container import DataFrameSchema
@@ -169,9 +172,14 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                         f"'check_name' is not supported for {field_name}."
                     )
 
+                nullable = (
+                    field.nullable
+                    if field.nullable_explicit
+                    else annotation.nullable
+                )
                 dtype = _get_nullable_coercion_dtype(
                     dtype,
-                    nullable=field.nullable,
+                    nullable=nullable,
                     coerce=field.coerce
                     or bool(getattr(cls.__config__, "coerce", False)),
                 )
@@ -179,7 +187,8 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                 column_kwargs = (
                     field.column_properties(
                         dtype,
-                        required=not annotation.optional,
+                        nullable=annotation.nullable,
+                        required=not annotation.is_optional_field,
                         checks=field_checks,
                         parsers=field_parsers,
                         name=field_name,
@@ -193,7 +202,7 @@ class DataFrameModel(_DataFrameModel[pd.DataFrame, DataFrameSchema]):
                 annotation.origin in get_index_types()
                 or annotation.raw_annotation in get_index_types()
             ):
-                if annotation.optional:
+                if annotation.is_optional_field:
                     raise SchemaInitError(
                         f"Index '{field_name}' cannot be Optional."
                     )

--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -12,7 +12,10 @@ from pandera.api.checks import Check
 from pandera.api.dataframe.model import (
     DataFrameModel as _DataFrameModel,
 )
-from pandera.api.dataframe.model import _dtype_metadata, get_dtype_kwargs
+from pandera.api.dataframe.model import (
+    _dtype_metadata,
+    get_dtype_kwargs,
+)
 from pandera.api.dataframe.model_components import FieldInfo
 from pandera.api.polars.components import Column
 from pandera.api.polars.container import DataFrameSchema
@@ -104,7 +107,8 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
                 column_kwargs = (
                     field.column_properties(
                         dtype,
-                        required=not annotation.optional,
+                        nullable=annotation.nullable,
+                        required=not annotation.is_optional_field,
                         checks=field_checks,
                         name=field_name,
                     )

--- a/pandera/api/pyarrow/model.py
+++ b/pandera/api/pyarrow/model.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from pandera.api.base.schema import BaseSchema
 from pandera.api.checks import Check
 from pandera.api.dataframe.model import DataFrameModel as _DataFrameModel
-from pandera.api.dataframe.model import _dtype_metadata, get_dtype_kwargs
+from pandera.api.dataframe.model import (
+    _dtype_metadata,
+    get_dtype_kwargs,
+)
 from pandera.api.dataframe.model_components import FieldInfo
 from pandera.api.pyarrow.components import Column
 from pandera.api.pyarrow.container import DataFrameSchema
@@ -98,7 +101,8 @@ class DataFrameModel(_DataFrameModel[pa.Table, DataFrameSchema]):
                 column_kwargs = (
                     field.column_properties(
                         dtype,
-                        required=not annotation.optional,
+                        nullable=annotation.nullable,
+                        required=not annotation.is_optional_field,
                         checks=field_checks,
                         name=field_name,
                     )

--- a/pandera/api/pyspark/model.py
+++ b/pandera/api/pyspark/model.py
@@ -21,7 +21,9 @@ from pandera.api.checks import Check
 from pandera.api.dataframe.model import (
     DataFrameModel as _DataFrameModel,
 )
-from pandera.api.dataframe.model import _dtype_metadata
+from pandera.api.dataframe.model import (
+    _dtype_metadata,
+)
 from pandera.api.dataframe.model_components import Field, FieldInfo
 from pandera.errors import SchemaInitError
 from pandera.typing import AnnotationInfo
@@ -202,8 +204,13 @@ class DataFrameModel(_DataFrameModel[PySparkFrame, DataFrameSchema]):
         for field, (annot_info, field_info) in cls._collect_fields().items():
             if isinstance(annot_info.arg, TypeVar):
                 if annot_info.arg in param_dict:
-                    raw_annot = annot_info.origin[param_dict[annot_info.arg]]  # type: ignore
-                    if annot_info.optional:
+                    raw_dtype: Any = param_dict[annot_info.arg]
+                    raw_annot = (
+                        annot_info.origin[raw_dtype]  # type: ignore
+                        if annot_info.origin is not None
+                        else raw_dtype
+                    )
+                    if annot_info.nullable or annot_info.optional:
                         raw_annot = Optional[raw_annot]  # noqa: UP045
                     extra["__annotations__"][field] = raw_annot
                     extra[field] = copy.deepcopy(field_info)
@@ -277,7 +284,8 @@ class DataFrameModel(_DataFrameModel[PySparkFrame, DataFrameSchema]):
                 column_kwargs = (
                     field.column_properties(
                         dtype,
-                        required=not annotation.optional,
+                        nullable=annotation.nullable,
+                        required=not annotation.is_optional_field,
                         checks=field_checks,
                         name=field_name,
                     )

--- a/pandera/api/pyspark/model_components.py
+++ b/pandera/api/pyspark/model_components.py
@@ -44,7 +44,8 @@ def Field(
     ] = None,
     str_matches: str | None = None,
     str_startswith: str | None = None,
-    nullable: bool = False,
+    nullable: bool | None = None,
+    required: bool | None = None,
     unique: bool = False,
     coerce: bool = False,
     regex: bool = False,
@@ -99,6 +100,7 @@ def Field(
     :param str_startswith: Check that the column/index starts with a substring.
         See :func:`~pandera.api.checks.Check.str_startswith` for more information.
     :param nullable: Whether or not the column/index can contain null values.
+    :param required: Whether or not the column is allowed to be missing.
     :param unique: Whether column values should be unique. Currently Not supported
     :param coerce: coerces the data type if ``True``.
     :param regex: whether or not the field name or alias is a regex pattern.
@@ -139,6 +141,7 @@ def Field(
         str_matches=str_matches,
         str_startswith=str_startswith,
         nullable=nullable,
+        required=required,
         unique=unique,
         coerce=coerce,
         regex=regex,

--- a/pandera/api/xarray/model.py
+++ b/pandera/api/xarray/model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 import threading
 import typing
-from typing import Any, ClassVar, cast, get_args, get_origin
+from typing import Any, ClassVar, TypeGuard, cast, get_args, get_origin
 
 import typing_inspect
 
@@ -661,7 +661,7 @@ class DatasetModel(_XarrayModelBase):
         )
 
 
-def _is_dataset_model(cls: Any) -> bool:
+def _is_dataset_model(cls: Any) -> TypeGuard[type[DatasetModel]]:
     return isinstance(cls, type) and issubclass(cls, DatasetModel)
 
 

--- a/pandera/typing/__init__.py
+++ b/pandera/typing/__init__.py
@@ -6,7 +6,7 @@ the typing module.
 
 from functools import lru_cache
 
-from pandera.typing.common import AnnotationInfo
+from pandera.typing.common import AnnotationInfo, FieldType
 
 try:
     from pandera.typing.pandas import (
@@ -121,6 +121,7 @@ def get_index_types():
 
 __all__ = [
     "AnnotationInfo",
+    "FieldType",
     "DataFrame",
     "Series",
     "Index",

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -13,9 +13,11 @@ from typing import (  # type: ignore[attr-defined]
     _GenericAlias,
     get_args,
     get_origin,
+    overload,
 )
 
 import typing_inspect
+from typing_extensions import TypeVarTuple, Unpack
 
 from pandera import dtypes, errors
 
@@ -70,6 +72,8 @@ GenericDtype = TypeVar(  # type: ignore
 )
 
 DataFrameModel = TypeVar("DataFrameModel", bound="DataFrameModel")  # type: ignore
+FieldDtype = TypeVar("FieldDtype")
+FieldMetadata = TypeVarTuple("FieldMetadata")
 
 
 if TYPE_CHECKING:
@@ -183,21 +187,69 @@ class IndexBase(Generic[GenericDtype]):
         raise AttributeError("Indexes should resolve to pa.Index-s")
 
 
+class FieldType(Generic[FieldDtype, Unpack[FieldMetadata]]):
+    """Typing-only descriptor for a :class:`DataFrameModel` field.
+
+    ``FieldType[T]`` describes the dtype consumed by Pandera's runtime model
+    parser while modeling class-level access as the field name. A backend
+    ``pa.Field(...)`` object may be supplied as additional metadata, or as the
+    assigned value of the field.
+
+    The additional type parameters are intentionally variadic so that the
+    runtime parser can accept field metadata without requiring a second type
+    parameter when no metadata is present.
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any):
+        raise TypeError(
+            "pandera.typing.FieldType is for type annotations only; use "
+            "the backend Field function for runtime metadata"
+        )
+
+    @overload
+    def __get__(self, instance: None, owner: type[Any]) -> str: ...
+
+    @overload
+    def __get__(self, instance: object, owner: type[Any]) -> FieldDtype: ...
+
+    def __get__(
+        self, instance: object | None, owner: type[Any]
+    ) -> str | FieldDtype:
+        raise AttributeError(
+            "FieldType should resolve to a DataFrameModel field"
+        )
+
+
+def _is_optional_field_annotation(annotation: Any) -> bool:
+    """Return whether an annotation has optional field presence semantics."""
+    if getattr(annotation, "__metadata__", None):
+        annotation = get_args(annotation)[0]
+    origin = get_origin(annotation)
+    if origin is None or not isinstance(origin, type):
+        return False
+    return issubclass(origin, (SeriesBase, IndexBase, FieldType))
+
+
 class AnnotationInfo:
     """Captures extra information about an annotation.
 
     Attributes:
         origin: The non-parameterized generic class.
         args: All generic types for accessing as an iterable.
-        arg: The first generic type (DataFrameModel does not support more than
-            1 argument).
+        arg: The first generic type. ``FieldType`` may have additional
+            metadata arguments.
         literal: Whether the annotation is a literal.
         optional: Whether the annotation is optional.
+        nullable: Whether the annotation's values are nullable.
+        is_optional_field: Whether an outer ``None`` marks an optional field.
+        is_field: Whether the annotation uses
+            ``pandera.typing.FieldType[T]``.
         raw_annotation: The raw annotation.
-        metadata: Extra arguments passed to :data:`typing.Annotated`.
+        metadata: Extra arguments passed to :data:`typing.Annotated` or
+            ``FieldType``.
     """
 
-    def __init__(self, raw_annotation: type) -> None:
+    def __init__(self, raw_annotation: Any) -> None:
         self._parse_annotation(raw_annotation)
 
     @property
@@ -227,7 +279,7 @@ class AnnotationInfo:
         """True if the annotation wraps a pandera model class."""
         return self.is_generic_df or self.is_generic_xarray
 
-    def _parse_annotation(self, raw_annotation: type) -> None:
+    def _parse_annotation(self, raw_annotation: Any) -> None:
         """Parse key information from annotation.
 
         :param annotation: A subscripted type.
@@ -236,34 +288,94 @@ class AnnotationInfo:
         self.raw_annotation = raw_annotation
         self.origin = self.arg = None
         self.is_annotated_type = False
+        self.is_optional_field = False
+        self.is_field = False
+        self.nullable = False
 
-        self.optional = typing_inspect.is_optional_type(raw_annotation)
-        if self.optional and typing_inspect.is_union_type(raw_annotation):
-            # Annotated with Optional or Union[..., NoneType]
+        is_optional = typing_inspect.is_optional_type(raw_annotation)
+        optional_arg = (
+            get_args(raw_annotation)[0]
+            if is_optional and typing_inspect.is_union_type(raw_annotation)
+            else raw_annotation
+        )
+        self.optional = is_optional
+        self.is_optional_field = is_optional and _is_optional_field_annotation(
+            optional_arg
+        )
+        self.nullable = is_optional and not self.is_optional_field
+        if is_optional and typing_inspect.is_union_type(raw_annotation):
+            # Unwrap Optional or Union[..., NoneType]
             # get_args -> (pandera.typing.Index[str], <class 'NoneType'>)
             raw_annotation = get_args(raw_annotation)[0]
             self.raw_annotation = raw_annotation
+
+        metadata = getattr(raw_annotation, "__metadata__", None)
+        if metadata:
+            self.is_annotated_type = True
+            raw_annotation = get_args(raw_annotation)[0]
 
         self.origin = get_origin(raw_annotation)
         # Replace empty tuple returned from get_args by None
         args = get_args(raw_annotation) or None
         self.args = args
-        self.arg = args[0] if args else args
+        self.arg = (
+            args[0]
+            if args
+            else raw_annotation
+            if self.is_annotated_type
+            else None
+        )
 
-        metadata = getattr(raw_annotation, "__metadata__", None)
-
-        if metadata:
-            self.is_annotated_type = True
-            if self.arg is not None:
-                try:
-                    inspect.signature(self.arg)
-                except ValueError:
+        is_typing_field = (
+            raw_annotation is FieldType or self.origin is FieldType
+        )
+        if metadata and self.arg is not None:
+            try:
+                inspect.signature(self.arg)
+            except (TypeError, ValueError):
+                # Preserve the historical behavior for arbitrary Annotated
+                # metadata that is not a dtype constructor argument.
+                if not is_typing_field:
                     metadata = None
 
-        elif metadata := getattr(self.arg, "__metadata__", None):
+        if not metadata and (
+            nested_metadata := getattr(self.arg, "__metadata__", None)
+        ):
+            metadata = nested_metadata
             self.arg = get_args(self.arg)[0]
 
         self.metadata = metadata
+
+        if is_typing_field:
+            self.is_field = True
+            field_args = get_args(raw_annotation)
+            field_dtype = field_args[0] if field_args else None
+            field_metadata = field_args[1:]
+            self.metadata = tuple(self.metadata or ()) + field_metadata or None
+            if typing_inspect.is_optional_type(
+                field_dtype
+            ) and typing_inspect.is_union_type(field_dtype):
+                self.nullable = True
+                field_dtype = get_args(field_dtype)[0]
+
+            raw_annotation = field_dtype
+            self.raw_annotation = raw_annotation
+            self.origin = get_origin(raw_annotation)
+            self.args = get_args(raw_annotation) or None
+            self.arg = (
+                self.args[0]
+                if self.args
+                else raw_annotation
+                if raw_annotation is not None
+                else None
+            )
+
+        if typing_inspect.is_optional_type(
+            raw_annotation
+        ) and typing_inspect.is_union_type(raw_annotation):
+            self.nullable = True
+            raw_annotation = get_args(raw_annotation)[0]
+            self.raw_annotation = raw_annotation
 
         self.literal = get_origin(self.arg) is typing.Literal
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ dev = [
     "hypothesis >= 6.92.7",
     "ipdb",
     "joblib",
-    "mypy == 1.10.0",
+    "mypy == 1.19.1",
     "nox",
     "pip",
     "polars >= 1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ dev = [
     "python-multipart",
     "pytz",
     "ruff",
+    "ty",
     "uv",
     "uvicorn",
     "xdoctest",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ numpy >= 1.24.4
 pandas >= 2.1.1
 isort >= 5.7.0
 joblib
-mypy == 1.10.0
+mypy == 1.19.1
 pytest
 pytest-cov
 pytest-xdist

--- a/tests/ibis/test_ibis_model.py
+++ b/tests/ibis/test_ibis_model.py
@@ -1,6 +1,6 @@
 """Unit tests for Ibis table model."""
 
-from typing import Annotated, Optional
+from typing import Optional
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -9,6 +9,7 @@ import pytest
 import pandera.ibis as pa
 from pandera.errors import SchemaError
 from pandera.ibis import Column, DataFrameModel, DataFrameSchema
+from pandera.typing import FieldType
 
 
 @pytest.fixture
@@ -39,34 +40,99 @@ def test_model_schema_equivalency(
     assert t_model_basic.to_schema() == t_schema_basic
 
 
-def test_model_schema_equivalency_with_optional():
-    class ModelWithOptional(DataFrameModel):
+def test_model_schema_equivalency_with_nullable():
+    class ModelWithNullable(DataFrameModel):
         string_col: str | None
         int_col: int
 
     schema = DataFrameSchema(
-        name="ModelWithOptional",
+        name="ModelWithNullable",
         columns={
-            "string_col": Column(dt.String, required=False),
+            "string_col": Column(dt.String, nullable=True),
             "int_col": Column(dt.Int64),
         },
     )
-    assert ModelWithOptional.to_schema() == schema
+    assert ModelWithNullable.to_schema() == schema
 
 
-def test_annotated_field_metadata_propagation():
-    """``Annotated[T, pa.Field(...)]`` should propagate the embedded
-    ``FieldInfo`` metadata (description, title, unique, checks, etc.) to
+def test_field_type_presence_and_nullability():
+    """Test the ``FieldType`` presence and nullability contract."""
+
+    class Model(DataFrameModel):
+        required: dt.Int64
+        nullable_values: dt.Int64 | None
+        optional_presence: FieldType[dt.Int64] | None
+        explicit_nullable: dt.Int64 | None = pa.Field(nullable=False)
+
+    schema = Model.to_schema()
+    assert schema.columns["required"].dtype == Column(dt.Int64).dtype
+    assert schema.columns["required"].required
+    assert not schema.columns["required"].nullable
+    assert schema.columns["nullable_values"].required
+    assert schema.columns["nullable_values"].nullable
+    assert not schema.columns["optional_presence"].required
+    assert not schema.columns["explicit_nullable"].nullable
+    assert Model.required == "required"
+    assert isinstance(Model.optional_presence, str)
+
+
+def test_field_type_contract():
+    """The typing-only field marker composes with runtime field metadata."""
+
+    class Model(DataFrameModel):
+        checked: FieldType[
+            dt.Int64,
+            pa.Field(
+                alias="renamed",
+                description="checked field",
+                metadata={"source": "typing-field"},
+                title="Checked",
+                unique=True,
+                gt=0,
+            ),
+        ]
+        nullable: FieldType[dt.Int64 | None, pa.Field()]
+        optional: FieldType[dt.String] | None
+        optional_metadata: FieldType[dt.String, pa.Field(required=False)]
+        assigned: FieldType[dt.Int64] = pa.Field(description="assigned")
+
+    schema = Model.to_schema()
+    checked = schema.columns["renamed"]
+    assert checked.required
+    assert not checked.nullable
+    assert checked.description == "checked field"
+    assert checked.metadata == {"source": "typing-field"}
+    assert checked.title == "Checked"
+    assert checked.unique
+    assert checked.checks
+    assert schema.columns["nullable"].required
+    assert schema.columns["nullable"].nullable
+    assert not schema.columns["optional"].required
+    assert not schema.columns["optional_metadata"].required
+    assert schema.columns["assigned"].description == "assigned"
+    assert Model.checked == "renamed"
+
+    valid = ibis.memtable({"renamed": [1], "nullable": [1], "assigned": [2]})
+    Model.validate(valid)
+    with pytest.raises(SchemaError):
+        Model.validate(
+            ibis.memtable({"renamed": [0], "nullable": [1], "assigned": [2]})
+        )
+
+
+def test_field_type_metadata_propagation():
+    """``FieldType[T, pa.Field(...)]`` should propagate field metadata
+    (description, title, unique, checks, etc.) to
     the ibis schema. See
     https://github.com/unionai-oss/pandera/issues/2110.
     """
 
     class Schema(DataFrameModel):
-        name: Annotated[str, pa.Field(description="Name of the person")]
+        name: FieldType[str, pa.Field(description="Name of the person")]
         age: int = pa.Field(ge=0, description="Age of the person")
-        val: Annotated[float, pa.Field(ge=0.0, description="A value")]
-        identifier: Annotated[int, pa.Field(unique=True, title="Identifier")]
-        tag: Annotated[str, pa.Field(metadata={"k": "v"})]
+        val: FieldType[float, pa.Field(ge=0.0, description="A value")]
+        identifier: FieldType[int, pa.Field(unique=True, title="Identifier")]
+        tag: FieldType[str, pa.Field(metadata={"k": "v"})]
 
     schema = Schema.to_schema()
 
@@ -77,7 +143,7 @@ def test_annotated_field_metadata_propagation():
     assert schema.columns["identifier"].title == "Identifier"
     assert schema.columns["tag"].metadata == {"k": "v"}
 
-    # ``ge`` check defined inside the Annotated FieldInfo should also
+    # ``ge`` check defined inside the FieldType metadata should also
     # be applied during validation.
     valid = ibis.memtable(
         {
@@ -103,18 +169,14 @@ def test_annotated_field_metadata_propagation():
         Schema.validate(invalid)
 
 
-def test_annotated_field_no_metadata_dedup():
-    """Two ``Annotated`` annotations using independent ``pa.Field(...)``
-    calls must not be deduplicated by Python's ``typing.Annotated`` cache.
-    Without unique hashing on un-named ``FieldInfo`` instances, the second
-    model would inadvertently inherit the first model's field configuration.
-    """
+def test_field_type_metadata_no_dedup():
+    """Independent ``FieldType`` metadata objects must remain distinct."""
 
     class ModelA(DataFrameModel):
-        value: Annotated[int, pa.Field(ge=18, le=100)]
+        value: FieldType[int, pa.Field(ge=18, le=100)]
 
     class ModelB(DataFrameModel):
-        value: Annotated[int, pa.Field(unique=True, title="ID")]
+        value: FieldType[int, pa.Field(unique=True, title="ID")]
 
     schema_a = ModelA.to_schema()
     schema_b = ModelB.to_schema()

--- a/tests/mypy/polars_modules/polars_model_typing_field_type.py
+++ b/tests/mypy/polars_modules/polars_model_typing_field_type.py
@@ -1,0 +1,25 @@
+"""No-plugin static coverage for ``pandera.typing.FieldType``."""
+
+import polars as pl
+
+import pandera.polars as pa
+from pandera.typing import FieldType
+
+
+class Schema(pa.DataFrameModel):
+    required: FieldType[pl.List] = pa.Field()
+    nullable_values: FieldType[int | None] = pa.Field()
+    optional_presence: FieldType[int] | None
+    optional_assignment: FieldType[int] = pa.Field(required=False)
+
+
+def accepts_name(name: str) -> str:
+    return name
+
+
+required_name: str = Schema.required
+nullable_name: str = Schema.nullable_values
+required_names: list[str] = [Schema.required, Schema.nullable_values]
+accepted_name: str = accepts_name(Schema.required)
+optional_name: str | None = Schema.optional_presence
+optional_assignment_name: str = Schema.optional_assignment

--- a/tests/mypy/test_polars_static_type_checking.py
+++ b/tests/mypy/test_polars_static_type_checking.py
@@ -103,3 +103,25 @@ def test_mypy_polars_column_parametrized_dtypes() -> None:
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ty_polars_typing_field_type_no_plugin() -> None:
+    """Check the public ``FieldType`` descriptor with ty and no plugin."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ty",
+            "check",
+            str(
+                test_module_dir
+                / "polars_modules"
+                / "polars_model_typing_field_type.py"
+            ),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -7,17 +7,19 @@ from collections.abc import Iterable
 from copy import deepcopy
 from enum import Enum
 from typing import Annotated, Any, Generic, Optional, TypeVar
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
 
+import pandera.api.dataframe.model as dataframe_model
 import pandera.api.extensions as pax
 import pandera.pandas as pa
 from pandera.api.base.model import MetaModel
 from pandera.errors import SchemaError, SchemaInitError
-from pandera.typing import DataFrame, Index, Series, String
+from pandera.typing import DataFrame, FieldType, Index, Series, String
 from pandera.typing import pandas as pandas_typing
 
 
@@ -116,6 +118,204 @@ def test_schema_with_bare_types():
     )
 
     assert expected == Model.to_schema()
+
+
+def test_field_type_presence_and_nullability() -> None:
+    """Test the ``FieldType`` presence and nullability contract."""
+
+    class Model(pa.DataFrameModel):
+        required: int
+        nullable_values: int | None
+        optional_presence: FieldType[int] | None
+        explicit_nullable: int | None = pa.Field(nullable=False)
+        explicit_non_nullable: int = pa.Field(nullable=True)
+        aliased: str = pa.Field(alias="renamed")
+
+    schema = Model.to_schema()
+
+    assert schema.columns["required"].dtype == pa.Column(int).dtype
+    assert schema.columns["required"].required
+    assert not schema.columns["required"].nullable
+
+    assert schema.columns["nullable_values"].dtype == pa.Column(int).dtype
+    assert schema.columns["nullable_values"].required
+    assert schema.columns["nullable_values"].nullable
+
+    assert not schema.columns["optional_presence"].required
+    assert not schema.columns["optional_presence"].nullable
+
+    assert not schema.columns["explicit_nullable"].nullable
+    assert schema.columns["explicit_non_nullable"].nullable
+    assert Model.aliased == "renamed"
+    for name in (
+        Model.required,
+        Model.nullable_values,
+        Model.optional_presence,
+    ):
+        assert isinstance(name, str)
+
+
+def test_field_type_contract() -> None:
+    """The typing-only field marker composes with runtime field metadata."""
+
+    class Model(pa.DataFrameModel):
+        checked: FieldType[  # type: ignore[valid-type]
+            int,
+            pa.Field(
+                alias="renamed",
+                description="checked field",
+                metadata={"source": "typing-field"},
+                title="Checked",
+                unique=True,
+                gt=0,
+            ),
+        ]
+        nullable: FieldType[int | None, pa.Field()]  # type: ignore[valid-type]
+        optional: FieldType[str] | None
+        required_override: FieldType[int] | None = pa.Field(required=True)
+        assigned: FieldType[int] = pa.Field(description="assigned")
+
+    schema = Model.to_schema()
+    checked = schema.columns["renamed"]
+    assert checked.required
+    assert not checked.nullable
+    assert checked.description == "checked field"
+    assert checked.metadata == {"source": "typing-field"}
+    assert checked.title == "Checked"
+    assert checked.unique
+    assert checked.checks
+    assert schema.columns["nullable"].required
+    assert schema.columns["nullable"].nullable
+    assert not schema.columns["optional"].required
+    assert schema.columns["required_override"].required
+    assert schema.columns["assigned"].description == "assigned"
+    assert Model.checked == "renamed"
+
+    valid = pd.DataFrame(
+        {
+            "renamed": [1],
+            "nullable": pd.Series([1, None], dtype="Int64").iloc[:1],
+            "required_override": [3],
+            "assigned": [2],
+        }
+    )
+    Model.validate(valid)
+    with pytest.raises(SchemaError):
+        Model.validate(valid.assign(renamed=[0]))
+
+
+def test_field_type_metadata_with_postponed_annotation() -> None:
+    """Embedded metadata survives annotations evaluated after class creation."""
+
+    class Model(pa.DataFrameModel):
+        # Static checkers reject value expressions inside type arguments; this
+        # test intentionally exercises postponed runtime evaluation.
+        embedded: "FieldType[int, pa.Field(description='embedded')]"  # type: ignore[valid-type]
+
+    assert Model.to_schema().columns["embedded"].description == "embedded"
+
+
+def test_field_type_metadata_with_unresolved_annotation() -> None:
+    """Install fields when postponed annotation evaluation is unavailable."""
+    get_annotations = dataframe_model.inspect.get_annotations
+
+    def unresolved_annotations(
+        cls: type, *, eval_str: bool = False
+    ) -> dict[str, object]:
+        if eval_str:
+            raise NameError("unresolved annotation")
+        return get_annotations(cls, eval_str=eval_str)
+
+    with patch.object(
+        dataframe_model.inspect,
+        "get_annotations",
+        unresolved_annotations,
+    ):
+
+        class Model(pa.DataFrameModel):
+            value: FieldType[int]
+
+    assert Model.to_schema().columns["value"].dtype == pa.Column(int).dtype
+
+
+def test_field_type_annotated_metadata() -> None:
+    """FieldType remains compatible with embedded Annotated metadata."""
+
+    class Model(pa.DataFrameModel):
+        value: Annotated[FieldType[int], pa.Field(description="annotated")]
+
+    assert Model.to_schema().columns["value"].description == "annotated"
+
+
+def test_field_type_requires_a_dtype_parameter() -> None:
+    """The typing-only marker cannot be used as an unparameterized dtype."""
+
+    with pytest.raises(TypeError):
+        FieldType()
+
+    class DescriptorField(FieldType[int]):
+        pass
+
+    descriptor = object.__new__(DescriptorField)
+    with pytest.raises(AttributeError, match="should resolve"):
+        descriptor.__get__(None, pa.DataFrameModel)
+
+    class Invalid(pa.DataFrameModel):
+        value: FieldType
+
+    with pytest.raises(SchemaInitError, match="must be parameterized"):
+        Invalid.to_schema()
+
+
+def test_field_type_metadata_and_inheritance() -> None:
+    """Test ``FieldType`` metadata and inherited fields."""
+
+    class Parent(pa.DataFrameModel):
+        inherited: FieldType[  # type: ignore[valid-type]
+            int, pa.Field(description="inherited")
+        ]
+        overridden: FieldType[  # type: ignore[valid-type]
+            int, pa.Field(description="parent")
+        ]
+
+    class Child(Parent):
+        overridden: FieldType[  # type: ignore[valid-type]
+            int, pa.Field(description="overridden")
+        ]
+        annotated: FieldType[  # type: ignore[valid-type]
+            str, pa.Field(alias="annotated_name", title="Annotated")
+        ]
+        optional: FieldType[  # type: ignore[valid-type]
+            int, pa.Field(description="optional", required=False)
+        ]
+
+    schema = Child.to_schema()
+    assert schema.columns["inherited"].description == "inherited"
+    assert schema.columns["overridden"].description == "overridden"
+    assert schema.columns["annotated_name"].title == "Annotated"
+    assert schema.columns["optional"].description == "optional"
+    assert not schema.columns["optional"].required
+    assert Child.inherited == "inherited"
+    assert Child.annotated == "annotated_name"
+
+
+def test_index_field_nullable_override() -> None:
+    """Explicit index nullability is passed to the runtime schema."""
+
+    class Model(pa.DataFrameModel):
+        index: Index[int] = pa.Field(nullable=True)
+
+    assert Model.to_schema().index.nullable
+
+
+def test_nullable_annotation_coercion() -> None:
+    """Inferred nullability must also guide pandas dtype coercion."""
+
+    class Model(pa.DataFrameModel):
+        value: int | None = pa.Field(coerce=True)
+
+    validated = Model.validate(pd.DataFrame({"value": [1, None]}))
+    assert validated["value"].isna().sum() == 1
 
 
 def test_empty_schema() -> None:
@@ -2004,6 +2204,20 @@ def test_generic_optional_field() -> None:
     FloatYModel.validate(pd.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}))
 
 
+def test_generic_nullable_field() -> None:
+    """Preserve nullable values through generic substitution."""
+    T = TypeVar("T", int, float, str)
+
+    class GenericModel(pa.DataFrameModel, Generic[T]):
+        value: T | None
+
+    class IntModel(GenericModel[int]): ...
+
+    column = IntModel.to_schema().columns["value"]
+    assert column.dtype == pa.Column(int).dtype
+    assert column.nullable
+
+
 def test_generic_model_multiple_inheritance() -> None:
     T = TypeVar("T", int, float, str)
 
@@ -2150,20 +2364,21 @@ def test_pandas_fields_metadata():
     assert PanderaSchema.get_metadata() == expected
 
 
-def test_annotated_field_metadata_propagation():
-    """``Annotated[T, pa.Field(...)]`` should propagate the embedded
-    ``FieldInfo`` metadata (description, title, unique, checks, etc.) to
+def test_field_type_metadata_propagation():
+    """``FieldType[T, pa.Field(...)]`` should propagate field metadata
+    (description, title, unique, checks, etc.) to
     the resulting schema. See https://github.com/unionai-oss/pandera/issues/2110.
     """
 
     class Schema(pa.DataFrameModel):
-        name: Annotated[str, pa.Field(description="Name of the person")]
+        name: FieldType[str, pa.Field(description="Name of the person")]
         age: int = pa.Field(ge=0, description="Age of the person")
-        month: Annotated[
-            int, pa.Field(ge=1, le=12, description="Month of the year")
+        month: FieldType[
+            int,
+            pa.Field(ge=1, le=12, description="Month of the year"),
         ]
-        identifier: Annotated[int, pa.Field(unique=True, title="Identifier")]
-        tag: Annotated[str, pa.Field(metadata={"k": "v"})]
+        identifier: FieldType[int, pa.Field(unique=True, title="Identifier")]
+        tag: FieldType[str, pa.Field(metadata={"k": "v"})]
 
     schema = Schema.to_schema()
 
@@ -2174,7 +2389,7 @@ def test_annotated_field_metadata_propagation():
     assert schema.columns["identifier"].title == "Identifier"
     assert schema.columns["tag"].metadata == {"k": "v"}
 
-    # ``ge``/``le`` checks defined inside the Annotated FieldInfo should
+    # ``ge``/``le`` checks defined inside the FieldType metadata should
     # also be applied during validation.
     valid = pd.DataFrame(
         {
@@ -2193,18 +2408,14 @@ def test_annotated_field_metadata_propagation():
         Schema.validate(invalid)
 
 
-def test_annotated_field_no_metadata_dedup():
-    """Two ``Annotated`` annotations using independent ``pa.Field(...)``
-    calls must not be deduplicated by Python's ``typing.Annotated`` cache.
-    Without unique hashing on un-named ``FieldInfo`` instances, the second
-    model would inadvertently inherit the first model's field configuration.
-    """
+def test_field_type_metadata_no_dedup():
+    """Independent ``FieldType`` metadata objects must remain distinct."""
 
     class ModelA(pa.DataFrameModel):
-        value: Annotated[int, pa.Field(ge=18, le=100)]
+        value: FieldType[int, pa.Field(ge=18, le=100)]
 
     class ModelB(pa.DataFrameModel):
-        value: Annotated[int, pa.Field(unique=True, title="ID")]
+        value: FieldType[int, pa.Field(unique=True, title="ID")]
 
     schema_a = ModelA.to_schema()
     schema_b = ModelB.to_schema()
@@ -2216,14 +2427,11 @@ def test_annotated_field_no_metadata_dedup():
     assert schema_b.columns["value"].checks == []
 
 
-def test_annotated_field_explicit_assignment_wins():
-    """When a field is annotated with ``Annotated[T, pa.Field(...)]`` and
-    also explicitly assigned a ``pa.Field(...)``, the explicit assignment
-    takes precedence.
-    """
+def test_field_type_explicit_assignment_wins():
+    """An explicit ``pa.Field(...)`` assignment takes precedence."""
 
     class Schema(pa.DataFrameModel):
-        value: Annotated[int, pa.Field(description="from annotated")] = (
+        value: FieldType[int, pa.Field(description="from metadata")] = (
             pa.Field(description="from assignment")
         )
 

--- a/tests/pandas/test_model_components.py
+++ b/tests/pandas/test_model_components.py
@@ -21,6 +21,15 @@ def test_field_to_column() -> None:
             assert col.required == value
 
 
+def test_field_required_override() -> None:
+    """Explicit ``required`` metadata overrides inferred presence."""
+    for value in [True, False]:
+        col_kwargs = pa.Field(required=value).column_properties(
+            pa.DateTime, required=not value
+        )
+        assert pa.Column(**col_kwargs).required == value
+
+
 def test_field_to_index() -> None:
     """Test that Field outputs the correct index options."""
     for flag in ["nullable", "unique"]:

--- a/tests/pandas/test_typing.py
+++ b/tests/pandas/test_typing.py
@@ -1,7 +1,7 @@
 """Test typing annotations for the model api."""
 
 import re
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,7 @@ import pytest
 import pandera.pandas as pa
 from pandera.api.pandas.model import _get_nullable_coercion_dtype
 from pandera.dtypes import DataType
-from pandera.typing import DataFrame, Index, Series
+from pandera.typing import AnnotationInfo, DataFrame, Index, Series
 
 try:  # python 3.9+
     from typing import Annotated  # type: ignore
@@ -394,6 +394,23 @@ def test_invalid_annotated_dtype():
     )
     with pytest.raises(TypeError, match=err_msg):
         SchemaInvalidAnnotatedDtype.to_schema()
+
+
+def test_annotation_info_metadata_and_literal_annotations() -> None:
+    """Parse nested metadata, nullable values, and literal dtypes."""
+    optional_series = AnnotationInfo(Annotated[Series[int], "metadata"] | None)
+    assert optional_series.optional
+    assert optional_series.is_optional_field
+
+    nullable = AnnotationInfo(Annotated[int | None, "metadata"])
+    assert nullable.nullable
+
+    annotated_literal = AnnotationInfo(Annotated[Literal["value"], "metadata"])
+    assert annotated_literal.arg == "value"
+
+    literal = AnnotationInfo(Series[Literal["value"]])
+    assert literal.literal
+    assert literal.arg == "value"
 
 
 class SchemaRedundantField(pa.DataFrameModel):

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -30,6 +30,7 @@ from pandera.polars import (
     check,
     dataframe_check,
 )
+from pandera.typing import FieldType
 
 
 @pytest.fixture
@@ -143,19 +144,103 @@ def test_model_schema_equivalency(
     assert ldf_model_basic.to_schema() == ldf_schema_basic
 
 
-def test_model_schema_equivalency_with_optional():
-    class ModelWithOptional(DataFrameModel):
+def test_model_schema_equivalency_with_nullable():
+    class ModelWithNullable(DataFrameModel):
         string_col: str | None
         int_col: int
 
     schema = DataFrameSchema(
-        name="ModelWithOptional",
+        name="ModelWithNullable",
         columns={
-            "string_col": Column(pl.Utf8, required=False),
+            "string_col": Column(pl.Utf8, nullable=True),
             "int_col": Column(pl.Int64),
         },
     )
-    assert ModelWithOptional.to_schema() == schema
+    assert ModelWithNullable.to_schema() == schema
+
+
+def test_field_type_presence_and_nullability():
+    """Test the ``FieldType`` presence and nullability contract."""
+
+    class Model(DataFrameModel):
+        items: pl.List
+        nullable_values: int | None
+        optional_presence: FieldType[int] | None
+        explicit_nullable: int | None = Field(nullable=False)
+
+    schema = Model.to_schema()
+    assert schema.columns["items"].dtype == Column(pl.List).dtype
+    assert schema.columns["nullable_values"].nullable
+    assert schema.columns["nullable_values"].required
+    assert not schema.columns["optional_presence"].required
+    assert not schema.columns["optional_presence"].nullable
+    assert not schema.columns["explicit_nullable"].nullable
+    assert Model.items == "items"
+    assert isinstance(Model.optional_presence, str)
+
+
+def test_field_type_contract():
+    """The typing-only field marker composes with runtime field metadata."""
+
+    class Model(DataFrameModel):
+        checked: FieldType[
+            int,
+            Field(
+                alias="renamed",
+                description="checked field",
+                metadata={"source": "typing-field"},
+                title="Checked",
+                unique=True,
+                gt=0,
+            ),
+        ]
+        nullable: FieldType[int | None, Field()]
+        optional: FieldType[str] | None
+        assigned: FieldType[int] = Field(description="assigned")
+
+    schema = Model.to_schema()
+    checked = schema.columns["renamed"]
+    assert checked.required
+    assert not checked.nullable
+    assert checked.description == "checked field"
+    assert checked.metadata == {"source": "typing-field"}
+    assert checked.title == "Checked"
+    assert checked.unique
+    assert checked.checks
+    assert schema.columns["nullable"].required
+    assert schema.columns["nullable"].nullable
+    assert not schema.columns["optional"].required
+    assert schema.columns["assigned"].description == "assigned"
+    assert Model.checked == "renamed"
+
+    valid = pl.DataFrame({"renamed": [1], "nullable": [1], "assigned": [2]})
+    Model.validate(valid)
+    with pytest.raises(SchemaError):
+        Model.validate(valid.with_columns(pl.lit(0).alias("renamed")))
+
+
+def test_field_type_metadata_and_inheritance():
+    """Test ``FieldType`` metadata and inheritance with Polars."""
+
+    class Parent(DataFrameModel):
+        inherited: FieldType[int, Field(description="inherited")]
+        overridden: FieldType[int, Field(description="parent")]
+
+    class Child(Parent):
+        overridden: FieldType[int, Field(description="overridden")]
+        annotated: FieldType[
+            str, Field(alias="annotated_name", title="Annotated")
+        ]
+        optional: FieldType[int, Field(description="optional", required=False)]
+
+    schema = Child.to_schema()
+    assert schema.columns["inherited"].description == "inherited"
+    assert schema.columns["overridden"].description == "overridden"
+    assert schema.columns["annotated_name"].title == "Annotated"
+    assert schema.columns["optional"].description == "optional"
+    assert not schema.columns["optional"].required
+    assert Child.inherited == "inherited"
+    assert Child.annotated == "annotated_name"
 
 
 @pytest.mark.parametrize(
@@ -371,19 +456,19 @@ def test_model_field_access_returns_string():
     assert ModelWithBareTypes.y == "y"
 
 
-def test_annotated_field_metadata_propagation():
-    """``Annotated[T, pa.Field(...)]`` should propagate the embedded
-    ``FieldInfo`` metadata (description, title, unique, checks, etc.) to
+def test_field_type_metadata_propagation():
+    """``FieldType[T, pa.Field(...)]`` should propagate field metadata
+    (description, title, unique, checks, etc.) to
     the polars schema. See
     https://github.com/unionai-oss/pandera/issues/2110.
     """
 
     class Schema(DataFrameModel):
-        name: Annotated[str, Field(description="Name of the person")]
+        name: FieldType[str, Field(description="Name of the person")]
         age: int = Field(ge=0, description="Age of the person")
-        val: Annotated[float, Field(ge=0.0, description="A value")]
-        identifier: Annotated[int, Field(unique=True, title="Identifier")]
-        tag: Annotated[str, Field(metadata={"k": "v"})]
+        val: FieldType[float, Field(ge=0.0, description="A value")]
+        identifier: FieldType[int, Field(unique=True, title="Identifier")]
+        tag: FieldType[str, Field(metadata={"k": "v"})]
 
     schema = Schema.to_schema()
 
@@ -394,7 +479,7 @@ def test_annotated_field_metadata_propagation():
     assert schema.columns["identifier"].title == "Identifier"
     assert schema.columns["tag"].metadata == {"k": "v"}
 
-    # ``ge`` check defined inside the Annotated FieldInfo should also
+    # ``ge`` check defined inside the FieldType metadata should also
     # be applied during validation.
     valid = pl.DataFrame(
         {
@@ -412,18 +497,14 @@ def test_annotated_field_metadata_propagation():
         Schema.validate(invalid)
 
 
-def test_annotated_field_no_metadata_dedup():
-    """Two ``Annotated`` annotations using independent ``Field(...)``
-    calls must not be deduplicated by Python's ``typing.Annotated`` cache.
-    Without unique hashing on un-named ``FieldInfo`` instances, the second
-    model would inadvertently inherit the first model's field configuration.
-    """
+def test_field_type_metadata_no_dedup():
+    """Independent ``FieldType`` metadata objects must remain distinct."""
 
     class ModelA(DataFrameModel):
-        value: Annotated[int, Field(ge=18, le=100)]
+        value: FieldType[int, Field(ge=18, le=100)]
 
     class ModelB(DataFrameModel):
-        value: Annotated[int, Field(unique=True, title="ID")]
+        value: FieldType[int, Field(unique=True, title="ID")]
 
     schema_a = ModelA.to_schema()
     schema_b = ModelB.to_schema()

--- a/tests/pyarrow/test_pyarrow_model.py
+++ b/tests/pyarrow/test_pyarrow_model.py
@@ -5,6 +5,7 @@ import pytest
 
 import pandera.pyarrow as pa
 from pandera.errors import SchemaError
+from pandera.typing import FieldType
 from pandera.typing.pyarrow import Table
 
 
@@ -17,6 +18,75 @@ def test_model_to_schema():
     schema = SimpleModel.to_schema()
     assert isinstance(schema, pa.DataFrameSchema)
     assert list(schema.columns) == ["int_col", "str_col"]
+
+
+def test_model_field_type_presence_and_nullability():
+    """Test the ``FieldType`` presence and nullability contract."""
+
+    class Model(pa.DataFrameModel):
+        required: int
+        nullable_values: int | None
+        optional_presence: FieldType[int] | None
+        explicit_nullable: int | None = pa.Field(nullable=False)
+
+    schema = Model.to_schema()
+    assert schema.columns["required"].dtype == pa.Column(int).dtype
+    assert schema.columns["required"].required
+    assert not schema.columns["required"].nullable
+    assert schema.columns["nullable_values"].required
+    assert schema.columns["nullable_values"].nullable
+    assert not schema.columns["optional_presence"].required
+    assert not schema.columns["explicit_nullable"].nullable
+    assert Model.required == "required"
+    assert isinstance(Model.optional_presence, str)
+
+
+def test_field_type_contract():
+    """The typing-only field marker composes with runtime field metadata."""
+
+    class Model(pa.DataFrameModel):
+        checked: FieldType[
+            int,
+            pa.Field(
+                alias="renamed",
+                description="checked field",
+                metadata={"source": "typing-field"},
+                title="Checked",
+                unique=True,
+                gt=0,
+            ),
+        ]
+        nullable: FieldType[int | None, pa.Field()]
+        optional: FieldType[str] | None
+        optional_metadata: FieldType[str, pa.Field(required=False)]
+        assigned: FieldType[int] = pa.Field(description="assigned")
+
+    schema = Model.to_schema()
+    checked = schema.columns["renamed"]
+    assert checked.required
+    assert not checked.nullable
+    assert checked.description == "checked field"
+    assert checked.metadata == {"source": "typing-field"}
+    assert checked.title == "Checked"
+    assert checked.unique
+    assert checked.checks
+    assert schema.columns["nullable"].required
+    assert schema.columns["nullable"].nullable
+    assert not schema.columns["optional"].required
+    assert not schema.columns["optional_metadata"].required
+    assert schema.columns["assigned"].description == "assigned"
+    assert Model.checked == "renamed"
+
+    valid = pyarrow.table(
+        {
+            "renamed": [1],
+            "nullable": pyarrow.array([1], type=pyarrow.int64()),
+            "assigned": [2],
+        }
+    )
+    Model.validate(valid)
+    with pytest.raises(SchemaError):
+        Model.validate(valid.set_column(0, "renamed", pyarrow.array([0])))
 
 
 def test_model_validate():
@@ -44,7 +114,7 @@ def test_model_with_field_checks():
 def test_model_optional_column():
     class WithOptional(pa.DataFrameModel):
         a: int
-        b: str | None
+        b: FieldType[str] | None
 
     # 'b' is optional, so a table without it validates...
     tbl = pyarrow.table({"a": [1]})

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -2,7 +2,7 @@
 
 import decimal
 from contextlib import nullcontext as does_not_raise
-from typing import Annotated, Optional
+from typing import Generic, Optional, TypeVar
 
 import pyspark.sql.types as T
 import pytest
@@ -14,8 +14,13 @@ import pandera.pyspark as pa
 from pandera.api.checks import Check
 from pandera.api.pyspark.model import docstring_substitution
 from pandera.config import CONFIG, PanderaConfig, ValidationDepth
-from pandera.errors import SchemaDefinitionError, SchemaError, SchemaErrors
+from pandera.errors import (
+    SchemaDefinitionError,
+    SchemaError,
+    SchemaErrors,
+)
 from pandera.pyspark import DataFrameModel, DataFrameSchema, Field
+from pandera.typing import FieldType
 from tests.pyspark.conftest import spark_df, validate_collecting_errors
 
 pytestmark = pytest.mark.parametrize(
@@ -49,6 +54,88 @@ def test_schema_with_bare_types(
     )
 
     assert expected == Model.to_schema()
+
+
+def test_field_type_presence_and_nullability(spark_session):
+    """Test the ``FieldType`` presence and nullability contract."""
+
+    class Model(DataFrameModel):
+        required: T.IntegerType
+        nullable_values: T.IntegerType | None
+        nullable_with_omitted_field: T.IntegerType | None = Field()
+        optional_presence: FieldType[T.IntegerType] | None
+        explicit_nullable: T.IntegerType | None = Field(nullable=False)
+
+    schema = Model.to_schema()
+    assert schema.columns["required"].dtype == pa.Column(T.IntegerType()).dtype
+    assert schema.columns["required"].required
+    assert not schema.columns["required"].nullable
+    assert schema.columns["nullable_values"].required
+    assert schema.columns["nullable_values"].nullable
+    assert schema.columns["nullable_with_omitted_field"].nullable
+    assert not schema.columns["optional_presence"].required
+    assert not schema.columns["explicit_nullable"].nullable
+    assert Model.required == "required"
+    assert isinstance(Model.optional_presence, str)
+
+
+def test_field_type_contract(spark_session):
+    """The typing-only field marker composes with runtime field metadata."""
+
+    class Model(DataFrameModel):
+        checked: FieldType[
+            T.IntegerType,
+            Field(
+                alias="renamed",
+                description="checked field",
+                metadata={"source": "typing-field"},
+                title="Checked",
+                gt=0,
+            ),
+        ]
+        nullable: FieldType[T.IntegerType | None, Field()]
+        optional: FieldType[T.StringType] | None
+        assigned: FieldType[T.IntegerType] = Field(description="assigned")
+
+    schema = Model.to_schema()
+    checked = schema.columns["renamed"]
+    assert checked.required
+    assert not checked.nullable
+    assert checked.description == "checked field"
+    assert checked.metadata == {"source": "typing-field"}
+    assert checked.title == "Checked"
+    assert checked.checks
+    assert schema.columns["nullable"].required
+    assert schema.columns["nullable"].nullable
+    assert not schema.columns["optional"].required
+    assert schema.columns["assigned"].description == "assigned"
+    assert Model.checked == "renamed"
+
+
+def test_generic_nullable_field(spark_session):
+    """Preserve nullable values through PySpark generic substitution."""
+    Dtype = TypeVar("Dtype")
+
+    class GenericModel(DataFrameModel, Generic[Dtype]):
+        value: Dtype | None
+
+    class IntegerModel(GenericModel[T.IntegerType]): ...
+
+    schema = IntegerModel.to_schema()
+    assert schema.columns["value"].nullable
+
+
+def test_generic_non_nullable_field(spark_session):
+    """Preserve non-nullable values through PySpark generic substitution."""
+    Dtype = TypeVar("Dtype")
+
+    class GenericModel(DataFrameModel, Generic[Dtype]):
+        value: Dtype
+
+    class IntegerModel(GenericModel[T.IntegerType]): ...
+
+    schema = IntegerModel.to_schema()
+    assert not schema.columns["value"].nullable
 
 
 def test_schema_with_bare_types_and_field(
@@ -146,22 +233,22 @@ def test_schema_with_bare_types_field_type(spark_session, request):
     assert errors is not None
 
 
-def test_annotated_field_metadata_propagation(spark_session, request):
-    """``Annotated[T, pa.Field(...)]`` should propagate the embedded
-    ``FieldInfo`` metadata (description, title, checks, etc.) to the
+def test_field_type_metadata_propagation(spark_session, request):
+    """``FieldType[T, pa.Field(...)]`` should propagate field metadata
+    (description, title, checks, etc.) to the
     pyspark schema. See
     https://github.com/unionai-oss/pandera/issues/2110.
     """
 
     class ProductsModel(DataFrameModel):
-        """Test schema using ``typing.Annotated`` for metadata."""
+        """Test schema using ``FieldType`` for metadata."""
 
-        product_id: Annotated[T.IntegerType, Field(title="Product ID")]
-        product_name: Annotated[
+        product_id: FieldType[T.IntegerType, Field(title="Product ID")]
+        product_name: FieldType[
             T.StringType, Field(description="Product name")
         ]
-        price: Annotated[T.DoubleType, Field(gt=0.0, description="Unit price")]
-        list_price: Annotated[
+        price: FieldType[T.DoubleType, Field(gt=0.0, description="Unit price")]
+        list_price: FieldType[
             T.DecimalType, 20, 5, Field(description="Listed price")
         ]
 
@@ -173,16 +260,14 @@ def test_annotated_field_metadata_propagation(spark_session, request):
     assert isinstance(schema.columns["list_price"].dtype.type, T.DecimalType)
 
 
-def test_annotated_field_no_metadata_dedup(spark_session, request):
-    """Two ``Annotated`` annotations using independent ``Field(...)``
-    calls must not be deduplicated by Python's ``typing.Annotated`` cache.
-    """
+def test_field_type_metadata_no_dedup(spark_session, request):
+    """Independent ``FieldType`` metadata objects must remain distinct."""
 
     class ModelA(DataFrameModel):
-        value: Annotated[T.IntegerType, Field(gt=18)]
+        value: FieldType[T.IntegerType, Field(gt=18)]
 
     class ModelB(DataFrameModel):
-        value: Annotated[T.IntegerType, Field(title="ID")]
+        value: FieldType[T.IntegerType, Field(title="ID")]
 
     schema_a = ModelA.to_schema()
     schema_b = ModelB.to_schema()
@@ -547,9 +632,9 @@ def test_schema():
     class Schema(pa.DataFrameModel):
         """Simple DataFrameModel containing optional columns."""
 
-        a: str | None
-        b: str | None = pa.Field(eq="b")
-        c: str | None  # test pandera.typing alias
+        a: FieldType[str] | None
+        b: FieldType[str, pa.Field(eq="b", required=False)]
+        c: FieldType[str, pa.Field(required=False)]
 
     return Schema
 

--- a/tests/xarray/test_data_tree_model.py
+++ b/tests/xarray/test_data_tree_model.py
@@ -56,6 +56,21 @@ class TestDataTreeModel:
         assert "surface" in schema.children
         assert "upper" in schema.children
 
+    def test_nested_data_tree_model(self):
+        class NestedTree(pa.DataTreeModel):
+            surface: SurfaceModel
+
+        class ClimateTree(pa.DataTreeModel):
+            nested: NestedTree
+
+        schema = ClimateTree.to_schema()
+
+        assert isinstance(schema.children["nested"], pa.DataTreeSchema)
+        assert isinstance(
+            schema.children["nested"].children["surface"],
+            pa.DatasetSchema,
+        )
+
     def test_validate(self, simple_tree):
         class ClimateTree(pa.DataTreeModel):
             surface: SurfaceModel


### PR DESCRIPTION
## Motivation

`DataFrameModel` fields have two deliberately different lives. At runtime, Pandera replaces the class attribute with a field descriptor whose class-level value is the column name (`str`). A generic static checker, however, sees the field's annotation as the attribute type. With native backend annotations such as Polars' `pl.List`, that mismatch can produce a false positive when a schema field is passed to an API expecting a column name.

The existing Pandera mypy plugin can compensate for this in mypy, but a checker-specific plugin cannot provide the same contract to other checkers such as `ty`. This change makes the runtime/static boundary explicit in Pandera's public typing API without adding a checker-specific plugin.

## What changed

- Added `pandera.typing.FieldType`, a typing-only descriptor for `DataFrameModel` fields. Its generic argument remains the schema dtype while class-level access is typed as `str`.
- Kept `pandera.typing.FieldType` distinct from each backend's runtime `pa.Field(...)` function. `FieldType` is not instantiated at runtime.
- Added shared parser support across pandas/GeoPandas, Polars, Ibis, PyArrow, and PySpark.
- Added variadic `FieldType` metadata support, so field metadata can be embedded as `FieldType[T, pa.Field(...)]`.
- Added the checker-friendly assignment form:

```python
class Schema(pa.DataFrameModel):
    values: FieldType[pl.List] = pa.Field()
    nullable_field: FieldType[int | None] = pa.Field()
    optional_field: FieldType[int] | None
```

- Added `required=` to backend `Field` APIs, with explicit requiredness taking precedence over inferred presence.
- Preserved the distinction between value nullability and field presence:

  | Annotation | Meaning |
  | --- | --- |
  | `FieldType[T]` | Required, non-nullable field by default |
  | `FieldType[T \| None]` | Required field with nullable values |
  | `FieldType[T] \| None` | Field may be absent |
  | `FieldType[T] = pa.Field(required=False)` | Field may be absent |

- Preserved bare dtype annotations, `Series[T]`/`Index[T]`, assignment-based fields, and legacy `Optional[Series[T]]` optional-column declarations.
- Retained `Annotated` compatibility for existing dtype metadata and field declarations, while making `FieldType` the primary descriptor contract.
- Added runtime, cross-backend, static `ty`, documentation, and ADR coverage.

## Checker compatibility

`FieldType[T, pa.Field(...)]` is accepted by Pandera's runtime parser. Some generic checkers reject calls inside type arguments, so the assignment form should be used when running `ty`. The no-plugin Polars fixture verifies that
class-level access can be passed to a function expecting `str`.

Plain `Annotated[T, ...]` remains useful for metadata and parameterized dtypes, but it does not by itself change a generic checker's view of a model attribute. `FieldType` supplies that descriptor-level contract.

## Verification

- `prek run --all-files --no-progress`
- `make quick-docs` (`191` doctests, `0` failures)
- Focused pandas, Polars, Ibis, and PyArrow tests (`237` passed)
- PySpark model tests with matching driver and worker interpreters (`52` passed)
- No-plugin `ty` check for the Polars `FieldType` fixture
- Repository static type-checking suite (`4` passed)

The ADRs remain `Proposed` pending maintainer approval on this pull request.
