### PR TITLE
fix: respect pydantic serialization aliases

### DIFF
--- a/pandera/engines/pandas_engine.py
+++ b/pandera/engines/pandas_engine.py
@@ -1433,10 +1433,12 @@ class PydanticModel(DataType):
 
     @property
     def column_names(self) -> list[str]:
-        """Return pydantic field aliases, falling back to field names."""
+        """Return serialized pydantic field names."""
         if PYDANTIC_V2:
             return [
-                field.alias or name
+                getattr(field, "serialization_alias", None)
+                or field.alias
+                or name
                 for name, field in self.type.model_fields.items()  # type: ignore[attr-defined]
             ]
         return [

--- a/tests/pandas/test_pydantic_dtype.py
+++ b/tests/pandas/test_pydantic_dtype.py
@@ -171,3 +171,30 @@ def test_pydantic_model_validates_empty_dataframe_with_aliases():
         "Amount in local currency",
     ]
     assert validated.empty
+
+
+@pytest.mark.skipif(
+    not PYDANTIC_V2,
+    reason="serialization_alias is only available in Pydantic v2",
+)
+def test_pydantic_model_preserves_serialization_aliases():
+    """Schema columns should match Pydantic's serialized row keys."""
+
+    class Row(BaseModel):
+        dash_length: float = Field(
+            default=1.0, serialization_alias="dashLength"
+        )
+
+    schema = pa.DataFrameSchema(dtype=PydanticModel(Row), coerce=False)
+    data = pd.DataFrame({"dash_length": [2.0]})
+
+    validated = schema.validate(data)
+    assert validated.columns.tolist() == ["dashLength"]
+    assert validated["dashLength"].tolist() == [2.0]
+
+    empty = pd.DataFrame(columns=["dashLength"])
+    with pytest.warns(
+        UserWarning, match="PydanticModel cannot validate an empty dataframe"
+    ):
+        validated_empty = schema.validate(empty)
+    assert validated_empty.columns.tolist() == ["dashLength"]


### PR DESCRIPTION
Closes #2444

## Summary

`PydanticModel.coerce()` serializes rows with `by_alias=True`, but inferred schema columns ignored Pydantic v2 `serialization_alias`. Prefer the serialization alias when resolving output column names so schema validation matches the coerced dataframe.

## Validation

- `pytest -q tests/pandas/test_pydantic_dtype.py`
- pandas test suite: 2486 passed, 16 skipped, 4 xfailed
- Pydantic v1 compatibility: 26 passed, 7 skipped
- `prek run --all-files`