### PR TITLE
fix(docs): scope pyspark JDK24 security-manager opt-in to JDK 24 only

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,15 +59,18 @@ def _java_specification_major() -> int | None:
 
 
 def _ensure_pyspark_jdk24_jvm_opts() -> None:
-    """Let local Spark start on JDK 24+ (Hadoop UGI / Subject.getSubject).
+    """Let local Spark start on JDK 24 (Hadoop UGI / Subject.getSubject).
 
-    See JEP 486. Notebook kernels inherit this process env. No-op on JDK < 24.
+    See JEP 486. Notebook kernels inherit this process env. Only applies to
+    JDK 24: on JDK 25+ the JVM hard-fails at startup ("Enabling a Security
+    Manager is not supported") if this flag is present at all, and Spark
+    starts fine there without it, so this is a no-op outside JDK 24.
     """
     flag = "-Djava.security.manager=allow"
     if flag in os.environ.get("JAVA_TOOL_OPTIONS", ""):
         return
     major = _java_specification_major()
-    if major is None or major < 24:
+    if major != 24:
         return
     prev = os.environ.get("JAVA_TOOL_OPTIONS", "").strip()
     os.environ["JAVA_TOOL_OPTIONS"] = (


### PR DESCRIPTION
## Summary
- `docs/source/conf.py` had a local-dev workaround that injects `-Djava.security.manager=allow` into `JAVA_TOOL_OPTIONS` whenever `java` reports major version 24+, to let local Spark start under JEP 486's Security Manager deprecation on JDK 24.
- On JDK 25+ merely *passing* that flag makes the JVM hard-fail at startup (`java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.`), which broke `nox -s docs-3.12` notebook execution for `error_report.md`, `pyspark.md`, and `pyspark_sql.md` (warnings-as-errors turned this into a build failure).
- Verified Spark 4.2.0 starts fine on JDK 25 without any special flag, so the fix narrows the condition from "JDK ≥ 24" to "JDK == 24" — a no-op on JDK 25+.

CI is unaffected since `.github/workflows/ci-tests.yml` pins `java-version: "17"` for the jobs that use it; this only affected local docs builds on newer JDKs.

## Test plan
- [x] `rm -rf docs/_build && uvx nox -db uv -r --non-interactive --session docs-3.12` — full session (sphinx doctest build + xdoctest) completes successfully with no failures, run twice to confirm.