### PR TITLE
fix(ci): bump mypy 1.10.0 -> 1.19.1 for the mypy test extras

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ The nox `tests` session maps extras to test directories: `extra=None` runs
 
 - **Ruff:** Linting (`I`, `UP` rules) and formatting. Line length: 79.
 - **isort:** Import sorting (line length 79).
-- **mypy:** Static type checking (v1.10.0). Config in `mypy.ini`.
+- **mypy:** Static type checking (v1.19.1). Config in `mypy.ini`.
 - **pyupgrade:** Python 3.9+ syntax upgrades.
 - **flynt:** f-string conversion.
 - **codespell:** Spell checking.

--- a/environment.yml
+++ b/environment.yml
@@ -55,7 +55,7 @@ dependencies:
   - pandas >= 2.1.1
   - isort >= 5.7.0
   - joblib
-  - mypy = 1.10.0
+  - mypy = 1.19.1
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ dev = [
     "hypothesis >= 6.92.7",
     "ipdb",
     "joblib",
-    "mypy == 1.10.0",
+    "mypy == 1.19.1",
     "nox",
     "pip",
     "polars >= 1.20.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ numpy >= 1.24.4
 pandas >= 2.1.1
 isort >= 5.7.0
 joblib
-mypy == 1.10.0
+mypy == 1.19.1
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
## Summary

Fixes the `extra='mypy'` CI failures (e.g. on
https://github.com/unionai-oss/pandera/actions/runs/32612379380/job/97127334951?pr=2451)
where every mypy test leg on Python >= 3.12 failed with
`Expected N errors but got 0` or a raw mypy `NotImplementedError`
crash.

## Root cause

- `scipy-stubs` is unpinned. Release **1.18.1.0** (published
  2026-08-22, `requires-python >= 3.12` — which is exactly why only
  the 3.12+ legs broke) introduced PEP 695 `TypeVarTuple` class syntax
  in `scipy/stats/_typing.pyi`:

  ```python
  class BaseBunch[*Ts](tuple[*Ts], BunchMixin[tuple[*Ts]]):
  ```

- The mypy used by the `tests` nox session is the dev dependency
  group pin, **mypy 1.10.0** (Dec 2023). mypy 1.10.0 cannot process
  PEP 695 `TypeVarTuple` parameters: the base class degrades to
  `tuple[*Any]` and mypy crashes with `NotImplementedError` in
  `calculate_tuple_fallback` (mypy/semanal_shared.py).
- The crash propagates to any test whose import graph reaches
  `scipy.stats`: `polars -> pandas.plotting._core -> scipy.stats`
  (mypy follows `TYPE_CHECKING` imports under
  `follow_imports = silent`). A crashed mypy run prints no errors,
  hence the `Expected N errors but got 0` assertion failures.
- Python 3.10/3.11 legs passed because they resolve the previous
  scipy-stubs release (1.18.1.0 requires Python >= 3.12).

## Fix

Bump mypy `1.10.0` -> `1.19.1` in the dev dependency group
(`pyproject.toml`), `environment.yml`, and the generated
`requirements.txt` — the same version the pre-commit mypy hook
already uses, so the two mypy versions in the repo are now aligned.

## Verification

Ran the full `tests/mypy` suite locally (macOS arm64, same as the
failing runner) with mypy 1.19.1 + scipy-stubs 1.18.1.0 + the
previously failing dependency set:

| Python | pandas | result (full tests/mypy suite) |
|---|---|---|
| 3.13 | 2.3.3 | 20 passed, 13 xfailed |
| 3.13 | 3.0.0 | 20 passed, 13 xfailed |
| 3.14 | 3.0.0 | 20 passed, 13 xfailed |

Also confirmed with mypy 1.10.0 that a bare `import polars`
reproduces the exact `NotImplementedError` traceback from CI, and
that mypy 1.19.1 checks the same file cleanly.
