### PR TITLE
fix(decorators): support keyword-only / variadic functions in check_input

### DIFF
--- a/pandera/decorators.py
+++ b/pandera/decorators.py
@@ -70,6 +70,11 @@ def _get_fn_argnames(fn: Callable) -> list[str]:
 
     arg_spec_args = inspect.getfullargspec(fn).args
 
+    if not arg_spec_args:
+        # keyword-only / variadic functions have no positional args to
+        # introspect; there is no self/cls to exclude either.
+        return arg_spec_args
+
     first_arg_is_self = arg_spec_args[0] == "self"
     first_arg_is_cls = arg_spec_args[0] == "cls"
     is_py_newer_than_39 = sys.version_info[:2] >= (3, 9)
@@ -261,10 +266,31 @@ def check_input(
             elif obj_getter is None:
                 try:
                     _fn = _unwrap_fn(wrapped)
-                    obj_arg_name, *_ = _get_fn_argnames(wrapped)
+                    argnames = _get_fn_argnames(wrapped)
+                    if argnames:
+                        obj_arg_name = argnames[0]
+                    else:
+                        # No positional args (keyword-only / variadic
+                        # function): fall back to the first signature
+                        # parameter of any kind, minus implicit self/cls.
+                        sig_params = [
+                            name
+                            for name in inspect.signature(_fn).parameters
+                            if name not in ("self", "cls")
+                        ]
+                        if not sig_params:
+                            raise ValueError(
+                                f"error in check_input decorator of function "
+                                f"'{wrapped.__name__}': no argument to validate"
+                            )
+                        obj_arg_name = sig_params[0]
                     arg_spec_args = inspect.getfullargspec(_fn).args
 
-                    arg_idx = arg_spec_args.index(obj_arg_name)
+                    arg_idx = (
+                        arg_spec_args.index(obj_arg_name)
+                        if obj_arg_name in arg_spec_args
+                        else -1
+                    )
 
                     if obj_arg_name in kwargs:
                         obj = kwargs[obj_arg_name]

--- a/tests/pandas/test_decorators.py
+++ b/tests/pandas/test_decorators.py
@@ -1909,3 +1909,38 @@ def test_check_types_catches_inplace_mutation():
     df = DataFrame[InSchema]({"id": [1], "name": ["foo"]})
     with pytest.raises(errors.SchemaError):
         mutate_after_typing(df)
+
+
+def test_check_input_keyword_only_args():
+    """check_input must not crash on functions with no positional args (#2422)."""
+
+    @check_input(DataFrameSchema({"col": Column(int)}))
+    def process(*, df):
+        return df
+
+    expected = pd.DataFrame({"col": [1, 2]})
+    out = process(df=expected)
+    pd.testing.assert_frame_equal(out, expected)
+
+
+def test_get_fn_argnames_no_positional_args():
+    from pandera.decorators import _get_fn_argnames
+
+    def keyword_only(*, df, output_col):
+        pass
+
+    def variadic(*args):
+        pass
+
+    def keywords(**kwargs):
+        pass
+
+    class Widget:
+        def method(self, x):
+            pass
+
+    assert _get_fn_argnames(keyword_only) == []
+    assert _get_fn_argnames(variadic) == []
+    assert _get_fn_argnames(keywords) == []
+    # regression guard: self-exclusion semantics unchanged
+    assert _get_fn_argnames(Widget.method) == ["x"]


### PR DESCRIPTION
Fixes #2422

## Motivation

`_get_fn_argnames()` crashes with `IndexError` when the decorated function has no positional parameters (keyword-only args, `*args`, or `**kwargs`): `inspect.getfullargspec(fn).args` returns `[]` and the code immediately indexes `[0]` to check for `self`/`cls`.

Fixing only that guard is not enough for an end-to-end fix: the default (`obj_getter=None`) path of `check_input` also unpacks the argnames list (`obj_arg_name, *_ = _get_fn_argnames(wrapped)`) and resolves `arg_idx = arg_spec_args.index(obj_arg_name)`, both of which fail for keyword-only functions even with the guard in place.

## Changes

- `_get_fn_argnames`: early-return `[]` before the `[0]` access (no positional args → nothing to introspect, no self/cls to exclude).
- `check_input` default path: when positional argnames are empty, fall back to the first signature parameter of any kind, excluding implicit `self`/`cls`; resolve `arg_idx` via a membership check so keyword-only names don't raise on `.index()`. The kwargs-first validation order from #2428 is preserved.

## Testing

- New regression tests in `tests/pandas/test_decorators.py`:
  - `test_check_input_keyword_only_args`: end-to-end `@check_input` on `def process(*, df)` validates and passes through the frame.
  - `test_get_fn_argnames_no_positional_args`: keyword-only / `*args` / `**kwargs` return `[]`; method `self`-exclusion semantics unchanged.
- Full `tests/pandas/test_decorators.py`: **74 passed, 1 skipped**.
- `tests/core`: one pre-existing failure (`test_pyspark_pandas_does_not_route_to_pyspark_sql`) that reproduces identically without this change (pyspark not installed locally) — unrelated.
- `ruff check` + `ruff format --check` clean.

## Potential concerns

- For keyword-only functions the validated argument defaults to the first keyword-only parameter; callers can always override with an explicit `obj_getter` (int/str). I considered raising instead of falling back, but silently choosing the first kw-only arg mirrors how positional functions pick their first argument.