### PR TITLE
docs: announce Pandera CLI and PyArrow support in banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -223,9 +223,9 @@ html_theme = "furo"
 # documentation.
 
 announcement = """
-📢 Pandera 0.32.0 introduces the <i> Narwhals-powered backend </i>!
-Use a unified backend to power the validation of different dataframe libraries.
-Learn more details <a href='./narwhals_backend.html'>here</a>
+📢 New in Pandera: validate schemas from the command line with the
+<a href='./cli.html'>Pandera CLI</a>, and validate <a href='./pyarrow.html'>PyArrow</a>
+dataframes natively!
 """
 
 html_logo = "_static/pandera-banner.png"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -223,7 +223,7 @@ html_theme = "furo"
 # documentation.
 
 announcement = """
-📢 New in Pandera: validate schemas from the command line with the
+📢 New in Pandera 0.33.0: validate schemas from the command line with the
 <a href='./cli.html'>Pandera CLI</a>, and validate <a href='./pyarrow.html'>PyArrow</a>
 dataframes natively!
 """


### PR DESCRIPTION
Replace the outdated Narwhals-backend announcement with links to the new CLI and PyArrow docs pages.


Claude-Session: https://claude.ai/code/session_01ADdVfzQhQwzuKJKdxdeGfy