### PR TITLE
fix: restore optional-column semantics for bare `T | None` annotations

### DIFF
--- a/adrs/20260819-02-dataframe-model-optionality.md
+++ b/adrs/20260819-02-dataframe-model-optionality.md
@@ -10,10 +10,17 @@ Pandera has two different concepts that are easy to conflate:
 - whether a declared column must be present in the input data; and
 - whether values in a present column may be null.
 
-The annotation contract should make the distinction visible. `None` inside a
-dtype describes value nullability, while an outer `| None` on the typing-only
-`FieldType` descriptor describes optional field presence. `Field(required=...)`
-and `Field(nullable=...)` remain explicit overrides.
+The annotation contract should make the distinction visible. `None` inside
+`FieldType[...]` describes value nullability, while an outer `| None` on the
+annotation describes optional field presence. `Field(required=...)` and
+`Field(nullable=...)` remain explicit overrides.
+
+Pandera has interpreted an outer `| None` as optional column presence since
+the `DataFrameModel` API was introduced, for both `Optional[Series[T]]` and
+bare `Optional[T]` annotations. Redefining a bare `T | None` as a required,
+nullable column silently changed the meaning of existing schemas
+([#2457](https://github.com/unionai-oss/pandera/issues/2457)), so the outer
+union keeps its historical presence meaning for every annotation form.
 
 ## Decision
 
@@ -25,8 +32,9 @@ from pandera.typing import FieldType
 
 class Schema(pa.DataFrameModel):
     required: int
-    nullable_values: int | None
+    nullable_values: FieldType[int | None]
     optional_presence: FieldType[int] | None
+    legacy_optional_presence: int | None
 ```
 
 When the static descriptor is needed for every field, the equivalent forms
@@ -53,8 +61,8 @@ The meanings are:
 | Annotation | Schema meaning |
 | --- | --- |
 | `T` or `FieldType[T]` | Required column; non-nullable by default |
-| `T \| None` or `FieldType[T \| None]` | Required column whose values may be null |
-| `FieldType[T] \| None` | Column may be absent from the input data |
+| `FieldType[T \| None]` | Required column whose values may be null |
+| `T \| None` or `FieldType[T] \| None` | Column may be absent from the input data |
 
 `pandera.typing.FieldType[T]` is typing-only and does not replace the runtime
 backend `pa.Field(...)` function. Explicit `required` and `nullable` values
@@ -69,11 +77,10 @@ optional model argument without making a required schema field optional.
 `Field(required=...)` is optional so that an omitted value does not override
 the annotation's inferred presence. When supplied, it takes precedence over
 the annotation. Likewise, an explicit `Field(nullable=...)` takes precedence
-over nullability inferred from `T | None`.
+over nullability inferred from `FieldType[T | None]`.
 
-The established `Optional[Series[T]]` spelling remains supported for
-backwards compatibility and continues to mean optional column presence. This
-legacy wrapper is distinct from a bare `T | None` annotation. Optional index
+The established `Optional[Series[T]]` and bare `Optional[T]` spellings remain
+supported and continue to mean optional column presence. Optional index
 annotations remain invalid where the backend has historically rejected them.
 
 ## Consequences
@@ -89,8 +96,8 @@ annotations remain invalid where the backend has historically rejected them.
 
 ### Negative
 
-- Users must distinguish a bare `T | None` from `FieldType[T] | None` and the
-  legacy `Optional[Series[T]]` spelling.
+- Value nullability cannot be expressed by a bare `T | None` annotation; it
+  requires `FieldType[T | None]` or an explicit `Field(nullable=True)`.
 - The `FieldType` implementation must track whether `required` and `nullable`
   were explicitly supplied so omitted values do not override inference.
 - Backend parsers must apply the same rules consistently.
@@ -113,16 +120,19 @@ preserves that descriptor idea while differentiating it from backend runtime
 
 ### Make nullable metadata the only nullable spelling
 
-This keeps all metadata in `Field`, but loses the conventional type-level
-meaning of `T | None`. The annotation form remains the primary way to express
-value nullability, with explicit `Field(nullable=...)` as an override.
+This keeps all metadata in `Field`, but loses the type-level spelling of
+nullability entirely. `FieldType[T | None]` remains the annotation-level way
+to express value nullability, with explicit `Field(nullable=...)` as an
+override.
 
-### Use only required metadata and keep T | None as presence optional
+### Reinterpret a bare T | None as nullable values
 
-This would preserve the old interpretation for bare dtype annotations, but
-would make `None` mean different things depending on whether it describes a
-dtype or a field declaration. The contract reserves bare `T | None` for
-nullable values and uses `FieldType[T] | None` for optional presence.
+This was the contract released in `0.33.0`. It reads naturally, but it
+silently flipped every pre-existing `col: T | None` declaration from optional
+to required, breaking user schemas without a deprecation path
+([#2457](https://github.com/unionai-oss/pandera/issues/2457)). The outer
+union is therefore reserved for presence in every annotation form, and the
+dtype position inside `FieldType[...]` carries nullability.
 
 ## Implementation status
 

--- a/docs/source/dataframe_models.md
+++ b/docs/source/dataframe_models.md
@@ -486,9 +486,8 @@ runtime metadata function and must not be instantiated. Existing bare dtypes,
 
 By default all columns specified in the schema are {ref}`required<required>`
 and non-nullable, meaning that a missing column or a null value raises an
-exception. Put `None` inside `FieldType[...]` to allow null values, and use an
-outer `| None` or `required=False` metadata to allow the column itself to be
-missing.
+exception. An outer `| None` on the annotation makes the column itself
+optional, and `None` *inside* `FieldType[...]` allows null values.
 
 ```{code-cell} python
 import pandas as pd
@@ -499,7 +498,8 @@ from pandera.typing import FieldType
 class Schema(pa.DataFrameModel):
     required: str
     nullable: FieldType[int | None]
-    optional: FieldType[float] | None
+    optional: float | None
+    optional_checked: FieldType[float] | None
 
 df = pd.DataFrame(
     {
@@ -515,7 +515,8 @@ The meanings are:
 | Annotation | Column required? | Values nullable? |
 | ---------- | ---------------- | ---------------- |
 | `T` | Yes | No |
-| `T | None` | Yes | Yes |
+| `FieldType[T | None]` | Yes | Yes |
+| `T | None` | No | No |
 | `FieldType[T] | None` | No | No |
 
 The same meanings apply to `FieldType[T, pa.Field(...)]`. An explicit
@@ -525,9 +526,9 @@ precedence over metadata supplied in `FieldType`.
 
 An explicit `pa.Field(nullable=...)` setting takes precedence over the
 nullability inferred from the annotation. Existing
-`Optional[Series[T]]` annotations remain supported for optional column
-presence. An optional field does not get added during validation. To add
-missing fields, use
+`Optional[Series[T]]` and bare `Optional[T]` annotations remain supported for
+optional column presence. An optional field does not get added during
+validation. To add missing fields, use
 {ref}`add_missing_columns=True <adding-missing-columns>` in the model
 `Config` with required fields that specify a `default` value or
 `nullable=True`.

--- a/pandera/typing/common.py
+++ b/pandera/typing/common.py
@@ -220,16 +220,6 @@ class FieldType(Generic[FieldDtype, Unpack[FieldMetadata]]):
         )
 
 
-def _is_optional_field_annotation(annotation: Any) -> bool:
-    """Return whether an annotation has optional field presence semantics."""
-    if getattr(annotation, "__metadata__", None):
-        annotation = get_args(annotation)[0]
-    origin = get_origin(annotation)
-    if origin is None or not isinstance(origin, type):
-        return False
-    return issubclass(origin, (SeriesBase, IndexBase, FieldType))
-
-
 class AnnotationInfo:
     """Captures extra information about an annotation.
 
@@ -241,7 +231,8 @@ class AnnotationInfo:
         literal: Whether the annotation is a literal.
         optional: Whether the annotation is optional.
         nullable: Whether the annotation's values are nullable.
-        is_optional_field: Whether an outer ``None`` marks an optional field.
+        is_optional_field: Whether the field may be absent from the data, i.e.
+            whether the annotation has an outer ``| None``.
         is_field: Whether the annotation uses
             ``pandera.typing.FieldType[T]``.
         raw_annotation: The raw annotation.
@@ -292,17 +283,14 @@ class AnnotationInfo:
         self.is_field = False
         self.nullable = False
 
+        # An outer ``| None`` always marks optional field presence, e.g.
+        # ``int | None``, ``Optional[Series[int]]``, or ``FieldType[int] | None``.
+        # Value nullability is expressed by a ``None`` *inside* the dtype
+        # position, e.g. ``FieldType[int | None]``, or by
+        # ``Field(nullable=True)``.
         is_optional = typing_inspect.is_optional_type(raw_annotation)
-        optional_arg = (
-            get_args(raw_annotation)[0]
-            if is_optional and typing_inspect.is_union_type(raw_annotation)
-            else raw_annotation
-        )
         self.optional = is_optional
-        self.is_optional_field = is_optional and _is_optional_field_annotation(
-            optional_arg
-        )
-        self.nullable = is_optional and not self.is_optional_field
+        self.is_optional_field = is_optional
         if is_optional and typing_inspect.is_union_type(raw_annotation):
             # Unwrap Optional or Union[..., NoneType]
             # get_args -> (pandera.typing.Index[str], <class 'NoneType'>)

--- a/tests/ibis/test_ibis_model.py
+++ b/tests/ibis/test_ibis_model.py
@@ -40,19 +40,19 @@ def test_model_schema_equivalency(
     assert t_model_basic.to_schema() == t_schema_basic
 
 
-def test_model_schema_equivalency_with_nullable():
-    class ModelWithNullable(DataFrameModel):
+def test_model_schema_equivalency_with_optional():
+    class ModelWithOptional(DataFrameModel):
         string_col: str | None
         int_col: int
 
     schema = DataFrameSchema(
-        name="ModelWithNullable",
+        name="ModelWithOptional",
         columns={
-            "string_col": Column(dt.String, nullable=True),
+            "string_col": Column(dt.String, required=False),
             "int_col": Column(dt.Int64),
         },
     )
-    assert ModelWithNullable.to_schema() == schema
+    assert ModelWithOptional.to_schema() == schema
 
 
 def test_field_type_presence_and_nullability():
@@ -60,9 +60,10 @@ def test_field_type_presence_and_nullability():
 
     class Model(DataFrameModel):
         required: dt.Int64
-        nullable_values: dt.Int64 | None
+        nullable_values: FieldType[dt.Int64 | None]
         optional_presence: FieldType[dt.Int64] | None
-        explicit_nullable: dt.Int64 | None = pa.Field(nullable=False)
+        legacy_optional_presence: dt.Int64 | None
+        explicit_nullable: dt.Int64 = pa.Field(nullable=True)
 
     schema = Model.to_schema()
     assert schema.columns["required"].dtype == Column(dt.Int64).dtype
@@ -71,7 +72,10 @@ def test_field_type_presence_and_nullability():
     assert schema.columns["nullable_values"].required
     assert schema.columns["nullable_values"].nullable
     assert not schema.columns["optional_presence"].required
-    assert not schema.columns["explicit_nullable"].nullable
+    # bare ``T | None`` keeps its historical optional-presence meaning
+    assert not schema.columns["legacy_optional_presence"].required
+    assert not schema.columns["legacy_optional_presence"].nullable
+    assert schema.columns["explicit_nullable"].nullable
     assert Model.required == "required"
     assert isinstance(Model.optional_presence, str)
 

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -125,10 +125,11 @@ def test_field_type_presence_and_nullability() -> None:
 
     class Model(pa.DataFrameModel):
         required: int
-        nullable_values: int | None
+        nullable_values: FieldType[int | None]  # type: ignore[valid-type]
         optional_presence: FieldType[int] | None
-        explicit_nullable: int | None = pa.Field(nullable=False)
-        explicit_non_nullable: int = pa.Field(nullable=True)
+        legacy_optional_presence: int | None
+        explicit_nullable: int = pa.Field(nullable=True)
+        explicit_required: FieldType[int] | None = pa.Field(required=True)
         aliased: str = pa.Field(alias="renamed")
 
     schema = Model.to_schema()
@@ -144,8 +145,14 @@ def test_field_type_presence_and_nullability() -> None:
     assert not schema.columns["optional_presence"].required
     assert not schema.columns["optional_presence"].nullable
 
-    assert not schema.columns["explicit_nullable"].nullable
-    assert schema.columns["explicit_non_nullable"].nullable
+    # a bare ``T | None`` annotation keeps its historical meaning: the column
+    # may be absent, and its values are non-nullable unless stated otherwise.
+    # See https://github.com/unionai-oss/pandera/issues/2457
+    assert not schema.columns["legacy_optional_presence"].required
+    assert not schema.columns["legacy_optional_presence"].nullable
+
+    assert schema.columns["explicit_nullable"].nullable
+    assert schema.columns["explicit_required"].required
     assert Model.aliased == "renamed"
     for name in (
         Model.required,
@@ -312,7 +319,7 @@ def test_nullable_annotation_coercion() -> None:
     """Inferred nullability must also guide pandas dtype coercion."""
 
     class Model(pa.DataFrameModel):
-        value: int | None = pa.Field(coerce=True)
+        value: FieldType[int | None] = pa.Field(coerce=True)  # type: ignore[valid-type]
 
     validated = Model.validate(pd.DataFrame({"value": [1, None]}))
     assert validated["value"].isna().sum() == 1
@@ -431,6 +438,29 @@ def test_optional_column() -> None:
     assert not schema.columns["b"].required
     assert not schema.columns["c"].required
     assert not schema.columns["d"].required
+
+
+def test_optional_bare_dtype_column() -> None:
+    """Bare ``T | None`` annotations declare an optional column.
+
+    Regression test for https://github.com/unionai-oss/pandera/issues/2457
+    """
+
+    class Schema(pa.DataFrameModel):
+        a: int
+        b: int | None
+        c: Optional[str]  # noqa: UP045
+        d: Annotated[int, pa.Field(gt=0)] | None
+        e: int | None = pa.Field(required=True)
+
+    schema = Schema.to_schema()
+    assert schema.columns["a"].required
+    for name in ("b", "c", "d"):
+        assert not schema.columns[name].required
+        assert not schema.columns[name].nullable
+    assert schema.columns["e"].required
+
+    Schema.validate(pd.DataFrame({"a": [1], "e": [1]}))
 
 
 def test_optional_column_with_typing_module_alias() -> None:
@@ -2209,7 +2239,7 @@ def test_generic_nullable_field() -> None:
     T = TypeVar("T", int, float, str)
 
     class GenericModel(pa.DataFrameModel, Generic[T]):
-        value: T | None
+        value: T = pa.Field(nullable=True)
 
     class IntModel(GenericModel[int]): ...
 

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -144,19 +144,19 @@ def test_model_schema_equivalency(
     assert ldf_model_basic.to_schema() == ldf_schema_basic
 
 
-def test_model_schema_equivalency_with_nullable():
-    class ModelWithNullable(DataFrameModel):
+def test_model_schema_equivalency_with_optional():
+    class ModelWithOptional(DataFrameModel):
         string_col: str | None
         int_col: int
 
     schema = DataFrameSchema(
-        name="ModelWithNullable",
+        name="ModelWithOptional",
         columns={
-            "string_col": Column(pl.Utf8, nullable=True),
+            "string_col": Column(pl.Utf8, required=False),
             "int_col": Column(pl.Int64),
         },
     )
-    assert ModelWithNullable.to_schema() == schema
+    assert ModelWithOptional.to_schema() == schema
 
 
 def test_field_type_presence_and_nullability():
@@ -164,9 +164,10 @@ def test_field_type_presence_and_nullability():
 
     class Model(DataFrameModel):
         items: pl.List
-        nullable_values: int | None
+        nullable_values: FieldType[int | None]
         optional_presence: FieldType[int] | None
-        explicit_nullable: int | None = Field(nullable=False)
+        legacy_optional_presence: int | None
+        explicit_nullable: int = Field(nullable=True)
 
     schema = Model.to_schema()
     assert schema.columns["items"].dtype == Column(pl.List).dtype
@@ -174,7 +175,10 @@ def test_field_type_presence_and_nullability():
     assert schema.columns["nullable_values"].required
     assert not schema.columns["optional_presence"].required
     assert not schema.columns["optional_presence"].nullable
-    assert not schema.columns["explicit_nullable"].nullable
+    # bare ``T | None`` keeps its historical optional-presence meaning
+    assert not schema.columns["legacy_optional_presence"].required
+    assert not schema.columns["legacy_optional_presence"].nullable
+    assert schema.columns["explicit_nullable"].nullable
     assert Model.items == "items"
     assert isinstance(Model.optional_presence, str)
 

--- a/tests/pyarrow/test_pyarrow_model.py
+++ b/tests/pyarrow/test_pyarrow_model.py
@@ -25,9 +25,10 @@ def test_model_field_type_presence_and_nullability():
 
     class Model(pa.DataFrameModel):
         required: int
-        nullable_values: int | None
+        nullable_values: FieldType[int | None]
         optional_presence: FieldType[int] | None
-        explicit_nullable: int | None = pa.Field(nullable=False)
+        legacy_optional_presence: int | None
+        explicit_nullable: int = pa.Field(nullable=True)
 
     schema = Model.to_schema()
     assert schema.columns["required"].dtype == pa.Column(int).dtype
@@ -36,7 +37,10 @@ def test_model_field_type_presence_and_nullability():
     assert schema.columns["nullable_values"].required
     assert schema.columns["nullable_values"].nullable
     assert not schema.columns["optional_presence"].required
-    assert not schema.columns["explicit_nullable"].nullable
+    # bare ``T | None`` keeps its historical optional-presence meaning
+    assert not schema.columns["legacy_optional_presence"].required
+    assert not schema.columns["legacy_optional_presence"].nullable
+    assert schema.columns["explicit_nullable"].nullable
     assert Model.required == "required"
     assert isinstance(Model.optional_presence, str)
 
@@ -114,7 +118,7 @@ def test_model_with_field_checks():
 def test_model_optional_column():
     class WithOptional(pa.DataFrameModel):
         a: int
-        b: FieldType[str] | None
+        b: str | None
 
     # 'b' is optional, so a table without it validates...
     tbl = pyarrow.table({"a": [1]})

--- a/tests/pyspark/test_pyspark_model.py
+++ b/tests/pyspark/test_pyspark_model.py
@@ -61,10 +61,11 @@ def test_field_type_presence_and_nullability(spark_session):
 
     class Model(DataFrameModel):
         required: T.IntegerType
-        nullable_values: T.IntegerType | None
-        nullable_with_omitted_field: T.IntegerType | None = Field()
+        nullable_values: FieldType[T.IntegerType | None]
+        nullable_with_omitted_field: FieldType[T.IntegerType | None] = Field()
         optional_presence: FieldType[T.IntegerType] | None
-        explicit_nullable: T.IntegerType | None = Field(nullable=False)
+        legacy_optional_presence: T.IntegerType | None
+        explicit_nullable: T.IntegerType = Field(nullable=True)
 
     schema = Model.to_schema()
     assert schema.columns["required"].dtype == pa.Column(T.IntegerType()).dtype
@@ -74,7 +75,10 @@ def test_field_type_presence_and_nullability(spark_session):
     assert schema.columns["nullable_values"].nullable
     assert schema.columns["nullable_with_omitted_field"].nullable
     assert not schema.columns["optional_presence"].required
-    assert not schema.columns["explicit_nullable"].nullable
+    # bare ``T | None`` keeps its historical optional-presence meaning
+    assert not schema.columns["legacy_optional_presence"].required
+    assert not schema.columns["legacy_optional_presence"].nullable
+    assert schema.columns["explicit_nullable"].nullable
     assert Model.required == "required"
     assert isinstance(Model.optional_presence, str)
 
@@ -117,7 +121,7 @@ def test_generic_nullable_field(spark_session):
     Dtype = TypeVar("Dtype")
 
     class GenericModel(DataFrameModel, Generic[Dtype]):
-        value: Dtype | None
+        value: Dtype = Field(nullable=True)
 
     class IntegerModel(GenericModel[T.IntegerType]): ...
 
@@ -632,9 +636,9 @@ def test_schema():
     class Schema(pa.DataFrameModel):
         """Simple DataFrameModel containing optional columns."""
 
-        a: FieldType[str] | None
-        b: FieldType[str, pa.Field(eq="b", required=False)]
-        c: FieldType[str, pa.Field(required=False)]
+        a: str | None
+        b: str | None = pa.Field(eq="b")
+        c: FieldType[str] | None
 
     return Schema
 


### PR DESCRIPTION
Fixes #2457.

## What broke

#2448 redefined what an outer `| None` means on a `DataFrameModel` field. It now marks optional column *presence* only when the inner type is `Series`, `Index`, or `FieldType`; a bare `col: T | None` became a **required** column with nullable values.

That spelling has meant "this column may be absent" since the `DataFrameModel` API was introduced, so schemas that had validated frames with the column missing started raising `column '...' not in dataframe` in 0.33.0:

```python
class Schema(pa.DataFrameModel):
    a: int
    b: int | None

Schema.validate(pd.DataFrame({"a": [1, 2]}))  # 0.32: ok. 0.33.0: SchemaError
```

Behavior across `9777c23b`:

| annotation | 0.32 | 0.33.0 |
| --- | --- | --- |
| `b: int \| None` | required=False, nullable=False | **required=True**, nullable=True |
| `c: Optional[int]` | required=False, nullable=False | **required=True**, nullable=True |
| `d: Optional[Series[int]]` | required=False | required=False (unchanged) |
| `l: int \| None = pa.Field(coerce=True)` | dtype `int64` | dtype **`Int64`** |

The regression did not surface in CI because #2448 also rewrote the tests that encoded the old contract — e.g. `tests/polars/test_polars_model.py::test_model_schema_equivalency_with_optional` had its expectation changed from `Column(pl.Utf8, required=False)` to `Column(pl.Utf8, nullable=True)`, and the pyspark/pyarrow optional-column fixtures were respelled to `FieldType[str] | None`.

ADR `20260819-02` shows the change was deliberate (it explicitly rejected "keep `T | None` as presence optional"), but it shipped in a minor release with no deprecation path.

## The fix

`pandera/typing/common.py` — an outer `| None` again marks optional field presence for every annotation form. Value nullability comes only from a `None` inside the dtype position (`FieldType[T | None]`, `Annotated[T | None, ...]`) or an explicit `Field(nullable=True)`.

| Annotation | Column required? | Values nullable? |
| --- | --- | --- |
| `T`, `FieldType[T]` | yes | no |
| `FieldType[T \| None]` | yes | yes |
| `T \| None`, `FieldType[T] \| None`, `Optional[Series[T]]` | no | no |

Everything else #2448 added is untouched: the `FieldType` descriptor and its static-checker contract, `required=` on the backend `Field` functions, and `FieldType[T, pa.Field(...)]` metadata. `Annotated[Optional[T], ...]`, which raised `TypeError` before 0.33.0, keeps working and stays nullable.

Also in this PR:

- restored the backend tests that #2448 rewrote (pandas, polars, ibis, pyarrow, pyspark), and added a `legacy_optional_presence` assertion to each `test_field_type_presence_and_nullability`
- new regression test `tests/pandas/test_model.py::test_optional_bare_dtype_column`
- updated the "Required columns" section of `docs/source/dataframe_models.md`
- updated ADR `20260819-02` — the rejected alternative is now the shipped-and-reverted one

## Verification

3612 passed across `tests/pandas`, `tests/polars`, `tests/pyarrow`, `tests/xarray`, `tests/ibis`, plus `tests/base tests/core tests/common tests/io` and `tests/mypy` (20 passed). `prek` hooks pass.

Pre-existing failures in my environment, identical on unmodified `main`: `test_ibis_backend_is_narwhals`, the `tests/narwhals` set (33 both before and after), `test_pyspark_pandas_does_not_route_to_pyspark_sql`, and one mypy test that needs `ty` installed. **`tests/pyspark` could not be run locally** (no pyspark/JDK) — those edits mirror the pandas ones but need CI.

## Open question

This restores `T | None` to *non*-nullable, matching 0.32 exactly, rather than making it "optional and nullable" — the looser reading silently weakens null checks and changes coerced dtypes. If `T | None` should eventually mean nullable, this should land as 0.33.1 and the new meaning should return in a major release behind a `DeprecationWarning` on bare `T | None`. Happy to add that warning here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP4dDyprYWVL9EBbGmYdbC