### PR TITLE
fix(polars): do not select absent optional columns when adding missin…

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -370,15 +370,19 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             **{k: v.default for k, v in missing_cols_schema.items()}
         ).cast({k: v.dtype.type for k, v in missing_cols_schema.items()})
 
-        # Get columns present in df but not in schema
-        cols_not_in_schema = [
-            col
-            for col in check_obj.collect_schema().names()
-            if col not in schema.columns
+        # Set column order: schema columns first, then the columns not in the
+        # schema. Optional (``required=False``) columns that are absent are
+        # not added and must not be selected.
+        present_columns = check_obj.collect_schema().names()
+        schema_cols_present = [
+            col for col in schema.columns if col in present_columns
         ]
-
-        # Set column order
-        check_obj = check_obj.select([*schema.columns, *cols_not_in_schema])
+        cols_not_in_schema = [
+            col for col in present_columns if col not in schema.columns
+        ]
+        check_obj = check_obj.select(
+            [*schema_cols_present, *cols_not_in_schema]
+        )
         return check_obj
 
     def strict_filter_columns(

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -279,6 +279,28 @@ def test_add_missing_columns_with_nullable(ldf_basic, ldf_schema_basic):
     )
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="add_missing_columns parser not implemented in Narwhals backend",
+    strict=True,
+)
+def test_add_missing_columns_with_absent_optional_column(ldf_basic):
+    """Absent optional columns are left out when missing columns are added."""
+    schema = DataFrameSchema(
+        {
+            "string_col": Column(pl.Utf8),
+            "int_col": Column(pl.Int64, default=1),
+            "optional_col": Column(pl.Float64, required=False),
+        },
+        add_missing_columns=True,
+    )
+    modified_data = ldf_basic.drop("int_col")
+    validated_data = modified_data.pipe(schema.validate)
+    assert validated_data.collect().equals(
+        ldf_basic.with_columns(int_col=pl.lit(1)).collect()
+    )
+
+
 def test_required_columns():
     """Test required columns."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #2459

### What

With `add_missing_columns=True`, the polars backend correctly skips absent optional (`required=False`) columns when adding missing columns — but the final column-ordering step selects **every** schema column, including the absent optional ones, so validation crashes:

```python
import polars as pl
import pandera.polars as pa

schema = pa.DataFrameSchema(
    {
        "a": pa.Column(pl.Int64),
        "b": pa.Column(pl.Int64, default=1),
        "opt": pa.Column(pl.Float64, required=False),
    },
    add_missing_columns=True,
)
schema.validate(pl.DataFrame({"a": [1]}))
# polars.exceptions.ColumnNotFoundError: unable to find column "opt"; valid columns: ["a", "b"]
```

It only triggers when a defaulted/nullable column is actually missing (otherwise the method returns early), which is why simple schemas never hit it. The pandas backend handles the same case fine (its insertion list filters on `col in df.columns or col_schema.required`), so this also brings the polars backend in line with pandas semantics: absent optional columns stay absent, defaulted columns are added.

### Fix

The ordering `select` uses only the schema columns that are present in the frame (schema order first, non-schema columns after — the existing polars-backend ordering convention, unchanged). For any input that previously validated successfully, all schema columns were present and the `select` is identical to before, so no passing behavior changes.

### Tests

`test_add_missing_columns_with_absent_optional_column`: optional column absent while a defaulted column is missing. Fails on `main` with the `ColumnNotFoundError` above; passes with the fix. Full `tests/polars` suite green (444 passed, 5 skipped).

*Prepared with AI assistance (Claude)*; reviewed and tested by me, Moandco (human)