### PR TITLE
ci: always run linters, regardless of changed paths

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -12,6 +12,8 @@
 #     shared build/CI config. Either one affects every test area, since that
 #     code can affect any backend (see derive_test_flags.sh).
 #   - Pure docs changes match only `docs`.
+#   - There is deliberately no `lint` filter: the lint job in ci-tests.yml
+#     is ungated and runs on every push/PR.
 
 global:
   - pyproject.toml
@@ -23,21 +25,6 @@ global:
   - .coveragerc
   - .github/**
   - scripts/**
-
-lint:
-  - pyproject.toml
-  - setup.py
-  - noxfile.py
-  - requirements.txt
-  - requirements-*.txt
-  - environment.yml
-  - .coveragerc
-  - .github/**
-  - scripts/**
-  - "**/*.py"
-  - "**/*.pyi"
-  - mypy.ini
-  - .pylintrc
 
 docs:
   - pyproject.toml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,7 +40,6 @@ jobs:
     name: Changed areas
     runs-on: ubuntu-latest
     outputs:
-      lint: ${{ steps.filter.outputs.lint }}
       docs: ${{ steps.filter.outputs.docs }}
       import_test: ${{ steps.flags.outputs.import_test }}
       base: ${{ steps.flags.outputs.base }}
@@ -91,11 +90,12 @@ jobs:
           FASTAPI: ${{ steps.filter.outputs.fastapi }}
         run: bash scripts/ci/derive_test_flags.sh >> "${GITHUB_OUTPUT}"
 
+  # Linters always run: formatting/typing rules apply repo-wide, and a missed
+  # lint failure costs more than a few extra short jobs. Do NOT gate this job
+  # on the `changes` job.
   lint:
     name: Linters (python=${{ matrix.python-version }} polars=${{ matrix.polars-version }} )
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.lint == 'true'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
#2450 gated the `lint` job on a `lint` paths-filter that only matched Python sources and build/CI config. Any PR that touches neither (e.g. a markdown-only change such as #2461, which edits AGENTS.md) skipped linting entirely.

Ungate the job so linters run on every push/PR and drop the now-unused `lint` filter and `changes` job output.


Claude-Session: https://claude.ai/code/session_01DNGBtvLoswv9W6R68hd9bW