### PR TITLE
fix(polars): add missing columns with string defaults as literals (#2463)

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -377,9 +377,17 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             if k in column_info.absent_column_names
         }
 
-        # Append missing columns
+        # Append missing columns. Defaults are wrapped in ``pl.lit`` so that a
+        # string default is a literal value, not a reference to a column.
         check_obj = check_obj.with_columns(
-            **{k: v.default for k, v in missing_cols_schema.items()}
+            **{
+                k: (
+                    v.default
+                    if isinstance(v.default, pl.Expr)
+                    else pl.lit(v.default)
+                )
+                for k, v in missing_cols_schema.items()
+            }
         ).cast({k: v.dtype.type for k, v in missing_cols_schema.items()})
 
         # Set column order: schema columns first, then the columns not in the

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -301,6 +301,22 @@ def test_add_missing_columns_with_absent_optional_column(ldf_basic):
     )
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="add_missing_columns parser not implemented in Narwhals backend",
+    strict=True,
+)
+def test_add_missing_columns_with_string_default(ldf_basic, ldf_schema_basic):
+    """A string default is added as a literal, not resolved as a column name."""
+    ldf_schema_basic.add_missing_columns = True
+    ldf_schema_basic.columns["string_col"].default = "int_col"
+    modified_data = ldf_basic.drop("string_col")
+    validated_data = modified_data.pipe(ldf_schema_basic.validate)
+    assert validated_data.collect().equals(
+        ldf_basic.with_columns(string_col=pl.lit("int_col")).collect()
+    )
+
+
 def test_required_columns():
     """Test required columns."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #2463

### What

`DataFrameSchemaBackend.add_missing_columns` (polars backend) passes column defaults into `with_columns(**{name: default})` as raw values. Polars resolves a bare `str` in that position as a **column reference**, not a literal, so a string default either raises

```
polars.exceptions.ColumnNotFoundError: unable to find column "units"
```

or — when the default happens to match an existing column name — silently fills the missing column with **that column's values** (data corruption, no error).

```python
import polars as pl
import pandera.polars as pa

schema = pa.DataFrameSchema(
    {"a": pa.Column(pl.Int64), "unit": pa.Column(pl.Utf8, default="units")},
    add_missing_columns=True,
)
schema.validate(pl.DataFrame({"a": [1]}))  # ColumnNotFoundError: unable to find column "units"
```

Every non-string default (int, float, None, datetime) already behaves as a literal, and the pandas backend adds string defaults fine, so this is an inconsistency in the polars backend only.

### Fix

Wrap non-`pl.Expr` defaults in `pl.lit(...)`; `pl.Expr` defaults are kept as-is so expression defaults keep working.

### Tests

`test_add_missing_columns_with_string_default` uses a default equal to an existing column's name — the silent-corruption case — and asserts the literal is added. Fails on `main`, passes with the fix; full `tests/polars` suite green (444 passed, 5 skipped).

*Prepared with AI assistance (Claude)*; reviewed and tested by me, Moandco (human)