### PR TITLE
Fix documented default for DataFrameSchema.reset_index drop

### DIFF
--- a/pandera/api/dataframe/container.py
+++ b/pandera/api/dataframe/container.py
@@ -1165,7 +1165,7 @@ class DataFrameSchema(Generic[TDataObject], BaseSchema):
         :class:`~pandera.api.dataframe.container.DataFrameSchema`
 
         :param level: list of labels
-        :param drop: bool, default True
+        :param drop: bool, default False
         :return: a new :class:`~pandera.api.dataframe.container.DataFrameSchema`
             with specified column(s) in the index.
         :raises: :class:`~pandera.errors.SchemaInitError` if no index set in


### PR DESCRIPTION
### What this fixes

`DataFrameSchema.reset_index` has the signature

```python
def reset_index(self, level: list[str] | None = None, drop: bool = False) -> Self:
```

but documents

```
:param drop: bool, default True
```

The docstring contradicts itself a few lines further down — the example calls `reset_index()` with defaults and shows `unique_id` moving *from the index into `columns`*, which is `drop=False` behaviour:

```
>>> print(example_schema.reset_index())
<Schema DataFrameSchema(
    columns={
        'probability': ...
        'unique_id': ...        # kept as a column, i.e. drop=False
    },
    ...
    index=None,
```

`set_index` in the same class genuinely defaults to `drop=True` and documents that correctly, so this reads like a copy-paste from `set_index` where the default was never updated. The signature also matches pandas' own `DataFrame.reset_index(drop=False)`, so the code is right and only the docstring needed changing.

`drop` is not cosmetic here — it decides whether the former index survives as a column in the resulting schema, so a reader trusting the docstring would expect the opposite of what happens.

### Scope

One line, docstring only. No behaviour change.

### Testing

Nothing to add — the existing doctest in this method already demonstrates the correct (`drop=False`) behaviour; it just disagreed with the `:param` line above it.

I checked the rest of the module for the same problem and `reset_index` is the only mismatch; `set_index`'s `drop`/`append` defaults are documented correctly.

Note: `pytest --doctest-modules pandera/api/dataframe/container.py -k "reset_index or set_index"` reports 2 failures on my machine, but it reports exactly the same 2 failures on a clean checkout without this change — they're unrelated repr differences in my environment, not something introduced here.
