### PR TITLE
docs: clarify parser and check execution order (#2045)

### DIFF
--- a/docs/source/parsers.md
+++ b/docs/source/parsers.md
@@ -84,13 +84,56 @@ schema.validate(data)
 You can specify both dataframe- and column-level parsers, where
 dataframe-level parsers are performed before column-level parsers. Assuming
 that a schema contains parsers and checks, the validation process consists of
-the following steps:
+the following steps, in order:
 
 1. dataframe-level parsing
-2. column-level parsing
-3. dataframe-level checks
-4. column-level and index-level checks
+2. for each column: column-level parsing, then column-level checks
+3. index-level parsing, then index-level checks
+4. dataframe-level checks
 
+This ordering is intentional: dataframe-level checks are meant to be applied
+only once all of the parsing steps have finished, so that they validate the
+data in the state that represents the user's best effort at parsing the raw
+dataframe into a valid one. Since checks are independent of one another by
+design, there's no functional difference between running dataframe-level
+checks before or after column- and index-level checks, but running
+dataframe-level checks *before* the column-level parsers have run would break
+the assumption that checks operate on already-parsed data.
+
+```{note}
+`coerce=True` is itself a built-in parser (see {ref}`coerced` for more details
+on dtype coercion), so coercion happens during the parsing phase described
+above, before any checks run. A column's own parsers run *before* that column
+is coerced, so if a value needs to be transformed into a coercible form —
+for example, normalizing `"1,0"` to `"1.0"` before it can be coerced to a
+float — you can do that either in a dataframe-level parser or in a parser on
+the column itself.
+```
+
+You can verify the order of operations for yourself by adding some print
+statements to your parsers and checks:
+
+```{code-cell} python
+schema = pa.DataFrameSchema(
+    parsers=pa.Parser(lambda df: print("=== dataframe parser ===") or df),
+    columns={
+        "a": pa.Column(
+            int,
+            parsers=pa.Parser(lambda s: print("=== column a parser ===") or s),
+            checks=pa.Check(lambda s: print("=== column a check ===") or True),
+        ),
+        "b": pa.Column(
+            int,
+            parsers=pa.Parser(lambda s: print("=== column b parser ===") or s),
+            checks=pa.Check(lambda s: print("=== column b check ===") or True),
+        ),
+    },
+    checks=pa.Check(lambda df: print("=== dataframe check ===") or True),
+)
+
+data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+schema.validate(data)
+```
 
 ## Parsing columns
 


### PR DESCRIPTION
Closes #2045

`docs/source/parsers.md` documented the parser/check execution order as:

1. dataframe-level parsing
2. column-level parsing
3. dataframe-level checks
4. column-level and index-level checks

Per @cosmicBboy's clarification in #2045, dataframe-level checks actually run
*last*, after all column-level parsing and checks, so that they see fully
parsed data. This PR corrects the list to the real order:

1. dataframe-level parsing
2. for each column: column-level parsing, then column-level checks
3. index-level parsing, then index-level checks
4. dataframe-level checks

It also:

- Explains why this order is intentional: dataframe-level checks should
  observe the data after every parser has had a chance to run. Check-vs-check
  ordering has no functional effect since checks are independent, but running
  dataframe checks before the column parsers would break the assumption that
  checks operate on already-parsed data.
- Adds a note that `coerce=True` is itself a built-in parser, so coercion
  happens during the parsing phase, before any checks run.
- Adds a small runnable example, in the same MyST `{code-cell}` style used
  elsewhere on the page, that prints a marker from every parser and check so
  readers can reproduce the order themselves.

The note also covers the follow-up question raised later in the thread about
transforming a value into a coercible form: since #2400 ("fix(pandas): run
column parsers before dataframe-level coercion"), a column's own parsers run
before that column is coerced, so that normalization can live in either a
dataframe-level or a column-level parser. The dataframe-level workaround
suggested in the issue thread is no longer the only option.

Docs only; no behavior change.

I verified the documented order against an editable install of this branch and
executed the page through myst-nb's notebook execution path (jupytext +
nbclient) so the printed output in the new example matches the surrounding
prose.
