### PR TITLE
fix(polars): don't select absent optional columns in add_missing_columns

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -370,15 +370,20 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             **{k: v.default for k, v in missing_cols_schema.items()}
         ).cast({k: v.dtype.type for k, v in missing_cols_schema.items()})
 
+        df_column_names = check_obj.collect_schema().names()
+
         # Get columns present in df but not in schema
         cols_not_in_schema = [
-            col
-            for col in check_obj.collect_schema().names()
-            if col not in schema.columns
+            col for col in df_column_names if col not in schema.columns
         ]
 
-        # Set column order
-        check_obj = check_obj.select([*schema.columns, *cols_not_in_schema])
+        # Set column order. Absent optional columns are never added above, so
+        # selecting every schema column would ask for one that does not exist.
+        cols_in_schema = [
+            col for col in schema.columns if col in df_column_names
+        ]
+
+        check_obj = check_obj.select([*cols_in_schema, *cols_not_in_schema])
         return check_obj
 
     def strict_filter_columns(

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -279,6 +279,25 @@ def test_add_missing_columns_with_nullable(ldf_basic, ldf_schema_basic):
     )
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="add_missing_columns parser not implemented in Narwhals backend",
+    strict=True,
+)
+def test_add_missing_columns_with_absent_optional_column(
+    ldf_basic, ldf_schema_basic
+):
+    """Absent optional columns are skipped, not selected."""
+    ldf_schema_basic.add_missing_columns = True
+    ldf_schema_basic.columns["int_col"].default = 1
+    ldf_schema_basic.columns["opt_col"] = Column(pl.Float64, required=False)
+    modified_data = ldf_basic.drop("int_col")
+    validated_data = modified_data.pipe(ldf_schema_basic.validate)
+    assert validated_data.collect().equals(
+        ldf_basic.with_columns(int_col=pl.lit(1)).collect()
+    )
+
+
 def test_required_columns():
     """Test required columns."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #2459

### Problem

With `add_missing_columns=True`, the polars backend only adds absent columns that are `required` — `collect_column_info` filters on `col_schema.required` when building `absent_column_names`. An absent optional column is therefore never added, which is correct.

The final column-ordering step then selected **every** schema column anyway:

```python
check_obj = check_obj.select([*schema.columns, *cols_not_in_schema])
```

so it asked polars for a column that was deliberately never added, and validation raised `ColumnNotFoundError` instead of passing.

### Fix

Restrict the ordering select to schema columns actually present in the frame. This matches the pandas backend, whose insertion logic filters on `col in df.columns or col_schema.required`.

As a side effect this also makes the select safe for regex columns, whose schema keys are patterns rather than real column names.

### Test

`test_add_missing_columns_with_absent_optional_column` covers it. Verified it fails on main with `ColumnNotFoundError` and passes with the fix. The rest of `tests/polars/` is unaffected (454 passed locally; the only failures were pre-existing `ImportError`s in `test_polars_io.py` from a missing optional dependency in my environment).