### PR TITLE
fix(polars): treat non-expression column defaults as literals

### DIFF
--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -365,9 +365,17 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
             if k in column_info.absent_column_names
         }
 
-        # Append missing columns
+        # Append missing columns. A default that is already an expression is
+        # used as-is; any other value is wrapped in pl.lit, because polars
+        # resolves a bare str in this position as a column reference rather
+        # than as the literal the default is meant to be.
         check_obj = check_obj.with_columns(
-            **{k: v.default for k, v in missing_cols_schema.items()}
+            **{
+                k: v.default
+                if isinstance(v.default, pl.Expr)
+                else pl.lit(v.default)
+                for k, v in missing_cols_schema.items()
+            }
         ).cast({k: v.dtype.type for k, v in missing_cols_schema.items()})
 
         # Get columns present in df but not in schema

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -279,6 +279,22 @@ def test_add_missing_columns_with_nullable(ldf_basic, ldf_schema_basic):
     )
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="add_missing_columns parser not implemented in Narwhals backend",
+    strict=True,
+)
+def test_add_missing_columns_with_string_default(ldf_basic, ldf_schema_basic):
+    """A string default is added as a literal, not a column reference."""
+    ldf_schema_basic.add_missing_columns = True
+    ldf_schema_basic.columns["string_col"].default = "int_col"
+    modified_data = ldf_basic.drop("string_col")
+    validated_data = modified_data.pipe(ldf_schema_basic.validate)
+    assert validated_data.collect().equals(
+        ldf_basic.with_columns(string_col=pl.lit("int_col")).collect()
+    )
+
+
 def test_required_columns():
     """Test required columns."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #2463

### Problem

`add_missing_columns` passed defaults straight into `with_columns`:

```python
check_obj.with_columns(**{k: v.default for k, v in missing_cols_schema.items()})
```

polars resolves a bare `str` in that position as a **column reference**, not a literal. So a string default either:

- raised `ColumnNotFoundError`, or
- worse, when the default happened to match an existing column's name, silently filled the missing column with that column's values — no error, wrong data.

Every non-string default already behaved as a literal, and the pandas backend adds string defaults correctly.

### Fix

Wrap non-expression defaults in `pl.lit`.

Defaults that are *already* polars expressions are passed through unchanged, so the documented expression-default behaviour (`default=pl.col("a")`, `default=pl.lit("foo")`) still works — that is what `test_expr_as_default` covers, and it passes.

### Test

`test_add_missing_columns_with_string_default` uses a default equal to an existing column's name, so it pins the silent-wrong-data variant rather than just the raising one. On main it fails, producing `["0", "1", "2"]` (the referenced column's values) instead of the literal.

`tests/polars/` passes locally: 452 passed, 6 skipped.