### PR TITLE
fix(polars): pass parser_output on Category.try_coerce's ParserError so lazy validation reports failure cases instead of crashing

### DIFF
--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -1003,6 +1003,7 @@ class Category(DataType, dtypes.Category):
                 f"Could not coerce {type(data_container)} data_container "
                 f"into type {self.type}. Invalid categories found in data_container.",
                 failure_cases=failure_cases,
+                parser_output=is_coercible.collect(),
             ) from exc
 
     def __belongs_to_categories(

--- a/pandera/engines/polars_engine.py
+++ b/pandera/engines/polars_engine.py
@@ -958,14 +958,25 @@ class Category(DataType, dtypes.Category):
         if isinstance(data_container, pl.LazyFrame):
             data_container = PolarsData(data_container)
 
-        lf = data_container.lazyframe.cast(self.type, strict=True)
-
         key = data_container.key or "*"
+
+        cast_dtypes: Union[
+            Mapping[
+                Union[ColumnNameOrSelector, PolarsDataType],
+                Union[PolarsDataType, PythonDataType],
+            ],
+            PolarsDataType,
+        ]
+        if key == "*":
+            cast_dtypes = self.type
+        else:
+            cast_dtypes = {key: self.type}
+        lf = data_container.lazyframe.cast(cast_dtypes, strict=True)
+
         belongs_to_categories = self.__belongs_to_categories(lf, key=key)
 
         all_true = (
-            belongs_to_categories.select(pl.all_horizontal(key))
-            .select(pl.all().all())
+            belongs_to_categories.select(pl.col("belongs").all())
             .collect()
             .item()
         )

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -707,6 +707,25 @@ def test_lazy_validation_errors():
         assert exc.failure_cases.shape[0] == 6
 
 
+def test_lazy_validation_errors_category_coerce():
+    """A Category coercion failure reports SchemaErrors, not an AssertionError.
+
+    Category.try_coerce raised ParserError without the parser_output kwarg
+    that failure_cases_metadata asserts is set (#1806).
+    """
+    schema = DataFrameSchema(
+        {"a": Column(pe.Category(categories=["a", "b", "c"]), coerce=True)}
+    )
+    # "x" and "y" fail coercion; the column is then also reported as still
+    # being a String, since the failed coercion left its dtype unchanged.
+    invalid_df = pl.DataFrame({"a": ["a", "x", "y"]})
+
+    try:
+        schema.validate(invalid_df, lazy=True)
+    except pa.errors.SchemaErrors as exc:
+        assert exc.failure_cases.shape[0] == 3
+
+
 def test_dataframe_validation_errors_nullable():
     schema = DataFrameSchema(
         {"a": Column(str, pa.Check.isin([*"abc"]), nullable=False)}

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -707,6 +707,16 @@ def test_lazy_validation_errors():
         assert exc.failure_cases.shape[0] == 6
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason=(
+        "The narwhals backend does not apply coerce=True at all (a "
+        "SchemaWarning fires and the column is left as-is), so "
+        "Category.try_coerce's ParserError path this test targets is never "
+        "reached there; only the plain dtype-mismatch failure case shows up."
+    ),
+    strict=True,
+)
 def test_lazy_validation_errors_category_coerce():
     """A Category coercion failure reports SchemaErrors, not an AssertionError.
 

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -276,6 +276,21 @@ def test_try_coerce_cast_failed(to_dtype, container):
         to_dtype.try_coerce(data_container=container)
 
 
+def test_try_coerce_category_cast_failed_sets_parser_output():
+    """Category.try_coerce's ParserError must carry parser_output.
+
+    failure_cases_metadata asserts SchemaError.check_output (populated from
+    ParserError.parser_output) is not None; leaving it unset crashed lazy
+    validation with a bare AssertionError instead of a SchemaErrors report
+    (#1806).
+    """
+    to_dtype = pe.Category(categories=["a", "b", "c"])
+    container = pl.LazyFrame({"0": ["a", "b", "f"]})
+    with pytest.raises(pandera.errors.ParserError) as exc_info:
+        to_dtype.try_coerce(data_container=container)
+    assert exc_info.value.parser_output is not None
+
+
 @pytest.mark.parametrize("dtype", all_types + special_types)
 def test_check_not_equivalent(dtype):
     """Test that check() rejects non-equivalent dtypes."""

--- a/tests/polars/test_polars_dtypes.py
+++ b/tests/polars/test_polars_dtypes.py
@@ -157,6 +157,25 @@ def test_coerce_no_cast_special(to_dtype, strategy):
         assert dtype == to_dtype.type
 
 
+def test_category_coerce_on_named_column():
+    """Category.coerce() on a named (non-"*") column (#1806).
+
+    coerce() cast the whole lazyframe to Utf8 instead of scoping the cast
+    to the target column, silently converting sibling columns to string;
+    its own validity check then looked up the target column name in a
+    frame that only has a "belongs" column, raising ColumnNotFoundError
+    for every named-column coercion regardless of whether the data was
+    actually coercible.
+    """
+    lf = pl.LazyFrame({"a": [datetime.datetime(2024, 1, 1)], "b": ["a"]})
+    coerced = pe.Category(categories=["a", "b", "c"]).coerce(
+        PolarsData(lf, key="b")
+    )
+    schema = coerced.collect_schema()
+    assert schema["a"] == pl.Datetime("us")
+    assert coerced.collect()["b"].to_list() == ["a"]
+
+
 @pytest.mark.parametrize(
     "data_type_cls", list(pe.Engine.get_registered_dtypes())
 )


### PR DESCRIPTION
`Category.coerce()` casts the whole lazyframe to `Utf8` instead of a mapping keyed on the target column, so coercing a `Category` column silently casts every sibling column to string too. That's the "columns converted to str" from the report.

Its own validity check then does `belongs_to_categories.select(pl.all_horizontal(key))`, but `__belongs_to_categories` already reduced that frame down to a single `belongs` column, so `key` (a real column name) is never found there. That raises `ColumnNotFoundError` for every non-wildcard coercion, valid data or not, which routes through `try_coerce`'s except branch either way. And that branch built its `ParserError` without `parser_output`, so `failure_cases_metadata`'s `assert err.check_output is not None` crashed lazy validation with a bare `AssertionError` instead of a `SchemaErrors` report.

Fixed all three: scoped the cast, fixed the column reference, and passed `parser_output`.

One thing this doesn't fix: the exact script in the issue still errors after these three, now with `SchemaError: expected column 'b' to have type Category, got String`. That's `check_dtype` comparing the raw post-coercion polars dtype (`Utf8`) against the schema's `Category`, and `Category.check()` has no case for "this is the coerced string form of a category, not a wrong type." I didn't touch that since it looked like a real design question (should `Category.check()` special-case it, should coercion mark the frame somehow) rather than a bug I could fix in place, so I'm leaving it to you. Referencing #1806 rather than closing it.

On python 3.11 with polars 1.44.1: three new tests pin the sibling-column corruption, the `ColumnNotFoundError` on a named column, and the `AssertionError` crash under `lazy=True`, none of them pass without this change. `tests/polars/` overall: 455 passed, 6 skipped, same skip set as before. ruff and ruff format are clean; mypy on this file has the same pre-existing errors it had before my change, nothing new. Only checked 3.11 here, not the full 3.10-3.14 x polars 1.20/1.33/1.42 matrix.
