### PR TITLE
fix(config): coerce a string validation_depth instead of silently disabling gating

### DIFF
--- a/pandera/config.py
+++ b/pandera/config.py
@@ -64,6 +64,22 @@ class PanderaConfig:
 _TRUTHY = {"true", "True", "1"}
 
 
+def _coerce_validation_depth(
+    validation_depth: ValidationDepth | str | None,
+) -> ValidationDepth | None:
+    """Coerce a user-supplied validation depth into a ``ValidationDepth``.
+
+    ``ValidationDepth`` is a plain ``Enum``, so an un-coerced string compares
+    unequal to every member. Every ``@validate_scope`` gate is a
+    ``config.validation_depth == ValidationDepth.X`` comparison, so storing
+    the raw string turns depth gating into a silent no-op. Coercing here also
+    makes an unknown value raise ``ValueError`` instead of disabling gating.
+    """
+    if validation_depth is None:
+        return None
+    return ValidationDepth(validation_depth)
+
+
 def _silenced_warnings_from_env() -> list[str]:
     """Collect silenced warnings from environment variables."""
     all_warning_names = [
@@ -81,9 +97,9 @@ def _config_from_env_vars():
         os.environ.get("PANDERA_VALIDATION_ENABLED", "True") in _TRUTHY
     )
 
-    validation_depth = os.environ.get("PANDERA_VALIDATION_DEPTH", None)
-    if validation_depth is not None:
-        validation_depth = ValidationDepth(validation_depth)
+    validation_depth = _coerce_validation_depth(
+        os.environ.get("PANDERA_VALIDATION_DEPTH", None)
+    )
 
     cache_dataframe = (
         os.environ.get("PANDERA_CACHE_DATAFRAME", "False") in _TRUTHY
@@ -146,7 +162,7 @@ _CONTEXT_CONFIG = _ContextConfig(_copy_config(CONFIG))
 
 def set_config(
     validation_enabled: bool | None = None,
-    validation_depth: ValidationDepth | None = None,
+    validation_depth: ValidationDepth | str | None = None,
     cache_dataframe: bool | None = None,
     keep_cached_dataframe: bool | None = None,
     use_narwhals_backend: bool | None = None,
@@ -156,7 +172,8 @@ def set_config(
 
     Args:
         validation_enabled: Enable or disable validation (default: None)
-        validation_depth: Validation depth level (SCHEMA_ONLY, DATA_ONLY, SCHEMA_AND_DATA)
+        validation_depth: Validation depth level (SCHEMA_ONLY, DATA_ONLY,
+            SCHEMA_AND_DATA), as a ``ValidationDepth`` or its string name
         cache_dataframe: Whether to cache dataframes during validation (default: None)
         keep_cached_dataframe: Whether to keep cached dataframes after validation (default: None)
         use_narwhals_backend: Enable Narwhals-powered backend for compatible backends (default: None)
@@ -174,7 +191,7 @@ def set_config(
     if validation_enabled is not None:
         CONFIG.validation_enabled = validation_enabled
     if validation_depth is not None:
-        CONFIG.validation_depth = validation_depth
+        CONFIG.validation_depth = _coerce_validation_depth(validation_depth)
     if cache_dataframe is not None:
         CONFIG.cache_dataframe = cache_dataframe
     if keep_cached_dataframe is not None:
@@ -200,7 +217,7 @@ def set_config(
 @contextmanager
 def config_context(
     validation_enabled: bool | None = None,
-    validation_depth: ValidationDepth | None = None,
+    validation_depth: ValidationDepth | str | None = None,
     cache_dataframe: bool | None = None,
     keep_cached_dataframe: bool | None = None,
     use_narwhals_backend: bool | None = None,
@@ -213,7 +230,9 @@ def config_context(
     if validation_enabled is not None:
         context_config.validation_enabled = validation_enabled
     if validation_depth is not None:
-        context_config.validation_depth = validation_depth
+        context_config.validation_depth = _coerce_validation_depth(
+            validation_depth
+        )
     if cache_dataframe is not None:
         context_config.cache_dataframe = cache_dataframe
     if keep_cached_dataframe is not None:

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -38,7 +38,9 @@ def test_set_config_updates_attributes():
         )
 
         assert CONFIG.validation_enabled is False
-        assert CONFIG.validation_depth == "DATA_ONLY"
+        # the string is coerced on the way in, so the stored value compares
+        # equal to the enum member the @validate_scope gates check against
+        assert CONFIG.validation_depth is ValidationDepth.DATA_ONLY
         assert CONFIG.cache_dataframe is True
         assert CONFIG.keep_cached_dataframe is True
         assert CONFIG.use_narwhals_backend is True
@@ -47,6 +49,41 @@ def test_set_config_updates_attributes():
         # Restore original values
         set_config(**original_values)
         CONFIG.validation_depth = original_values["validation_depth"]
+        reset_config_context()
+
+
+@pytest.mark.parametrize(
+    "validation_depth",
+    ["SCHEMA_ONLY", "DATA_ONLY", "SCHEMA_AND_DATA"],
+)
+def test_config_context_coerces_string_validation_depth(validation_depth):
+    """A string depth is stored as the matching ValidationDepth member.
+
+    ValidationDepth is a plain Enum, so an un-coerced string compares unequal
+    to every member and turns each @validate_scope gate into a no-op.
+    """
+    with config_context(validation_depth=validation_depth):
+        stored = get_config_context().validation_depth
+
+    assert stored is ValidationDepth(validation_depth)
+
+
+def test_config_context_rejects_unknown_validation_depth():
+    """An unknown depth raises instead of silently disabling gating."""
+    with pytest.raises(ValueError, match="not a valid ValidationDepth"):
+        with config_context(validation_depth="NOT_A_DEPTH"):
+            pass
+
+
+def test_set_config_rejects_unknown_validation_depth():
+    """set_config coerces on the same terms as config_context."""
+    original = CONFIG.validation_depth
+    try:
+        with pytest.raises(ValueError, match="not a valid ValidationDepth"):
+            set_config(validation_depth="NOT_A_DEPTH")
+        assert CONFIG.validation_depth == original
+    finally:
+        CONFIG.validation_depth = original
         reset_config_context()
 
 

--- a/tests/pandas/test_validation_depth.py
+++ b/tests/pandas/test_validation_depth.py
@@ -33,6 +33,12 @@ def custom_backend():
         [ValidationDepth.DATA_ONLY, [True, False]],
         [ValidationDepth.SCHEMA_AND_DATA, [False, False]],
         [None, [False, False]],
+        # a string names the same depth: config_context coerces it, so the
+        # gate behaves identically to the enum member. Left un-coerced these
+        # would all read [False, False] -- gating silently off.
+        ["SCHEMA_ONLY", [False, True]],
+        ["DATA_ONLY", [True, False]],
+        ["SCHEMA_AND_DATA", [False, False]],
     ],
 )
 def test_validate_scope(validation_depth, expected):
@@ -42,3 +48,10 @@ def test_validate_scope(validation_depth, expected):
         data_result = backend.check_data("foo")
         results = [schema_result.passed, data_result.passed]
         assert results == expected
+
+
+def test_validate_scope_rejects_unknown_validation_depth():
+    """An unknown depth must fail loudly rather than disable every gate."""
+    with pytest.raises(ValueError, match="not a valid ValidationDepth"):
+        with config_context(validation_depth="SCHEMA_ONLY_TYPO"):
+            pass


### PR DESCRIPTION
Fixes #2431.

### Problem

`ValidationDepth` is a plain `Enum`, so a string stored un-coerced compares unequal to every member. Every depth gate is a `config.validation_depth == ValidationDepth.X` comparison inside `@validate_scope`, so passing the string turns all gating — both scopes, every backend — into a silent no-op:

```python
with config_context(validation_depth="SCHEMA_ONLY"):
    backend.check_data("foo")   # DATA-scoped, ran anyway
```

@aladinor hit this through the xarray backend, where a nominally structural validation materialized a lazily-backed `Dataset` — remote chunk fetches against a zarr store, from a call that should not have touched the data — because the DATA-scoped `check_nullable` was never skipped.

The env-var path already coerced (`ValidationDepth(validation_depth)` for `PANDERA_VALIDATION_DEPTH`), so the same value behaved differently depending on which way it was supplied.

### Change

Coerce user-supplied depths in `set_config` and `config_context` through a shared `_coerce_validation_depth`, which the env-var path now also calls. This is the first of the two options in the issue; it keeps `ValidationDepth` a plain `Enum` rather than making it a `(str, Enum)`, so nothing about the existing member semantics changes.

An unknown value now raises rather than quietly turning gating off:

```python
>>> with config_context(validation_depth="SCHEMA_ONLY_TYPO"): ...
ValueError: 'SCHEMA_ONLY_TYPO' is not a valid ValidationDepth
```

The parameter types on both functions become `ValidationDepth | str | None`, so the accepted input is what the signature says. An already-coerced member passes through unchanged (`ValidationDepth(ValidationDepth.DATA_ONLY) is ValidationDepth.DATA_ONLY`), so the enum path is untouched.

### One existing assertion changed

`tests/base/test_config.py::test_set_config_updates_attributes` pinned the un-coerced behaviour:

```python
set_config(validation_depth="DATA_ONLY", ...)
assert CONFIG.validation_depth == "DATA_ONLY"     # before
assert CONFIG.validation_depth is ValidationDepth.DATA_ONLY   # after
```

Flagging it explicitly since it is the one place a test is asserting something different rather than being added.

### Tests

`test_validate_scope` is parametrised over the three string depths, asserting each gates identically to its enum member — the end-to-end shape of the bug, since un-coerced they would all read `[False, False]`. Plus coercion and `ValueError` cases for both `set_config` and `config_context`.

Nine of the twenty tests in the two files fail on `main` and pass here:

```
$ pytest tests/base/test_config.py tests/pandas/test_validation_depth.py -q
20 passed

$ pytest tests/base tests/pandas/test_config.py tests/pandas/test_pandas_config.py -q
38 passed
```

`ruff check`, `ruff format --check` and `mypy` are clean on the three changed files.

### Not included

The `str(SchemaErrors)` rendering as `{}` for a lazy `DataTreeSchema` failure, noted at the end of the issue — happy to send that separately if it's wanted.
