### PR TITLE
fix(polars): honour ignore_na=False when the check output is null

### DIFF
--- a/pandera/backends/polars/checks.py
+++ b/pandera/backends/polars/checks.py
@@ -91,6 +91,12 @@ class PolarsCheckBackend(BaseCheckBackend):
             results = results.with_columns(
                 pl.col(CHECK_OUTPUT_KEY) | pl.col(CHECK_OUTPUT_KEY).is_null()
             )
+        else:
+            # a null check output is not a pass: all() and filter(not_())
+            # both discard nulls, which makes ignore_na=False inert.
+            results = results.with_columns(
+                pl.col(CHECK_OUTPUT_KEY).fill_null(False)
+            )
         passed = results.select([pl.col(CHECK_OUTPUT_KEY).all()])
         failure_cases = horizontal_concat(
             [check_obj.lazyframe, results]

--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -55,6 +55,12 @@ def _column_check_fn_scalar_out(data: pa.PolarsData) -> pl.LazyFrame:
             True,
         ],
         [_column_check_fn_scalar_out, [-1, 2, 3, None], [False], True],
+        [
+            _column_check_fn_df_out,
+            [-1, 2, 3, None],
+            [False, True, True, False],
+            False,
+        ],
     ],
 )
 def test_polars_column_check(
@@ -75,6 +81,26 @@ def test_polars_column_check(
         invalid_check_result.check_output.collect()[CHECK_OUTPUT_KEY].to_list()
         == expected_output
     )
+
+
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="The narwhals backend ignores null check outputs on polars frames even when ignore_na=False",
+    strict=True,
+)
+def test_polars_check_ignore_na_false_fails_null_rows():
+    """A null value fails the check when ignore_na=False."""
+    lf = pl.LazyFrame({"col": pl.Series([None, 1, 2], dtype=int)})
+    schema = pa.DataFrameSchema(
+        {"col": pa.Column(int, pa.Check.ge(0, ignore_na=False), nullable=True)}
+    )
+
+    with pytest.raises(pa.errors.SchemaError):
+        schema.validate(lf)
+
+    with pytest.raises(pa.errors.SchemaErrors) as exc_info:
+        schema.validate(lf, lazy=True)
+    assert exc_info.value.failure_cases["failure_case"].to_list() == [None]
 
 
 def _df_check_fn_df_out(data: pa.PolarsData) -> pl.LazyFrame:


### PR DESCRIPTION
`Check(ignore_na=False)` does nothing on the polars backend. Same schema, same data, `["ab", None, "ac"]` with `Check.str_startswith("a", ignore_na=False)`: pandas raises with one failure case, polars passes. I ran all 13 built-in checks and on polars the flag changes nothing in any of them.

`postprocess_lazyframe_output` keeps the null in the check output, which is right, and then both consumers drop it: `all()` defaults to `ignore_nulls=True`, and `NOT null` is null, so `filter(pl.col(CHECK_OUTPUT_KEY).not_())` loses the row. So fill those nulls with False, mirroring the `ignore_na=True` branch above it. Filling the output rather than patching the two call sites also keeps the failure-case row lookup in `polars/base.py` working, since that finds the row with `.eq(False)`.

Two things to flag. With `drop_invalid_rows=True` and `ignore_na=False` a null row now gets dropped, where it was kept before. And pandas is looser than this: `Check.ge(0, ignore_na=False)` on a null passes there, since the NA survives into `check_output.all()`. I went with what `tests/narwhals/test_pandas_e2e.py::test_ignore_na_false_fails_nan_rows` pins.

Tests are the missing cell in `test_polars_column_check` and a schema-level one; both fail on main. `tests/polars` is green on 3.10/polars 1.20.0 and 3.11/polars 1.44.1, with and without `PANDERA_USE_NARWHALS_BACKEND`.

The narwhals backend has the same gap on polars frames, so the new test is xfail there rather than fixed. Different file, and I have not looked at its ibis or pyspark paths. Can do that as a follow-up.
