### PR TITLE
fix(polars): fail loudly on user-declared parsers instead of skipping them

### DIFF
--- a/pandera/api/polars/model.py
+++ b/pandera/api/polars/model.py
@@ -38,6 +38,13 @@ class DataFrameModel(_DataFrameModel[pl.LazyFrame, DataFrameSchema]):
 
     @classmethod
     def build_schema_(cls, **kwargs) -> DataFrameSchema:
+        # User-defined parsers are not supported by the polars backend yet
+        # (see issue #2472): fail loudly instead of silently dropping them.
+        if cls.__parsers__ or cls.__root_parsers__:
+            raise SchemaInitError(
+                "user-defined parsers are not supported by the polars "
+                "backend (see issue #2472)"
+            )
         return DataFrameSchema(
             cls._build_columns(cls.__fields__, cls.__checks__),
             checks=cls.__root_checks__,

--- a/pandera/backends/polars/container.py
+++ b/pandera/backends/polars/container.py
@@ -67,6 +67,18 @@ class DataFrameSchemaBackend(PolarsSchemaBackend):
                 "When drop_invalid_rows is True, lazy must be set to True."
             )
 
+        # User-defined parsers are not supported by the polars backend yet:
+        # neither the model builder nor this backend wires them up. Fail
+        # loudly instead of validating un-transformed data (#2472).
+        declared_parsers = list(getattr(schema, "parsers", None) or [])
+        for component in (getattr(schema, "columns", {}) or {}).values():
+            declared_parsers.extend(getattr(component, "parsers", None) or [])
+        if declared_parsers:
+            raise NotImplementedError(
+                "user-defined parsers are not supported by the polars "
+                "backend (see issue #2472)"
+            )
+
         core_parsers: list[tuple[Callable[..., Any], tuple[Any, ...]]] = [
             (self.add_missing_columns, (schema, column_info)),
             (self.strict_filter_columns, (schema, column_info)),

--- a/tests/polars/test_polars_container.py
+++ b/tests/polars/test_polars_container.py
@@ -293,6 +293,34 @@ def test_required_columns():
         ldf.drop("a").pipe(schema.validate).collect()
 
 
+@pytest.mark.xfail(
+    condition=CONFIG.use_narwhals_backend,
+    reason="user-parser guard not implemented in Narwhals backend (follow-up to #2472)",
+    strict=True,
+)
+def test_polars_user_parsers_raise():
+    """Declared parsers must fail loudly instead of being skipped (#2472)."""
+    from pandera.api.parsers import Parser
+
+    def _upper(obj):
+        return obj
+
+    # column-level declaration
+    schema = DataFrameSchema(
+        {"a": Column(pl.Utf8, parsers=Parser(_upper))},
+    )
+    with pytest.raises(NotImplementedError, match="not supported"):
+        schema.validate(pl.DataFrame({"a": ["x"]}))
+
+    # schema-level declaration
+    schema = DataFrameSchema(
+        {"a": Column(pl.Utf8)},
+        parsers=Parser(_upper),
+    )
+    with pytest.raises(NotImplementedError, match="not supported"):
+        schema.validate(pl.DataFrame({"a": ["x"]}))
+
+
 def test_missing_required_column_when_lazy_is_true():
     """Test missing required columns when lazy=True."""
     schema = DataFrameSchema(

--- a/tests/polars/test_polars_model.py
+++ b/tests/polars/test_polars_model.py
@@ -646,3 +646,22 @@ def test_category_coercion_failure_no_deprecation_warning(
     message = str(exc_info.value)
     assert "DeprecationWarning" not in message
     assert "Invalid categories" in message
+
+
+def test_polars_model_parsers_raise():
+    """Parsers declared on a polars model must fail loudly (#2472)."""
+    import pandera as pa
+    import pandera.polars as pa_pl
+    from pandera.errors import SchemaInitError
+    from pandera.typing.polars import Series
+
+    class ModelWithParser(pa_pl.DataFrameModel):
+        a: Series[pl.Utf8]
+
+        @pa.parser("a")
+        @classmethod
+        def _upper(cls, data):
+            return data
+
+    with pytest.raises(SchemaInitError, match="not supported"):
+        ModelWithParser.to_schema()


### PR DESCRIPTION
## Root Cause
User-declared parsers are silently ignored on the polars backend. `pandera/api/polars/model.py::_build_columns` never collects `__parsers__` (pandas wires field and root parsers in `pandera/api/pandas/model.py`), and `pandera/backends/polars/container.py::validate` has no `run_parsers` equivalent (pandas: `container.py:83,858`). Since the base `ComponentSchema` accepts and stores `parsers`, all three declaration styles (`Column(..., parsers=...)`, `DataFrameSchema(..., parsers=...)`, `@pa.parser` on a polars model) construct fine and then never execute — validation passes on un-transformed data. Details in #2472.

## Fix
Fail loudly at both entry points, consistent with the existing `NotImplementedError`s in the polars backend (e.g. duplicate column names):
- `backends/polars/container.py::validate` raises `NotImplementedError` when the schema or any column carries parsers.
- `api/polars/model.py::build_schema_` raises `SchemaInitError` when the model declares field or root parsers.

Full user-parser execution on polars is deliberately out of scope (parser functions are pandas-oriented); this turns silent corruption into a loud, actionable error.

## Test
- New: `test_polars_user_parsers_raise` (column- and schema-level) and `test_polars_model_parsers_raise` (decorator path). All three fail pre-fix (no error raised — the silent skip) and pass post-fix.
- Existing: `tests/polars/test_polars_container.py` + `test_polars_model.py` + `test_polars_components.py` — 163 passed. `ruff format --check` and `ruff check` clean (zero new findings vs main).
- Repro from #2472 verified: pandas uppercases (`['X']`), polars pre-fix silently keeps `['x']`, post-fix raises.

## Diff scope
4 files, +59/-0 (source: 19 lines across 2 files; rest is tests)


## Scope note

The Narwhals backend path shares the same silent-skip gap (verified: the new container test xfails under `PANDERA_USE_NARWHALS_BACKEND=True`, mirroring the neighboring tests). Scoped to the native polars backend plus the model builder; Narwhals coverage is a follow-up (noted on #2472).