### PR TITLE
Fix implicit Optional on Column dtype in the Ibis backend

### DIFF
--- a/pandera/api/ibis/components.py
+++ b/pandera/api/ibis/components.py
@@ -20,7 +20,7 @@ class Column(ComponentSchema[ibis.Table]):
 
     def __init__(
         self,
-        dtype: IbisDtypeInputTypes = None,
+        dtype: IbisDtypeInputTypes | None = None,
         checks: CheckList | None = None,
         nullable: bool = False,
         unique: bool = False,


### PR DESCRIPTION
`Column.__init__` in the Ibis backend annotates `dtype` as `IbisDtypeInputTypes` but defaults it to `None`:

https://github.com/unionai-oss/pandera/blob/main/pandera/api/ibis/components.py#L21-L24

`IbisDtypeInputTypes` doesn't include `None`:

```python
# pandera/api/ibis/types.py
IbisDtypeInputTypes = Union[
    str,
    type,
    dt.DataType,
]
```

so the annotation says a value is required when passing nothing is the normal case. PEP 484 prohibits this implicit Optional, and it's inconsistent in two directions:

- the other backends annotate the same parameter with `| None` — pandas `dtype: PandasDtypeInputTypes | None = None`, polars `dtype: PolarsDtypeInputTypes | None = None`, pyspark `dtype: PySparkDtypeInputTypes | None = None`
- every other optional parameter in this same signature (`checks`, `name`, `title`, `description`, `default`, `metadata`) already uses `| None`

The fix is the one-line annotation change, no behaviour change.

One note on scope: this isn't currently caught by the repo's mypy run, because `ibis` isn't installed in the type-check environment, so `dt.DataType` resolves to `Any` and the union silently absorbs `None`. On a reduced example with the alias fully resolved it's a hard error:

```
error: Incompatible default for argument "dtype" (default has type "None", argument has type "str | type")  [assignment]
note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
```

So this is about the annotation being accurate for anyone type-checking against pandera with ibis installed, rather than a currently-failing check.

Tests: `tests/ibis` doesn't collect in my environment (`ModuleNotFoundError: No module named 'ibis'`), and I confirmed it fails identically on an unmodified checkout, so that's environmental rather than caused by this change.
