### PR TITLE
Reject reversed bounds in Check.str_length

### DIFF
--- a/pandera/api/checks.py
+++ b/pandera/api/checks.py
@@ -717,6 +717,19 @@ class Check(BaseCheck):
                 "At least a minimum or a maximum need to be specified. Got "
                 "None."
             )
+        # Both bounds are inclusive here, so only max < min is empty. Without
+        # this the check builds and then fails every string, which reads as a
+        # data problem rather than a transposed pair of arguments. in_range
+        # refuses the same mistake.
+        if (
+            min_value is not None
+            and max_value is not None
+            and max_value < min_value
+        ):
+            raise ValueError(
+                f"The combination of min_value = {min_value} and "
+                f"max_value = {max_value} defines an empty interval!"
+            )
         return cls.from_builtin_check_name(
             "str_length",
             kwargs,

--- a/tests/pandas/test_checks_builtin.py
+++ b/tests/pandas/test_checks_builtin.py
@@ -400,6 +400,45 @@ class TestLessThanOrEqualTo:
         check_none_failures(values, check_fn(max_value, ignore_na=False))
 
 
+class TestStrLengthArguments:
+    """Tests for Check.str_length argument validation"""
+
+    @staticmethod
+    @pytest.mark.parametrize("args", [(3, 1), (5, 0)])
+    def test_reversed_bounds_are_rejected(args):
+        """A max below the min can never match, so refuse it at construction.
+
+        Without this the check builds and then fails every string, which
+        reads as a data problem rather than a transposed argument pair.
+        """
+        with pytest.raises(ValueError, match="empty interval"):
+            Check.str_length(*args)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        [
+            ((1, 5), {}),
+            ((2, 2), {}),
+            ((5,), {}),
+            ((), {"min_value": 2}),
+            ((), {"max_value": 2}),
+        ],
+    )
+    def test_valid_bounds_still_build(args, kwargs):
+        """The guard must not catch any form that was already accepted."""
+        assert Check.str_length(*args, **kwargs) is not None
+
+    @staticmethod
+    def test_matches_the_in_range_message():
+        """The same mistake reports the same way in both checks."""
+        with pytest.raises(ValueError) as str_length_error:
+            Check.str_length(3, 1)
+        with pytest.raises(ValueError) as in_range_error:
+            Check.in_range(3, 1)
+        assert str(str_length_error.value) == str(in_range_error.value)
+
+
 class TestInRange:
     """Tests for Check.in_range"""
 


### PR DESCRIPTION
`Check.in_range` refuses a max below its min at construction:

```python
Check.in_range(3, 1)
# ValueError: The combination of min_value = 3 and max_value = 1 defines an empty interval!
```

`Check.str_length` takes the same pair of bounds and accepts it:

```python
Check.str_length(3, 1)   # builds fine
```

The resulting check can never pass. Every string fails it, and the report reads as a
column full of bad data rather than as a transposed pair of arguments, so the person
reading it goes looking in the wrong place.

This adds the same guard with the same message. Both bounds are inclusive here, so only
max < min is empty and `str_length(2, 2)` stays valid.

Unchanged: `str_length(1, 5)`, `str_length(2, 2)`, the exact form `str_length(5)`,
min-only, and max-only.

`str_length` and `in_range` are the only two builtin checks that take a min/max pair, so
this is the whole of it.

Tests cover the two reversed spellings, the five accepted forms as controls, and one
asserting both checks now produce the same message for the same mistake. Three fail on the
commit before the change; the five control cases pass either way, which is what they are
for.

`tests/pandas`: 2135 passed. I compared the failing set with and without the change and
the only difference is the new tests. Three unrelated failures in that directory need
pyarrow, which is not installed here, and they fail the same way both with and without.
`ruff check` and `ruff format --check` are clean.

Not covered here: a negative `min_value` is still accepted, and #1406 covers the case
where neither bound is set. Both are separate from the reversed pair.