### PR TITLE
fix: strict=True does not validate the dataframe index

### DIFF
--- a/pandera/api/base/error_handler.py
+++ b/pandera/api/base/error_handler.py
@@ -37,6 +37,7 @@ ERROR_CATEGORY_MAP = {
     SchemaErrorReason.INVALID_COLUMN_NAME: ErrorCategory.SCHEMA,
     SchemaErrorReason.MISMATCH_INDEX: ErrorCategory.SCHEMA,
     SchemaErrorReason.PARSER_ERROR: ErrorCategory.DATA,
+    SchemaErrorReason.INDEX_NOT_IN_SCHEMA: ErrorCategory.SCHEMA,
 }
 
 

--- a/pandera/backends/pandas/container.py
+++ b/pandera/backends/pandas/container.py
@@ -178,6 +178,7 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             (self.check_column_names_are_unique, (check_obj, schema)),
             (self.check_column_presence, (check_obj, schema, column_info)),
             (self.check_column_values_are_unique, (sample, schema)),
+            (self.check_index_not_in_schema, (check_obj, schema)),
             (
                 self.run_schema_component_checks,
                 (sample, schema, components, lazy),
@@ -903,6 +904,55 @@ class DataFrameSchemaBackend(PandasSchemaBackend):
             passed=passed,
             check="dataframe_column_labels_unique",
             reason_code=SchemaErrorReason.DUPLICATE_COLUMN_LABELS,
+            message=message,
+            failure_cases=failure_cases,
+        )
+
+    @validate_scope(scope=ValidationScope.SCHEMA)
+    def check_index_not_in_schema(
+        self,
+        check_obj: pd.DataFrame,
+        schema,
+    ) -> CoreCheckResult:
+        """Under ``strict=True``, ensure the dataframe has the default index
+        if the schema doesn't declare one.
+
+        ``strict`` otherwise only constrains the dataframe's columns, so a
+        dataframe with a non-default index (e.g. one that's been filtered,
+        set to a column, or renamed) would silently pass validation even
+        though it carries information the schema knows nothing about.
+        """
+        passed = True
+        message = None
+        failure_cases = None
+
+        if schema.strict is not True or schema.index is not None:
+            return CoreCheckResult(
+                passed=passed,
+                check="index_not_in_schema",
+            )
+
+        index = check_obj.index
+        is_default_index = (
+            isinstance(index, pd.RangeIndex)
+            and index.name is None
+            and index.start == 0
+            and index.step == 1
+        )
+        if not is_default_index:
+            passed = False
+            message = (
+                "index is not the default pandas RangeIndex, but the "
+                f"{schema.__class__.__name__} does not declare an index and "
+                "strict=True. Either specify an index in the schema or "
+                "reset the dataframe's index to the default."
+            )
+            failure_cases = str(index)
+
+        return CoreCheckResult(
+            passed=passed,
+            check="index_not_in_schema",
+            reason_code=SchemaErrorReason.INDEX_NOT_IN_SCHEMA,
             message=message,
             failure_cases=failure_cases,
         )

--- a/pandera/errors.py
+++ b/pandera/errors.py
@@ -160,6 +160,7 @@ class SchemaErrorReason(Enum):
     ADD_MISSING_COLUMN_NO_DEFAULT = "add_missing_column_no_default"
     INVALID_COLUMN_NAME = "invalid_column_name"
     MISMATCH_INDEX = "mismatch_index"
+    INDEX_NOT_IN_SCHEMA = "index_not_in_schema"
 
 
 class SchemaErrors(ReducedPickleExceptionBase):

--- a/pandera/validation_depth.py
+++ b/pandera/validation_depth.py
@@ -30,6 +30,7 @@ VALIDATION_DEPTH_ERROR_CODE_MAP = {
     SchemaErrorReason.INVALID_COLUMN_NAME: ValidationScope.SCHEMA,
     SchemaErrorReason.MISMATCH_INDEX: ValidationScope.SCHEMA,
     SchemaErrorReason.PARSER_ERROR: ValidationScope.DATA,
+    SchemaErrorReason.INDEX_NOT_IN_SCHEMA: ValidationScope.SCHEMA,
 }
 
 

--- a/tests/pandas/test_schemas.py
+++ b/tests/pandas/test_schemas.py
@@ -229,6 +229,45 @@ def test_dataframe_schema_strict_and_ordered_raises_both_errors() -> None:
     assert errors.SchemaErrorReason.COLUMN_NOT_IN_SCHEMA in reason_codes
 
 
+def test_dataframe_schema_strict_index() -> None:
+    """Regression test for #1493: strict=True should also reject a
+    non-default index when the schema doesn't declare an index."""
+    schema = DataFrameSchema(
+        {"a": Column(int)},
+        strict=True,
+    )
+
+    # default RangeIndex passes
+    df_default_index = pd.DataFrame({"a": [1, 2, 3]})
+    assert isinstance(schema.validate(df_default_index), pd.DataFrame)
+
+    # named index fails, even though the index values themselves are valid
+    df_named_index = pd.DataFrame(
+        {"a": [1]}, index=pd.Index(["x"], name="foo")
+    )
+    with pytest.raises(errors.SchemaErrors) as exc_info:
+        schema.validate(df_named_index, lazy=True)
+    reason_codes = {e.reason_code for e in exc_info.value.schema_errors}
+    assert errors.SchemaErrorReason.INDEX_NOT_IN_SCHEMA in reason_codes
+
+    # non-RangeIndex (e.g. after filtering rows) fails
+    df_filtered = pd.DataFrame({"a": [1, 2, 3]}).loc[lambda d: d["a"] > 1]
+    with pytest.raises(errors.SchemaError):
+        schema.validate(df_filtered)
+
+    # strict=False allows any index, unchanged from before
+    lenient_schema = DataFrameSchema({"a": Column(int)}, strict=False)
+    assert isinstance(lenient_schema.validate(df_named_index), pd.DataFrame)
+
+    # a schema that declares its own index is unaffected
+    schema_with_index = DataFrameSchema(
+        {"a": Column(int)},
+        index=Index(str, name="foo"),
+        strict=True,
+    )
+    assert isinstance(schema_with_index.validate(df_named_index), pd.DataFrame)
+
+
 def test_dataframe_schema_strict_regex() -> None:
     """Test that strict dataframe schema checks for regex matches."""
     schema = DataFrameSchema(


### PR DESCRIPTION
Fixes #1493.

`strict=True` only checks that the dataframe's columns match the schema. If the schema doesn't declare an index, the index is never checked at all, so a dataframe with a named, filtered, or otherwise non-default index passes validation even though `strict=True` implies nothing outside the schema should slip through.

As suggested in the issue: when `strict=True` and the schema has no index spec, require the dataframe's index to be the default pandas `RangeIndex` (no name, starts at 0, step 1). Schemas that declare their own index, or don't set `strict=True`, are unaffected.

Added a new `SchemaErrorReason.INDEX_NOT_IN_SCHEMA` and a `check_index_not_in_schema` core check in the pandas container backend, following the same pattern as the existing `check_column_names_are_unique` check.

## Backward compatibility

No existing test was modified. This does change behavior for dataframes that combine `strict=True` with a non-default index and a schema that doesn't declare an index: those now raise where they previously passed silently. This is the exact behavior gap reported in #1493 and the fix a maintainer requested in the issue thread, so the change is intentional. Any caller currently relying on `strict=True` silently ignoring the index can either declare an index in the schema or reset the dataframe's index before validating.

## Testing

Verified against the exact repro in the issue, added a regression test (`test_dataframe_schema_strict_index`) covering: default index passes, named index raises, non-RangeIndex (e.g. post-filter) raises, `strict=False` is unaffected, and a schema with an explicit index declaration is unaffected. Ran the full `tests/pandas`, `tests/core`, `tests/io`, `tests/strategies`, and `tests/hypotheses` suites — all pass, no regressions. Also ran `ruff check`/`ruff format` and `mypy` on the changed files.