### PR TITLE
fix: partial MultiIndex check fails if only some index levels are declared

### DIFF
--- a/pandera/backends/pandas/components.py
+++ b/pandera/backends/pandas/components.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from pandera.api.base.error_handler import ErrorHandler, get_error_category
-from pandera.api.pandas.components import Column
+from pandera.api.pandas.components import Column, MultiIndex
 from pandera.api.pandas.types import (
     is_field,
     is_index,
@@ -309,6 +309,28 @@ class IndexBackend(ArraySchemaBackend):
         inplace: bool = False,
     ) -> Union[pd.DataFrame, pd.Series]:
         if is_multiindex(check_obj.index):
+            if (
+                schema.name is not None
+                and schema.name in check_obj.index.names
+            ):
+                # This Index schema names one level of an actual pandas
+                # MultiIndex, e.g. a DataFrameModel with a single
+                # ``check_name=True`` index field validated against a
+                # dataframe with more index levels than the schema
+                # declares. Delegate to MultiIndexBackend, which knows how
+                # to validate a single named level without requiring (or
+                # touching) the other levels.
+                multiindex_schema = MultiIndex([schema])
+                return multiindex_schema.get_backend(check_obj).validate(
+                    check_obj,
+                    multiindex_schema,
+                    head=head,
+                    tail=tail,
+                    sample=sample,
+                    random_state=random_state,
+                    lazy=lazy,
+                    inplace=inplace,
+                )
             raise SchemaError(
                 schema,
                 check_obj,
@@ -1245,34 +1267,35 @@ class MultiIndexBackend(PandasSchemaBackend):
             ):
                 current_level_pos += 1
 
-            # Now walk forward until we find the index name
+            # Now walk forward until we find the index name. Levels that
+            # aren't declared by this schema (a partial/subset MultiIndex
+            # schema) are simply skipped here rather than flagged as
+            # out-of-order: `_validate_index_names` performs the
+            # authoritative order and duplicate-name checks once the full
+            # mapping is known, so raising here would incorrectly reject
+            # a schema that only checks a subset of the index levels.
             while (
                 current_level_pos < n_levels
                 and mi_names[current_level_pos] != idx_name
             ):
-                # Any *other* name before we meet `idx_name` => out-of-order
-                self._collect_or_raise(
-                    error_handler,
-                    SchemaError(
-                        schema=schema,
-                        data=mi,
-                        message=f"column '{idx_name}' out-of-order",
-                        failure_cases=idx_name,
-                        check="column_ordered",
-                        reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,
-                    ),
-                    schema,
-                )
                 current_level_pos += 1
 
             if current_level_pos >= n_levels:
-                # ran off the end without finding target index level
+                # Ran off the end without finding the target index level. If
+                # the name exists elsewhere in the dataframe's levels, we
+                # must have already walked past it while matching an
+                # earlier schema level, i.e. a genuine ordering violation.
+                # Otherwise the name simply isn't in the dataframe at all.
+                if idx_name in mi_names:
+                    message = f"column '{idx_name}' out-of-order"
+                else:
+                    message = f"index level with name '{idx_name}' not found"
                 self._collect_or_raise(
                     error_handler,
                     SchemaError(
                         schema=schema,
                         data=mi,
-                        message=f"index level with name '{idx_name}' not found",
+                        message=message,
                         failure_cases=idx_name,
                         check="column_ordered",
                         reason_code=SchemaErrorReason.COLUMN_NOT_ORDERED,

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -624,6 +624,40 @@ def test_multiindex_check_name() -> None:
     assert isinstance(NotCheckNameSchema.validate(df), pd.DataFrame)
 
 
+def test_partial_multiindex_check_name() -> None:
+    """Regression test for #1460: a DataFrameModel with a single
+    ``check_name=True`` index field should validate just that one named
+    level of an actual pandas MultiIndex, not only a plain Index."""
+
+    m_idx = pd.MultiIndex.from_tuples(
+        ((1, 0, 0), (0, 1, 0), (0, 0, 1)), names=["a", "b", "c"]
+    )
+    df = pd.DataFrame({"col": (1, 2, 3)}, index=m_idx)
+
+    class TwoLevelSchema(pa.DataFrameModel):
+        b: Index[int] = pa.Field(check_name=True)
+        c: Index[int] = pa.Field(check_name=True)
+
+    assert isinstance(TwoLevelSchema.validate(df), pd.DataFrame)
+
+    class OneLevelSchema(pa.DataFrameModel):
+        c: Index[int] = pa.Field(check_name=True)
+
+    assert isinstance(OneLevelSchema.validate(df), pd.DataFrame)
+
+    class WrongNameSchema(pa.DataFrameModel):
+        z: Index[int] = pa.Field(check_name=True)
+
+    with pytest.raises(pa.errors.SchemaError):
+        WrongNameSchema.validate(df)
+
+    class WrongDtypeSchema(pa.DataFrameModel):
+        c: Index[str] = pa.Field(check_name=True)
+
+    with pytest.raises(pa.errors.SchemaError):
+        WrongDtypeSchema.validate(df)
+
+
 def test_multiindex_check_has_context() -> None:
     """Test that checks on MultiIndex levels can access the level by name."""
 

--- a/tests/pandas/test_schema_components.py
+++ b/tests/pandas/test_schema_components.py
@@ -329,6 +329,30 @@ def test_single_index_multi_index_mismatch() -> None:
         schema.validate(df_fail)
 
 
+def test_single_index_schema_validates_one_level_of_multiindex() -> None:
+    """Regression test for #1460: a single-level Index schema whose name
+    matches one level of an actual pandas MultiIndex should validate just
+    that level, rather than unconditionally raising a mismatch error."""
+    ind = pd.MultiIndex.from_tuples(
+        [("a", 1), ("c", 2), ("e", 3)],
+        names=("one", "two"),
+    )
+    df = pd.DataFrame(index=ind)
+
+    # name matches a level and values satisfy the schema's dtype
+    schema = DataFrameSchema(index=Index(str, name="one"))
+    validated = schema.validate(df)
+    assert isinstance(validated, pd.DataFrame)
+
+    # name matches a level, but values don't satisfy the schema's dtype
+    with pytest.raises(errors.SchemaError):
+        DataFrameSchema(index=Index(int, name="one")).validate(df)
+
+    # name doesn't match any level: falls back to the original mismatch error
+    with pytest.raises(errors.SchemaError, match="mismatch index"):
+        DataFrameSchema(index=Index(str, name="key")).validate(df)
+
+
 def test_multi_index_schema_coerce() -> None:
     """Test that multi index can be type-coerced."""
     indexes = [
@@ -897,6 +921,50 @@ def test_multiindex_ordered(
             schema(pd.DataFrame(index=multiindex))
         with pytest.raises(errors.SchemaErrors):
             schema(pd.DataFrame(index=multiindex), lazy=True)
+        return
+    assert isinstance(schema(pd.DataFrame(index=multiindex)), pd.DataFrame)
+
+
+@pytest.mark.parametrize(
+    "multiindex, schema, error",
+    [
+        # Regression tests for #1460: checking a subset of an ordered
+        # MultiIndex's levels shouldn't raise just because levels the
+        # schema doesn't declare are skipped over along the way.
+        [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", "b", "c"]),
+            MultiIndex([Index(int, name="c")]),
+            False,
+        ],
+        [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", "b", "c"]),
+            MultiIndex([Index(int, name="b"), Index(int, name="c")]),
+            False,
+        ],
+        [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", "b", "c"]),
+            MultiIndex([Index(int, name="a"), Index(int, name="c")]),
+            False,
+        ],
+        # a genuine ordering violation (schema wants c before a, data has
+        # a before c) must still be caught
+        [
+            pd.MultiIndex.from_arrays([[1], [1], [1]], names=["a", "b", "c"]),
+            MultiIndex([Index(int, name="c"), Index(int, name="a")]),
+            True,
+        ],
+    ],
+)
+def test_multiindex_ordered_partial_selection(
+    multiindex: pd.MultiIndex, schema: MultiIndex, error: bool
+) -> None:
+    """Test that an ordered MultiIndex schema can validate a subset of a
+    dataframe's index levels, skipping undeclared levels without raising,
+    while still catching genuine ordering violations among the declared
+    levels."""
+    if error:
+        with pytest.raises(errors.SchemaError):
+            schema(pd.DataFrame(index=multiindex))
         return
     assert isinstance(schema(pd.DataFrame(index=multiindex)), pd.DataFrame)
 


### PR DESCRIPTION
Fixes #1460.

Checking only some levels of a MultiIndex was broken in two related ways.

**1. `MultiIndexBackend`'s ordered-level mapping**

When walking the dataframe's MultiIndex levels to match them against the schema's declared index components (`ordered=True`, the default), any level it passed over while looking for the next declared name was flagged as an "out-of-order" error, even if that level isn't part of the schema at all. So a schema declaring only `b` and `c` of a `[a, b, c]` MultiIndex would fail just because it had to skip past `a`.

**2. `DataFrameModel` with a single `check_name=True` index field**

`DataFrameModel` collapses a schema with exactly one index field into a plain `Index` schema (not a `MultiIndex`), which is correct for the common case. But validating that against a dataframe whose actual index is a real `pd.MultiIndex` always raised `"Attempting to validate mismatch index"` in `IndexBackend`, regardless of whether the field's name matched one of the MultiIndex's levels. This is the literal repro from the issue.

## Fix

- `_map_ordered_levels` now only raises when a name is a genuine ordering violation (it exists somewhere in the index but was already walked past looking for an earlier schema entry) rather than for every skipped, undeclared level. The message differentiates "out-of-order" from "not found" based on this.
- `IndexBackend.validate` now checks whether its schema's `name` matches one of the levels of an actual MultiIndex before giving up, and if so delegates to `MultiIndexBackend` to validate just that level (without touching or requiring the others).

I initially tried making `DataFrameModel` always wrap a single named index field in `MultiIndex`, but that changes `schema.index`'s type from `Index` to `MultiIndex` for the common single-index case, which breaks `schema.index.name` introspection (caught by existing tests `test_alias` and `test_empty_with_index`). The `IndexBackend`-level fix avoids that: `schema.index` stays a plain `Index` for the common case, and only the previously-broken MultiIndex scenario changes behavior.

## Testing

Verified against the exact repro in the issue (both the "working" 2-column and "not working" 1-column cases), plus: wrong index name still raises, wrong dtype on the matched level still raises, ordinary (non-multi) index dataframes are unaffected, and a genuine ordering violation among declared levels is still caught. Added regression tests in `test_schema_components.py` (`test_single_index_schema_validates_one_level_of_multiindex`, `test_multiindex_ordered_partial_selection`) and `test_model.py` (`test_partial_multiindex_check_name`). Ran the full `tests/pandas`, `tests/core`, `tests/io`, `tests/strategies`, and `tests/hypotheses` suites — 3302 passed, no regressions. Also ran `ruff check`/`format` and `mypy` on the changed file.