### PR TITLE
fix: DataFrameModel ignores Config options inherited from a base config class

### DIFF
--- a/pandera/api/dataframe/model.py
+++ b/pandera/api/dataframe/model.py
@@ -522,13 +522,24 @@ class DataFrameModel(Generic[TDataFrame, TSchema], BaseModel):
             root_model.Config
         )
 
+        # A model's Config can inherit options from user-defined base config
+        # classes, which ``vars(config)`` doesn't see. Walk each Config's MRO
+        # to pick those up, skipping configs that belong to a model in this
+        # hierarchy (merged at that model's own level) and pandera's base
+        # config classes, so their defaults don't override a parent model.
+        model_configs = {getattr(base, _CONFIG_KEY) for base in bases}
+        model_configs.update(inspect.getmro(root_model.Config))
+
         for model in models:
-            config = getattr(model, _CONFIG_KEY, {})
-            base_options, base_extras = cls._extract_config_options_and_extras(
-                config
-            )
-            options.update(base_options)
-            extras.update(base_extras)
+            config = getattr(model, _CONFIG_KEY)
+            for config_cls in reversed(inspect.getmro(config)):
+                if config_cls is not config and config_cls in model_configs:
+                    continue
+                base_options, base_extras = (
+                    cls._extract_config_options_and_extras(config_cls)
+                )
+                options.update(base_options)
+                extras.update(base_extras)
 
         return type("Config", (cls.Config,), options), extras
 

--- a/tests/pandas/test_model.py
+++ b/tests/pandas/test_model.py
@@ -19,6 +19,7 @@ import pandera.api.dataframe.model as dataframe_model
 import pandera.api.extensions as pax
 import pandera.pandas as pa
 from pandera.api.base.model import MetaModel
+from pandera.api.pandas.model_config import BaseConfig
 from pandera.errors import SchemaError, SchemaInitError, SchemaWarning
 from pandera.typing import DataFrame, FieldType, Index, Series, String
 from pandera.typing import pandas as pandas_typing
@@ -1187,6 +1188,65 @@ def test_config() -> None:
     )
 
     assert expected == Child.to_schema()
+
+
+def test_config_inherits_from_base_config_class() -> None:
+    """Regression test for #1471: a model's Config inherits options from a
+    user-defined base config class, like regular Python class attributes."""
+
+    class ProjectConfig(BaseConfig):
+        coerce = True
+
+    class ProjectConfigNoBase:
+        coerce = True
+
+    class InheritsProjectConfig(pa.DataFrameModel):
+        a: Series[float]
+
+        class Config(ProjectConfig):
+            pass
+
+    class InheritsPlainConfig(pa.DataFrameModel):
+        a: Series[float]
+
+        class Config(ProjectConfigNoBase):
+            pass
+
+    class OverridesProjectConfig(pa.DataFrameModel):
+        a: Series[float]
+
+        class Config(ProjectConfig):
+            coerce = False
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    for model in (InheritsProjectConfig, InheritsPlainConfig):
+        assert model.to_schema().coerce
+        assert model.validate(df)["a"].dtype == "float64"
+
+    assert not OverridesProjectConfig.to_schema().coerce
+    with pytest.raises(SchemaError):
+        OverridesProjectConfig.validate(df)
+
+
+def test_config_base_config_defaults_do_not_override_parent_model() -> None:
+    """pandera's own BaseConfig defaults in a child model's Config shouldn't
+    override options set by a parent model."""
+
+    class Parent(pa.DataFrameModel):
+        a: Series[float]
+
+        class Config:
+            coerce = True
+            dtype = float
+
+    class Child(Parent):
+        class Config(BaseConfig):
+            strict = True
+
+    schema = Child.to_schema()
+    assert schema.coerce
+    assert schema.strict
+    assert str(schema.dtype) == "float64"
 
 
 def test_multiindex_unique() -> None:


### PR DESCRIPTION
Fixes #1471.

A model `Config` that inherits from a user-defined base config class loses the options set on that class:

```python
class ProjectConfig(BaseConfig):
    coerce = True

class Model(pa.DataFrameModel):
    a: Series[float]

    class Config(ProjectConfig):
        pass

Model.Config.coerce       # True
Model.to_schema().coerce  # False
```

`_collect_config_and_extras` reads each model's options with `vars(config)`, which only sees attributes set directly in the `Config` body. The root `BaseConfig` defaults are then set explicitly on the final `Config`, shadowing the inherited value. `validate()` is affected the same way since it goes through `to_schema()`.

The fix walks each model `Config`'s MRO and merges options from its base config classes. It skips classes that are some model's own `Config` (already merged at that model's level) and pandera's base config classes, so pandas `BaseConfig` defaults like `dtype=None` don't override a parent model's options.

Options and check extras defined on a base config class now take effect, matching what attribute lookup on the `Config` class already returns. `pyspark` and `xarray` models have their own copies of this logic and aren't changed here.

## Testing

- `test_config_inherits_from_base_config_class`: a base config subclassing `BaseConfig`, a plain base config class, and an explicit override in the child `Config` still winning. Fails before the fix.
- `test_config_base_config_defaults_do_not_override_parent_model`: locks in existing model-to-model inheritance.
- `tests/pandas`, `tests/core`, `tests/base`, `tests/io`, `tests/strategies`, `tests/hypotheses`, `tests/polars`: 3782 passed. `ruff check`/`ruff format` and `mypy` clean on the changed file.