### PR TITLE
test(polars): add regression test for aggregate check failure_cases

### DIFF
--- a/tests/polars/test_polars_check.py
+++ b/tests/polars/test_polars_check.py
@@ -444,3 +444,28 @@ def test_polars_lazy_failure_cases_empty_and_null_list():
     rendered = exc_info.value.failure_cases["failure_case"].to_list()
     assert "[]" in rendered
     assert any("null" in str(v) for v in rendered)
+
+
+def _aggregate_check_fn(data: pa.PolarsData) -> pl.LazyFrame:
+    """Reduce the column to a single boolean row."""
+    return data.lazyframe.select(pl.col(data.key).is_not_null().sum() > 0)
+
+
+def test_polars_aggregate_check_failure_cases_stay_a_dataframe():
+    """An aggregate check output must not corrupt failure_cases into a string.
+
+    Regression test for #2482: the check reduces the column to one row, so
+    concatenating it with the input horizontally raises ShapeError on
+    polars>=2.0.0rc1. The broad exception handler in the components backend
+    then stored the stringified error as failure_cases, turning a normal
+    validation failure into a type-confused SchemaError.
+    """
+    schema = pa.DataFrameSchema(
+        {"a": pa.Column(checks=[pa.Check(_aggregate_check_fn)], nullable=True)}
+    )
+    df = pl.DataFrame({"a": [None, None, None]})
+
+    with pytest.raises(pa.errors.SchemaError) as exc_info:
+        schema.validate(df)
+
+    assert isinstance(exc_info.value.failure_cases, pl.DataFrame)


### PR DESCRIPTION
## Summary

Adds an end-to-end regression test for #2482.

#2482 reports that a `Check` returning an aggregate `LazyFrame` (a single row) makes `SchemaError.failure_cases` a `str` containing `ShapeError("zip node received non-equal length inputs")` instead of a DataFrame, on `polars==2.0.0rc1`.

**That is already fixed on `main`.** The reporter tested 0.32.1; the fix landed after that release in #2411 ("fix(polars): avoid concat deprecation in lazy validation"), which routes the horizontal concat in `postprocess_lazyframe_output` through the `horizontal_concat` helper (`pandera/backends/polars/utils.py`), preferring `how="horizontal_extend"`. `git tag --contains 9d86aed` → `v0.33.0`, `v0.33.1`.

Nothing pinned the behavior, though: #2411 was a deprecation fix, and the existing `test_horizontal_concat_uses_supported_mode` covers the helper in isolation rather than the validation path that produced the corrupted `failure_cases`. This PR adds that coverage so the scenario can't silently regress.

## Verification

Bisected with the reporter's MCVE unchanged, on `polars==2.0.0rc1`:

| commit | `type(e.failure_cases)` |
| --- | --- |
| `9d86aed^` (before #2411) | `<class 'str'>` — `'ShapeError("zip node received non-equal length inputs")'` |
| `main` (`8ecdd0d`) | `polars.DataFrame`, shape (1, 1) |

The new test reproduces that split — on `9d86aed^` it fails with the exact reported symptom:

```
assert False
 +  where 'ShapeError("zip node received non-equal length inputs")' = SchemaError(...).failure_cases
```

and passes on `main`. Verified under both `polars==1.44.2` and `polars==2.0.0rc1`, so it is not pinned to the pre-release.

`tests/polars/` → 472 passed, 4 skipped. `ruff check` and `ruff format --check` clean on the changed file.

## Note on the second half of #2482

The report also flags the broad `except Exception` in `pandera/backends/polars/components.py` that stores `str(err)` as `failure_cases`. That path is still present, but it reads as deliberate rather than accidental — it sets `reason_code=SchemaErrorReason.CHECK_ERROR` and carries `original_exc`, distinguishing "the check raised" from "the check failed". I have not touched it here; happy to follow up if you would rather `failure_cases` were always a frame.

## Backward compatibility

No existing test was modified and no library code changed — this PR is test-only, so there is no user-facing behavior change.
